### PR TITLE
Disable swap in all nodes

### DIFF
--- a/vagrant/hack/ansible/roles/common/tasks/main.yml
+++ b/vagrant/hack/ansible/roles/common/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+
+# This task disables swap for Kubernetes node (see https://github.com/kubernetes/kubernetes/pull/31996)
+- name: Remove swapfile from /etc/fstab
+  mount:
+    name: swap
+    fstype: swap
+    state: absent
+
+- name: Disable swap
+  command: swapoff -a
+  when: ansible_swaptotal_mb > 0
+
 - import_tasks: debian.yml
   when: ansible_os_family == "Debian"
 


### PR DESCRIPTION
`kubeadm` fails with swap on https://github.com/kubernetes/kubernetes/pull/31996

Added tasks to disable swap in all nodes from https://github.com/kubernetes/contrib/blob/master/ansible/roles/node/tasks/swapoff.yml

