### PR TITLE
fix taint master example

### DIFF
--- a/docs/design/design_v1.10.md
+++ b/docs/design/design_v1.10.md
@@ -315,7 +315,7 @@ Please note that
 As soon as the control plane is available, kubeadm executes following actions:
 
 - Label  the master with `node-role.kubernetes.io/master=""`
-- Taints  the master with `node-role.kubernetes.io/master:NoSchedule`
+- Taints  the master with `node-role.kubernetes.io/master="":NoSchedule`
 
 Please note that
 


### PR DESCRIPTION
change the example of taint master from `node-role.kubernetes.io/master:NoSchedule` to `node-role.kubernetes.io/master="":NoSchedule`