### PR TITLE
Add Certified k8s Logo to v1.8 design doc

### DIFF
--- a/docs/design/design_v1.8.md
+++ b/docs/design/design_v1.8.md
@@ -1,6 +1,6 @@
 ## Implementation design for kubeadm
 
-`kubeadm init` and `kubeadm join` together provides a nice user experience for creating a best-practice but bare Kubernetes cluster from scratch.
+<img src="https://raw.githubusercontent.com/cncf/artwork/master/kubernetes/certified-kubernetes/1.8/color/certified_kubernetes_1.8_color.png" align="right" width="150px">`kubeadm init` and `kubeadm join` together provides a nice user experience for creating a best-practice but bare Kubernetes cluster from scratch.
 However, it might not be obvious _how_ kubeadm does that.
 
 This document strives to explain the phases of work that happen under the hood.


### PR DESCRIPTION
See https://github.com/kubernetes/kubeadm/issues/616

This uses the specifically versioned logo for the 1.8 design.