### PR TITLE
kubeadm-contrib-hack-lib

### DIFF
--- a/vagrant/hack/lib/ansible-utils.rb
+++ b/vagrant/hack/lib/ansible-utils.rb
@@ -1,0 +1,59 @@
+module AnsibleUtils
+
+    class Inventory
+        All = 'all'
+
+        def self.for(machines, roles)
+            groups       = {}
+            groups[All]  = []
+
+            roles.each do |r|
+                role = "#{r.downcase}s"
+                groups[role]=[]
+            end
+
+            machines.each do |machine|
+                groups[All] << machine.name 
+                machine.roles.each do |r|
+                    role = "#{r.downcase}s"
+                    if groups[role].empty? then  groups["primary_#{r.downcase}"]=[machine.name] end
+                    groups[role] << machine.name 
+                end
+            end
+            
+            return groups
+        end
+    end
+
+    class Tags
+        Prerequisites       = "prereqs" 
+        Etcd                = "etcd"
+        ExternalCA          = "externalCA"
+        ExternalVIP         = "vip"
+        Kubeadm_config      = "config"
+        Kubeadm_Init        = "init"
+        Kubeadm_Network     = "network"
+        Kubeadm_JoinMaster  = "joinMaster"
+        Kubeadm_Join        = "join"
+
+        def self.for(installEtcd, setupExternalCA, setupControlplaneVip, kubeadmInit, applyNetwork, kubeadmJoinMaster, kubeadmJoin)
+            if !kubeadmInit && (applyNetwork || kubeadmJoinMaster || kubeadmJoin) then raise "invalid action configuration: applyNetwork, kubeadmJoinMaster or kubeadmJoin will fail without kubeadmInit." end
+
+            if kubeadmInit && (!installEtcd && @etcdMode == KubeadmOptions::EtcdMode::External) then raise "invalid ansible action configuration: kubeadmInit will fail without installing external ETCD." end
+            if kubeadmInit && (!setupExternalCA && @certificateAuthority == KubeadmOptions::CertificateAuthority::External) then raise "invalid ansible action configuration: kubeadmInit will automatically create a local pki if the exxpected external CA is not provisioned." end
+            if kubeadmInit && (!setupControlplaneVip && @controlplaneAvailability == KubeadmOptions::ControlplaneAvailability::MultiMaster) then raise "invalid ansible action configuration: kubeadmInit will fail if the controlplane vip is not provisioned." end
+        
+            ansible_tags = [Prerequisites, Kubeadm_config]
+            ansible_tags << Etcd                if installEtcd
+            ansible_tags << ExternalCA          if setupExternalCA
+            ansible_tags << ExternalVIP         if setupControlplaneVip
+            ansible_tags << Kubeadm_Init        if kubeadmInit
+            ansible_tags << Network             if applyNetwork
+            ansible_tags << Kubeadm_JoinMaster  if kubeadmJoinMaster
+            ansible_tags << Kubeadm_Join        if kubeadmJoin
+    
+            return ansible_tags
+        end
+    end
+
+end

--- a/vagrant/hack/lib/cluster-api.rb
+++ b/vagrant/hack/lib/cluster-api.rb
@@ -1,0 +1,252 @@
+require 'yaml'
+
+require_relative 'kubeadm-options.rb'
+require_relative 'kubernetes-utils.rb'
+require_relative 'vagrant-utils.rb'
+require_relative 'ansible-utils.rb'
+require_relative 'utils.rb'
+
+require_relative 'test-guide.rb'
+
+class VagrantMachine
+    attr_accessor :name
+    attr_accessor :hostname
+    attr_accessor :box
+    attr_accessor :ip
+    attr_accessor :cpus
+    attr_accessor :memory
+    attr_accessor :roles
+end
+
+class VagrantMachineSet
+    attr_accessor :name
+    attr_accessor :replicas
+    attr_accessor :box
+    attr_accessor :cpus
+    attr_accessor :memory
+    attr_accessor :roles
+end
+
+class VagrantCluster
+    
+    attr_reader :name
+    attr_reader :version
+    attr_reader :controlplane
+    attr_reader :controlplaneAvailability
+    attr_reader :etcdMode
+    attr_reader :certificateAuthority
+    attr_reader :pkiLocation
+    attr_reader :dnsAddon
+    attr_reader :dnsDomain
+    attr_reader :networkAddon
+    attr_reader :serviceSubnet
+    attr_reader :podSubnet
+    attr_reader :kubeletConfig
+    
+    attr_reader :machines
+    attr_reader :masters
+    attr_reader :nodes
+    attr_reader :etcds
+
+    attr_reader :ansible_installEtcd
+    attr_reader :ansible_setupExternalCA
+    attr_reader :ansible_setupControlplaneVip
+    attr_reader :ansible_kubeadmInit
+    attr_reader :ansible_applyNetwork
+    attr_reader :ansible_kubeadmJoinMaster
+    attr_reader :ansible_kubeadmJoin
+
+    attr_reader :ansible_groups
+    attr_reader :ansible_extra_vars
+    attr_reader :ansible_tags
+
+    def self.fromClusterAPI (folder)
+        c = VagrantCluster.new
+        c.parseFolder folder
+        c.compose
+        return c
+    end
+
+    #$ ruby -r "./hack/lib/cluster-api.rb" -e "VagrantCluster.Test" up
+    def self.Test
+        c = fromClusterAPI('/Users/fabrizio/Documents/Workspace/Vagrant/kubernetes/dev/spec/*.yaml')
+            .injectKubeadmFromBazelBuild(prefix: nil)
+            .ansibleActions(
+                installEtcd: true,              # only if machine with Etcd role are defined (external etcd)
+                setupExternalCA: true,          # only if external certificate is requested
+                setupControlplaneVip: true,     # only if there are 2 or more machines with Master role (multi master scenario)
+                kubeadmInit: false, 
+                applyNetwork: false,
+                kubeadmJoinMaster: false, 
+                kubeadmJoin: false
+            )
+
+        TestGuide.print(c)
+    end
+
+    def initialize
+        @machineSets            = []
+        @machines               = []
+        @silent = VagrantUtils.silent
+    end
+
+    def parseFolder(folder)
+        Utils.putsTitle "Reading cluster API spec from #{folder}" unless @silent
+        Dir[folder].each do |file_name|
+            next if File.directory? file_name 
+
+            puts  "    - #{file_name}" unless @silent
+            data = YAML.load_file(file_name)
+  
+            case data["kind"]
+            when "Cluster"
+                parseClusterData data
+            when "MachineSet"
+                parseMachineSetData data
+            end
+        end
+    end
+
+    def parseClusterData(data)
+        @name                       = get data, "metadata", "name", validator: KuberentesUtils::DNS1123Label 
+        @extra_vars                 = get data, "spec", "providerConfig", "value"
+
+        @version                    = get data, "spec", "providerConfig", "value", "kubernetes", "version" #TODO: validate versione
+        @controlplane               = get data, "spec", "providerConfig", "value", "kubernetes", "controlplane", default: KubeadmOptions::Controlplane::StaticPods, validator: KubeadmOptions::Controlplane
+        # controlplaneAvailability will be implicitily derived from machineSets during compose
+        # etcdMode will be implicitily derived from machineSets during compose
+        @certificateAuthority       = get data, "spec", "providerConfig", "value", "kubernetes", "certificateAuthority", default: KubeadmOptions::CertificateAuthority::Local, validator: KubeadmOptions::CertificateAuthority
+        @pkiLocation                = get data, "spec", "providerConfig", "value", "kubernetes", "pkiLocation", default: KubeadmOptions::PKILocation::Filesystem, validator: KubeadmOptions::PKILocation
+        @dnsAddon                   = get data, "spec", "providerConfig", "value", "kubernetes", "dnsAddon", default: KubeadmOptions::DNSAddon::KubeDNS, validator: KubeadmOptions::DNSAddon
+        @dnsDomain                  = get data, "spec", "clusterNetwork", "serviceDomain", default: KubeadmOptions::DNSDomain , validator: KuberentesUtils::DNS1123Subdomain
+        @networkAddon               = get data, "spec", "providerConfig", "value", "kubernetes", "networkAddon", default: KubeadmOptions::NetworkAddon::Weavenet, validator: KubeadmOptions::NetworkAddon
+        serviceSubnet, podSubnet    = KubeadmOptions::NetworkAddon.defaultSubnetsFor @networkAddon
+        @serviceSubnet              = get data, "spec", "clusterNetwork", "services", "cidrblocks", default: serviceSubnet, validator: Utils::CIDRList
+        @podSubnet                  = get data, "spec", "clusterNetwork", "pods", "cidrblocks", default: podSubnet, validator: Utils::CIDRList
+        @kubeletConfig              = get data, "spec", "providerConfig", "value", "kubernetes", "kubeletConfig", default: KubeadmOptions::KubeletConfig::SystemdDropIn, validator: KubeadmOptions::KubeletConfig
+        
+        if @pkiLocation == KubeadmOptions::PKILocation::Secrets and @controlplane != KubeadmOptions::Controlplane::SelfHosted then raise "Invalid cluster definition. PKILocation can be secrets only if controlplane is self hosted" end
+    end
+
+    def parseMachineSetData(data)
+        s = VagrantMachineSet.new 
+        s.name        = get data, "metadata", "name", validator: KuberentesUtils::DNS1123Label
+        s.replicas    = get data, "spec", "replicas", validator: Utils::Integer
+        s.box         = get data, "spec", "template", "spec", "providerConfig", "value", "box"
+        s.cpus        = get data, "spec", "template", "spec", "providerConfig", "value", "cpus", validator: Utils::Integer
+        s.memory      = get data, "spec", "template", "spec", "providerConfig", "value", "memory", validator: Utils::Integer
+        s.roles       = get data, "spec", "template", "spec", "roles", validator: Roles
+        @machineSets << s
+    end
+
+    def compose
+        @masters = []
+        @etcds = []
+        @nodes = []
+
+        @machineSets.each do |s|
+            for i in 1..s.replicas
+                m = VagrantMachine.new
+                m.name              = if s.replicas == 1 then "#{@name}-#{s.name}" else "#{@name}-#{s.name}#{i}" end  
+                m.hostname          = "#{@name}-#{s.name}.local"
+                m.box               = s.box
+                m.ip                = "10.10.10.1#{i}"
+                m.cpus              = s.cpus
+                m.memory            = s.memory
+                m.roles             = s.roles
+                machines << m
+
+                @masters << m if m.roles.include?(Roles::Master)
+                @nodes   << m if m.roles.include?(Roles::Node)
+                @etcds   << m if m.roles.include?(Roles::Etcd)
+            end
+        end
+
+        if @masters.length == 0 then raise "Invalid cluster definition. At least one Master machine is required" end
+        
+        @etcdMode = KubeadmOptions::EtcdMode::Local
+        if @etcds.length > 0 then @etcdMode = KubeadmOptions::EtcdMode::External end
+
+        @controlplaneAvailability = KubeadmOptions::ControlplaneAvailability::SingleMaster 
+        if @masters.length > 1 then 
+            @controlplaneAvailability = KubeadmOptions::ControlplaneAvailability::MultiMaster 
+            if @etcdMode != KubeadmOptions::EtcdMode::External then raise "Invalid cluster definition. Multi masters requires external etcd." end
+            if @pkiLocation == KubeadmOptions::PKILocation::Secrets then raise "Invalid cluster definition. Multi masters does not support certificates in secrets yet." end
+        end
+        
+        Utils.putsTitle "Machines defined in cluster API spec" unless @silent
+        @machines.each do |m|
+            puts "    - #{m.name}, roles: #{m.roles.join(",")} ]" unless @silent
+        end
+    end
+
+    def get(data, *keys, default: nil, validator: nil)
+        d = data
+        keys.each do |k| 
+            if d.has_key?(k)
+                d = d[k]
+            else
+                if default!=nil 
+                    return default
+                else
+                    raise "Error parsing #{keys} (#{k} does't exists)"
+                end
+            end
+        end
+        if validator!=nil 
+            validator.validate d
+        end
+        return d
+    end
+
+    def injectKubeadmFromBazelBuild(prefix: nil)
+        @ansible_extra_vars['kubeadm_binary'] = VagrantUtils::InjectKubeadmFromBuildOutput(build_output_path = "bazel-bin/cmd/kubeadm/linux_amd64_pure_stripped", prefix = prefix)
+        return self
+    end
+
+    def injectKubeadmFromDockerBuild(prefix: nil)
+        @ansible_extra_vars['kubeadm_binary'] = VagrantUtils::InjectKubeadmFromBuildOutput(build_output_path = "_output/dockerized/bin/linux/amd64/", prefix = prefix)
+        return self
+    end
+
+    def injectKubeadmFromLocalBuild(prefix: nil)
+        @ansible_extra_vars['kubeadm_binary'] = VagrantUtils::InjectKubeadmFromBuildOutput(build_output_path = "_output/local/bin/linux/amd64/", prefix = prefix)
+        return self
+    end
+
+    def ansibleActions(installEtcd: true, setupExternalCA: true, setupControlplaneVip: true, kubeadmInit: false, applyNetwork: false, kubeadmJoinMaster: false, kubeadmJoin: false)    
+        @ansible_installEtcd            = installEtcd
+        @ansible_setupExternalCA        = setupExternalCA
+        @ansible_setupControlplaneVip   = setupControlplaneVip
+        @ansible_kubeadmInit            = kubeadmInit
+        @ansible_applyNetwork           = applyNetwork
+        @ansible_kubeadmJoinMaster      = kubeadmJoinMaster
+        @ansible_kubeadmJoin            = kubeadmJoin
+
+        @ansible_groups = AnsibleUtils::Inventory.for @machines, Roles::All
+        @ansible_extra_vars = @extra_vars
+        @ansible_extra_vars['kubernetes']['dnsDomain']     = @dnsDomain            unless @dnsDomain == KubeadmOptions::DNSDomain
+        @ansible_extra_vars['kubernetes']['serviceSubnet'] = @serviceSubnet.first  unless @serviceSubnet.first == nil
+        @ansible_extra_vars['kubernetes']['podSubnet']     = @podSubnet.first      unless @podSubnet.first == nil
+        @ansible_tags   = AnsibleUtils::Tags.for installEtcd, setupExternalCA, setupControlplaneVip, kubeadmInit, applyNetwork, kubeadmJoinMaster, kubeadmJoin
+        return self
+    end
+end
+
+class Roles
+    Master  = 'Master'    
+    Node    = 'Node'
+    Etcd    = 'Etcd'
+    
+    All    = [Master, Node, Etcd]
+    
+    def self.validate(data)
+        if data.kind_of?(Array)
+            data.each do |s|
+                raise "Invalid role '#{s}'. valid roles are [#{All.join(', ')}]." unless All.include?(s)
+            end 
+        else
+            raise "invalid roles list '#{data}'" 
+        end
+    end
+end 

--- a/vagrant/hack/lib/kubeadm-options.rb
+++ b/vagrant/hack/lib/kubeadm-options.rb
@@ -1,0 +1,126 @@
+module KubeadmOptions
+
+    # How the controlplane will be deployed?
+    class Controlplane
+        StaticPods  = 'staticPods'    
+        SelfHosting = 'selfHosting'
+
+        All         = [StaticPods, SelfHosting]
+
+        def self.validate(string)
+            unless [StaticPods, SelfHosting].include?(string)
+                raise "invalid controlplane type '#{string}'. Valid types are [#{All.join(', ')}]." 
+            end
+        end
+    end
+
+    # Which type of high availability for the controlplane are you planning?
+    # NB. this is implicitily derived from the machineSets:
+    # SingleMaster if only one machine with role Master exists, MultiMaster if more than one machine with role Master exists
+    class ControlplaneAvailability
+        SingleMaster    = 'singleMaster'        
+        MultiMaster     = 'multiMaster'
+
+        All             = [SingleMaster, MultiMaster]
+    end
+
+    # How etcd will be deployed?
+    # NB. this is implicitily derived from the machineSets:
+    # External if at least one machine with role etcd exists, otherwise local
+    class EtcdMode
+        Local       = 'local'        
+        External    = 'external'
+
+        All         = [Local, External]
+    end
+
+    # Which type of certificate authority are you going to use?
+    class CertificateAuthority
+        Local       = 'local'
+        External    = 'external' 
+
+        All         = [Local, External]
+
+        def self.validate(string)
+            unless All.include?(string)
+                raise "invalid CertificateAuthority type '#{string}'. Valid types are [#{All.join(', ')}]." 
+            end
+        end
+    end
+
+    # Where you PKI will be stored?
+    class PKILocation
+        Filesystem = 'filesystem'   
+        Secrets = 'secrets'
+
+        All    = [Filesystem, Secrets]
+
+        def self.validate(string)
+            unless All.include?(string)
+                raise "invalid PKILocation '#{string}'. Valid locations are [#{All.join(', ')}]." 
+            end
+        end
+    end
+
+    DNSDomain = "cluster.local"
+
+    # Which type of DNS you will use?
+    class DNSAddon
+        KubeDNS     = 'kubeDNS'      
+        CoreDNS     = 'coreDNS' 
+
+        All         = [KubeDNS, CoreDNS]
+
+        def self.validate(string)
+            unless All.include?(string)
+                raise "invalid DNS add-on '#{string}'. Valid add-ons are [#{All.join(', ')}]." 
+            end
+        end
+    end
+
+    # Which type of pod network add-on are you using?
+    class NetworkAddon
+        Weavenet    = 'weavenet' 
+        Flannel     = 'flannel'      
+        Calico      = 'calico' 
+
+        All         = [Weavenet, Flannel, Calico]
+
+        def self.validate(string)
+            unless All.include?(string)
+                raise "invalid network add-on '#{string}'. Valid add-ons are [#{All.join(', ')}]." 
+            end
+        end
+
+        def self.defaultSubnetsFor(addon)
+            case addon
+            when Weavenet
+                return [nil], [nil]
+            when Flannel
+                return [nil], ["10.244.0.0/16"]
+            when Calico
+                return [nil], ["192.168.0.0/16"]
+            end
+        end
+    end
+
+    # Which type of kubelet config are you using?
+    class KubeletConfig
+        SystemdDropIn           = 'systemdDropIn'      
+        DynamicKubeletConfig    = 'dynamicKubeletConfig' # technically this is SystemdDropIn + DynamicKubeletConfig
+
+        All                     = [SystemdDropIn, DynamicKubeletConfig]
+
+        def self.validate(string)
+            unless All.include?(string)
+                raise "invalid Kubelet config type '#{string}'. Valid types are [#{All.join(', ')}]." 
+            end
+        end
+    end
+
+    # TODO: 
+    # Which type of network are you using (Ipv4, Ipv6)                                    --> test supports ipv4 only
+    # Which type of environment are you simulating (with or without internet connection)  --> test supports with internet connection only
+    # How Kube-proxy will be configured (Iptables, Ipvs)                                  --> test supports Iptables only
+    # Auditing                                                                            --> test with auditing on
+end

--- a/vagrant/hack/lib/kubernetes-utils.rb
+++ b/vagrant/hack/lib/kubernetes-utils.rb
@@ -1,0 +1,19 @@
+module KuberentesUtils
+
+    class DNS1123Label
+        def self.validate(string)
+            unless string =~ /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/ 
+                raise "invalid dns1123Label '#{string}'" 
+            end
+        end
+    end
+    
+    class DNS1123Subdomain
+        def self.validate(string)
+            unless string =~ /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/ 
+                raise "invalid dns1123Subdomain '#{string}'" 
+            end
+        end
+    end
+
+end

--- a/vagrant/hack/lib/test-guide.rb
+++ b/vagrant/hack/lib/test-guide.rb
@@ -1,0 +1,160 @@
+require_relative 'kubeadm-options.rb'
+require_relative 'vagrant-utils.rb'
+
+class TestGuide
+
+    def self.print(c)
+        if VagrantUtils.silent then return end
+
+        Utils.putsTitle "Test guide for #{c.name}"
+
+        i = 1; print_overview i, c
+
+        if c.etcdMode == KubeadmOptions::EtcdMode::External || 
+            c.certificateAuthority == KubeadmOptions::CertificateAuthority::External ||
+            c.controlplaneAvailability == KubeadmOptions::ControlplaneAvailability::MultiMaster then
+            
+            i += 1; print_dependencies i, c
+        end
+
+        if (c.etcdMode == KubeadmOptions::EtcdMode::External && !c.ansible_installEtcd) || 
+            (c.certificateAuthority == KubeadmOptions::CertificateAuthority::External && !c.ansible_setupExternalCA) ||
+            (c.controlplaneAvailability == KubeadmOptions::ControlplaneAvailability::MultiMaster && !c.ansible_setupControlplaneVip) || 
+            !c.ansible_kubeadmInit ||
+            (c.masters.length>1 && !c.ansible_kubeadmJoinMaster) ||
+            (c.nodes.length>1 && !c.ansible_kubeadmJoin) then
+            
+            i += 1; print_completeprovisioning i, c
+        end
+
+        i += 1; print_testplan i, c
+    end
+
+    def self.print_overview(i, c)
+        Utils.putsTitle "#{i}. Cluster overview"
+        puts "    The cluster is composed by following machines:"
+        puts "    - #{c.masters.length} master nodes:"
+        c.masters.each do |m|
+            puts "       - #{m.name}"
+        end
+        if c.nodes.length > 0 
+            puts "    - #{c.nodes.length} nodes:" 
+            c.nodes.each do |m|
+                puts "       - #{m.name}"
+            end
+        end
+    end
+
+    def self.print_dependencies(i, c)
+        Utils.putsTitle "#{i}. Cluster dependencies"
+        verb = if c.ansible_kubeadmInit then "uses" else "will use" end
+     
+        if c.controlplaneAvailability == KubeadmOptions::ControlplaneAvailability::MultiMaster then 
+            if c.ansible_setupControlplaneVip
+                puts "    - The cluster #{verb} an external VIP for the controlplane to be configured on all the Master machines."
+            else
+                puts "    - The cluster #{verb} an external VIP for the controlplane alerady configured on all the Master machines."
+            end
+        end 
+
+        if c.certificateAuthority == KubeadmOptions::CertificateAuthority::External then 
+            if c.ansible_setupExternalCA
+                puts "    - The cluster #{verb} an external Certificate Authority to be created and distributed on all the Master machines."
+            else
+                puts "    - The cluster #{verb} an external Certificate Authority alerady created and distributed on all the Master machines."
+            end
+        end  
+
+        if c.etcdMode == KubeadmOptions::EtcdMode::External then 
+            if c.ansible_installEtcd
+                puts "    - The cluster #{verb} an external etcd cluster to be deployed on following machines:"
+            else
+                puts "    - The cluster #{verb} an external etcd cluster alerady deployed on following machines:"
+            end
+            c.etcds.each do |m|
+                puts "       - #{m.name}"
+            end
+        end 
+
+    end
+    
+    def self.print_completeprovisioning(i, c)
+        Utils.putsTitle "#{i}. Complete cluster provisioning"
+        
+        j = 0
+
+        if c.etcdMode == KubeadmOptions::EtcdMode::External && !c.ansible_installEtcd
+            j += 1; Utils.putsTitle2 "#{j}. Install Etcd"
+            puts "    - Install etcd on etcd machines using your preferred approach."
+            puts "    - Ensure that etcd endpoint and eventually etcd TLS certificates are set in kubeadm.conf"
+            puts
+        end
+
+        if c.certificateAuthority == KubeadmOptions::CertificateAuthority::External && !c.ansible_setupExternalCA
+            j += 1; Utils.putsTitle2 "#{j}. Setup an external Certificate Authority"
+            puts "    - Create an external CA using your preferred approach."
+            puts "    - Copy the certificates on `/etc/kubernetes/pki` all master nodes."
+            puts
+        end
+        
+        if c.controlplaneAvailability == KubeadmOptions::ControlplaneAvailability::MultiMaster && !c.ansible_setupControlplaneVip
+            j += 1; Utils.putsTitle2 "#{j}. Setup an external VIP or a loab balancer for the controlplane"
+            puts "    - Create an external VIP/load balancer using your preferred approach."
+            puts "    - Ensure that the controlplane address is set in kubeadm.conf."
+            puts
+        end 
+        
+        if !c.ansible_kubeadmInit
+            j += 1; Utils.putsTitle2 "#{j}. Kubeadm init"
+            puts "    - Run 'Kubeadm init' on #{c.masters.first.name}."
+            puts
+        end
+        
+        if !c.ansible_applyNetwork
+            j += 1; Utils.putsTitle2 "#{j}. Install network addon"
+            puts "    - Run 'kubectl apply ...'' "
+            puts
+        end
+
+        if c.masters.length>1 && !c.ansible_kubeadmJoinMaster
+            j += 1; Utils.putsTitle2 "#{j}. Join additional master nodes"
+            puts "    - Run 'Kubeadm join --experimentalmaster' on:"
+            c.masters.drop(1).each do |m|
+                puts "       - #{m.name}"
+            end
+            puts
+        end
+
+        if c.nodes.length>1 && !c.ansible_kubeadmJoin
+            j += 1; Utils.putsTitle2 "#{j}. Join worker nodes"
+            puts "    - Run 'Kubeadm join' on:"
+            c.nodes.each do |m|
+                puts "       - #{m.name}"
+            end
+            puts
+        end
+        
+        j = 0
+    end
+
+    def self.print_testplan(i, c)
+        Utils.putsTitle "#{i}. Test Kubeadm and Kubernets"
+        
+        j = 0
+
+        j += 1; Utils.putsTitle2 "#{j}. Test Kubernetes"
+        puts "    'vagrant ssh' to one Master machine and:"
+        puts "    - run kubeadm E2E test!"
+        puts "    - run kubernetes E2E test!"
+        puts "    - use kubectl!" 
+        puts
+
+        j += 1; Utils.putsTitle2 "#{j}. Test kubeadm updates"
+        puts "    ... " 
+        puts
+
+        j += 1; Utils.putsTitle2 "#{j}. Test kubeadm reset"
+        puts "    ... " 
+        puts
+    end
+end

--- a/vagrant/hack/lib/utils.rb
+++ b/vagrant/hack/lib/utils.rb
@@ -1,0 +1,37 @@
+module Utils
+
+    def self.putsTitle(msg)
+        puts "\033[1;34m==> #{msg}:\033[0m"
+    end
+
+    def self.putsTitle2(msg)
+        puts "\033[1;33m==>    #{msg}:\033[0m"
+    end
+
+    class Integer
+        def self.validate(string)
+            Integer(string) 
+        end
+    end
+
+    class CIDR
+        def self.validate(string)
+            unless string =~ /^(?=\d+\.\d+\.\d+\.\d+($|\/))(([1-9]?\d|1\d\d|2[0-4]\d|25[0-5])\.?){4}(\/([0-9]|[1-2][0-9]|3[0-2]))?$/ 
+                raise "invalid CIDR '#{string}'" 
+            end
+        end
+    end
+
+    class CIDRList
+        def self.validate(data)
+            if data.kind_of?(Array)
+                data.each do |s|
+                    CIDR.validate(s)
+                end 
+            else
+                raise "invalid CIDR list '#{data}'" 
+            end
+        end
+    end 
+
+end

--- a/vagrant/hack/lib/vagrant-utils.rb
+++ b/vagrant/hack/lib/vagrant-utils.rb
@@ -1,0 +1,31 @@
+require 'fileutils'
+
+class VagrantUtils
+
+    def self.silent
+        if ARGV.length >= 1 && ["provision", "up"].include?(ARGV[0].downcase) then 
+            return false 
+        else 
+            return true 
+        end
+    end
+
+    def self.InjectKubeadmFromBuildOutput(build_output_path:, prefix:nil)
+        root = File.join ENV["HOME"], "/go"
+        if ENV.has_key?("kube_root") 
+            root = ENV["kube_root"]
+        elsif ENV.has_key?("GOPATH") 
+            root = ENV["GOPATH"]
+        end 
+
+        kubeadm_source_binary = File.join root, "/src/k8s.io/kuberneteskubernetes", build_output, "kubeadm"
+
+        spearator = if prefix == nil then "" else "-" end
+        kubeadm_target_binary = File.join "/bin", "#{prefix}#{separator}kubeadm"
+
+        FileUtils.cp kubeadm_source_binary, kubeadm_target_binary
+
+        return kubeadm_target_binary
+    end
+    
+end


### PR DESCRIPTION
This PR implements the second part of https://github.com/kubernetes/kubeadm/pull/795 (2 of 3), that consists of a set of scripts that are responsible for parsing the cluster API spec and translates it into something that can be used by Vagrant and by the ansible provisioner.

NB. the test guide is only drafted, and it is intended to be improved over time ;-)

/CC @timothysc @luxas @stealthybox @liztio @detiber @chuckha 