### PR TITLE
move verify_packages_published to it's own folder

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,12 +1,8 @@
-## Tools for verifying Kubernetes packages are published
+### kubeadm e2e tests
 
-The `verify_packages_published.sh` script in this folder verifies that the necessary deb/rpms are published to official repositories.
-This script is run periodically and results are available at https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-all#periodic-kubernetes-e2e-packages-pushed
+This folder contains kubeadm e2e tests that run as periodic jobs.
 
-### Running
+The definitions for these jobs can be found in the test-infra repository
+[here](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/sig-cluster-lifecycle).
 
-The script should be run in a Docker container like this:
-
-```
-docker run -it -v $(pwd):/test debian:stretch /test/tests/e2e/verify_packages_published.sh
-```
+Test results can be monitored in this [testgrid dashboard](https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-all).

--- a/tests/e2e/packages/README.md
+++ b/tests/e2e/packages/README.md
@@ -1,0 +1,12 @@
+## Tools for verifying Kubernetes packages are published
+
+The `verify_packages_published.sh` script in this folder verifies that the necessary deb/rpms are published to official repositories.
+This script is run periodically and results are available at https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-all#periodic-kubernetes-e2e-packages-pushed
+
+### Running
+
+The script should be run in a Docker container like this:
+
+```
+docker run -it -v $(pwd):/test debian:stretch /test/tests/e2e/packages/verify_packages_published.sh
+```

--- a/tests/e2e/packages/verify_packages_published.sh
+++ b/tests/e2e/packages/verify_packages_published.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# This script is 
-
 # Install dependencies
 apt-get update && apt-get install -y apt-transport-https curl jq gnupg2 yum
 
@@ -48,8 +46,8 @@ for release in $(curl -s https://api.github.com/repos/kubernetes/kubernetes/rele
 	elif [[ $supported_versions != *"${minor#v}"* ]]; then
 		# release we don't care about (e.g. older releases)
 		skipped="$skipped $release"
-    else
-    	if [[ $deb_policy != *"${release#v}"* ]]; then
+	else
+		if [[ $deb_policy != *"${release#v}"* ]]; then
 			# release we care about but has missing debs
 			missing="$missing deb:$release"
 		else


### PR DESCRIPTION
also:
- update the test README to reflect the folder change.
- add a README in e2e/tests explaining that this folder
contains e2e tests and have some links in there.
- do some minor whitespace / comment cleanup in the .sh


my idea here is to have folders under e2e that specify e2e type.
(having this as early as possible is better!)

tests/e2e/packages is what would be available now.
tests/e2e/manifests is what's coming soon.

test-infra PR on hold here:
https://github.com/kubernetes/test-infra/pull/9565

/assign @fabriziopandini 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 
