### PR TITLE
Fix broken links for the design doc of bootstrap discovery.

### DIFF
--- a/docs/design/design_v1.7.md
+++ b/docs/design/design_v1.7.md
@@ -185,7 +185,7 @@ kubectl label node ${master_name} node-role.kubernetes.io/master=""
 
 #### cluster-info
 
-This phase creates the `cluster-info` ConfigMap in the `kube-public` namespace as defined in [the Bootstrap Tokens proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/bootstrap-discovery.md)
+This phase creates the `cluster-info` ConfigMap in the `kube-public` namespace as defined in [the Bootstrap Tokens proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md)
  - The `ca.crt` and the address/port of the apiserver is added to the `cluster-info` ConfigMap in the `kubeconfig` key
  - Exposes the `cluster-info` ConfigMap to unauthenticated users (i.e. users in RBAC group `system:unauthenticated`)
 

--- a/docs/design/design_v1.8.md
+++ b/docs/design/design_v1.8.md
@@ -271,7 +271,7 @@ Please note that
 
 ### Configure TLS-Bootstrapping for node joining
 
-Kubeadm uses [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) for joining new nodes to an existing cluster; for more details see also [design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/bootstrap-discovery.md).
+Kubeadm uses [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) for joining new nodes to an existing cluster; for more details see also [design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
 
 `kubeadm init`  ensures that everything is properly configured for this process, and this includes following steps as well as setting API Server and controller flags as already described in previous paragraphs.
 
@@ -380,7 +380,7 @@ Similarly to `kubeadm init`, also `kubeadm join` internal workflow consists of a
 
 This is split into discovery (having the Node trust the Kubernetes Master) and TLS bootstrap (having the Kubernetes Master trust the Node).
 
-see [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) , [design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/bootstrap-discovery.md).
+see [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) , [design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
 
 ### Discovery cluster-info
 


### PR DESCRIPTION
Fix broken links for the design doc of bootstrap discovery in design doc of kubeadm v1.7 v1.8

Signed-off-by: Ziqi Zhao <zhaoziqi@qiniu.com>