### PR TITLE
Merge vagrant-kubeadm-testing for contributor experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,17 @@ Follow either of the two links above to access the appropriate CLA and instructi
 ### Contributing A Patch
 
 1. Submit an issue describing your proposed change to the repo in question.
-1. The [repo owners](OWNERS) will respond to your issue promptly.
-1. If your proposed change is accepted, and you haven't already done so, sign a Contributor License Agreement (see details above).
-1. Fork the desired repo, develop and test your code changes.
-1. Submit a pull request.
+2. The [repo owners](OWNERS) will respond to your issue promptly.
+3. If your proposed change is accepted, and you haven't already done so, sign a Contributor License Agreement (see details above).
+4. Fork the desired repo, develop and test your code changes.
+5. Submit a pull request.
+
+### Building
+
+`kubeadm` uses the same build process as the rest of the `kubernetes/kubernetes` repository.
+However, you do not frequently have to build all of kubernetes to work on kubeadm.
+
+See [./vagrant/README.md](./vagrant/README.md) for a quick workflow to build and test your own kubeadm binaries. 🙂
 
 ### Adding dependencies
 

--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+bin

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,39 @@
+#### pre-requisite tools
+`vagrant, bazel, golang`
+
+# vagrant kubeadm testing
+This [Vagrantfile](./Vagrantfile) provisions a 4cpu/4GB Ubuntu 17.10 vm for the purpose of developing on kubeadm.   
+
+Recent packages of kubernetes components will be installed and a compatible Docker daemon is started and running.  
+The bashrc is configured by default to use `/etc/kubernetes/admin.conf`.  
+An upstream version of kubeadm is installed for reference usage.  
+
+[copy_kubeadm_bin.sh](./copy_kubeadm_bin.sh) takes your freshly built kubeadm binary, prefixes it with an issue
+number and copies it into `./bin`, so that it may be used from `/vagrant/bin` inside the VM for testing.  
+This is useful for comparing behavior and determining compatibility of binairies from builds.
+
+## example
+#### build two versions of kubeadm:
+```shell
+cd ~/go/src/k8s.io/kubernetes
+
+git checkout feature/kubeadm_594-etcd_tls
+bazel test //cmd/kubeadm/...
+bazel build //cmd/kubeadm --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
+issue=594 ~/go/src/k8s.io/kubeadm/vagrant/copy_kubeadm_bin.sh
+
+git checkout feature/kubeadm_710-etcd-ca
+bazel test //cmd/kubeadm/...
+bazel build //cmd/kubeadm --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
+issue=710 ~/go/src/k8s.io/kubeadm/vagrant/copy_kubeadm_bin.sh
+```
+#### experiment with the two builds on the vagrant:
+```shell
+cd ~/go/src/k8s.io/kubeadm/vagrant
+
+vagrant up
+vagrant ssh
+  sudo /vagrant/bin/594_kubeadm init
+  sudo /vagrant/bin/594_kubeadm reset
+  sudo /vagrant/bin/710_kubeadm init
+```

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,32 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-17.10"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.cpus   = "4"
+    vb.memory = "4096"
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    #!/bin/sh
+    set -ex
+    
+    apt-get update && apt-get install -y apt-transport-https
+    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+    echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+    apt-get update && apt-get install -y \
+      docker.io=1.13.1-0ubuntu6 \
+      kubelet=1.9.7-00 \
+      kubectl=1.9.7-00 \
+      kubeadm=1.9.7-00
+    
+    swapoff -a
+    systemctl enable docker.service
+
+    export KUBECONFIG=/etc/kubernetes/admin.conf
+    echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /etc/bash.bashrc
+    # sudo -i
+    # /vagrant/bin/594_kubeadm init
+    # kubectl apply -f https://git.io/weave-kube-1.6
+    # kubectl taint nodes --all node-role.kubernetes.io/master-
+  SHELL
+end

--- a/vagrant/copy_kubeadm_bin.sh
+++ b/vagrant/copy_kubeadm_bin.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# copy_kubeadm_bin takes your built kubeadm binary, prefixes it with an issue
+# number and copies it into this repo's /bin, so that it may be used from
+# `/vagrant/bin` inside the VM for testing.
+#
+#   usage:
+#     issue=710 ./copy_kubeadm_bin.sh
+#   env_vars:
+#     issue (*required)     Issue number(s) or descriptor used for prefixing the binary
+#     kube_root | GOPATH    Used for setting the kubernetes source root. (defaults to ~/go)
+#     builder               Used for selecting the host binpath. Can be one of [bazel|docker] (defaults to bazel)
+
+set -eu
+binary=kubeadm
+kube_root="${kube_root:-${GOPATH:-${HOME}/go}/src/k8s.io/kubernetes}"
+vagrant_root="$(cd "$(dirname "${BASH_SOURCE[0]:-$PWD}")" 2>/dev/null 1>&2 && pwd)"
+builder="${builder:-bazel}"
+
+bazel_binpath="bazel-bin/cmd/kubeadm/linux_amd64_pure_stripped/"
+docker_binpath="_output/local/bin/linux/amd64/"
+
+case "${builder}" in
+  docker) binpath="${docker_binpath}" ;;
+  bazel) binpath="${bazel_binpath}" ;;
+esac
+
+mkdir -p ${vagrant_root}/bin
+
+set -x
+cd "${kube_root}/${binpath}"
+chmod 755 ${binary}
+cp ${binary} ${issue}_${binary}
+cp ${binary} ${vagrant_root}/bin/${issue}_${binary}


### PR DESCRIPTION
We discussed on last week's kubeadm call, that we would like move this
repo into the kubeadm contributor repo, so we improve our shared tooling
and contributor experience.

This vagrant environment has been shown to aide in developer ramp up for
new contributors.
The documentation fixes provide a happier path to discovering how to
build the software.

approved by @timothysc

Fixes: https://github.com/stealthybox/vagrant-kubeadm-testing/issues/1