### PR TITLE
Update OWNERS to merge in core k8s repo kubeadm OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,19 @@
 # See the OWNERS file documentation:
-#  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
+#  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
 approvers:
 - mikedanese
-- errordeveloper
 - luxas
 - jbeda
+- krousey
+- timothysc
+reviewers:
+- mikedanese
+- luxas
+- dmmcquay
+- krousey
+- timothysc
+- fabriziopandini
+- jamiehannaford
+- kad
+- xiangpengzhao
+- mattmoyer


### PR DESCRIPTION
This file now includes all users in k8s.io/kubernetes/cmd/kubeadm/OWNERS.

I wasn't sure if I should leave `errordeveloper` as that user does not currently exist in the [core repo OWNERS file](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/OWNERS). Should I remove them here, or update the core OWNERS file to include them?

Closes #632. 