### PR TITLE
update owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,21 @@
 # See the OWNERS file documentation:
 #  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
 approvers:
-- mikedanese
 - luxas
-- jbeda
-- krousey
-- timothysc
-reviewers:
-- mikedanese
-- luxas
-- dmmcquay
-- krousey
 - timothysc
 - fabriziopandini
-- jamiehannaford
+reviewers:
+- luxas
+- timothysc
+- fabriziopandini
 - kad
 - xiangpengzhao
-- mattmoyer
+- stealthybox
+- liztio
+- chuckha
+- detiber
+- dixudx
+# Might want to add @kargakis, @jamiehannaford, @krousey and/or @dmmcquay back in the future
+labels: 
+- area/kubeadm
+- sig/cluster-lifecycle


### PR DESCRIPTION
/cc @luxas @timothysc 

Sets the owner file for `kubeadm/vagrant` folder equals to the current owner file in for `cmd/kubeadm` folder in main repo. 
Let me know if you want to do more specific appointments for this folder