### PR TITLE
verify_packages_published: highlight errors in gubernator

### DIFF
--- a/tests/e2e/verify_packages_published.sh
+++ b/tests/e2e/verify_packages_published.sh
@@ -77,7 +77,7 @@ if [[ ! -z "$available" ]]; then
 fi
 
 if [[ ! -z "$missing" ]]; then
-    echo "These versions do not have matching debs:"
+    echo "ERROR: These versions do not have matching packages:"
     echo "$missing"
     exit 1
 else


### PR DESCRIPTION
Gubernator highlights lines with `fail` and `error`.

Makes it possible to view the versions with missing packages
directly on this page:
  https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/periodic-kubernetes-e2e-packages-pushed/120

instead of requiring to click "Raw build-log.txt".

/assign @timothysc 
/kind bug
