### PR TITLE
Fix some typos

### DIFF
--- a/docs/design/design_v1.10.md
+++ b/docs/design/design_v1.10.md
@@ -213,7 +213,7 @@ The API server needs to know this in particular:
 
 Other flags that are set unconditionally:
 
- - `--insecure-port=0` to avoid insecure connections to the api server.
+ - `--insecure-port=0` to avoid insecure connections to the API server.
  - `--enable-bootstrap-token-auth=true` to enable the `BootstrapTokenAuthenticator` authentication module.
  - `--allow-privileged` to `true` (used e.g. by kube proxy).
  - `--client-ca-file` to `ca.crt`.

--- a/docs/design/design_v1.8.md
+++ b/docs/design/design_v1.8.md
@@ -170,7 +170,7 @@ Please note that:
 Common properties for the control plane components:
 
 - `hostNetwork: true` is present on all static pods since there is no network configured yet; accordingly 
-  -  the `address` of the api server for controller-manager and the scheduler will be set to `127.0.0.1`
+  -  the `address` of the API server for controller-manager and the scheduler will be set to `127.0.0.1`
   -  if using a local etcd server, `etcd-servers` address  will be set to `127.0.0.1:2379`
 - Leader election is enabled for both the controller-manager and the scheduler
 - controller-manager and the scheduler will reference kubeconfig files with their respective, unique identities

--- a/docs/design/design_v1.9.md
+++ b/docs/design/design_v1.9.md
@@ -213,7 +213,7 @@ The API server needs to know this in particular:
 
 Other flags that are set unconditionally:
 
- - `--insecure-port=0` to avoid insecure connections to the api server.
+ - `--insecure-port=0` to avoid insecure connections to the API server.
  - `--enable-bootstrap-token-auth=true` to enable the `BootstrapTokenAuthenticator` authentication module. 
  - `--allow-privileged` to `true` (used e.g. by kube proxy).
  - `--client-ca-file` to `ca.crt`.


### PR DESCRIPTION
In these article, "api server" and "API server" are not consistent. For example, in [docs/design/design_v1.9.md](https://github.com/kubernetes/kubeadm/compare/master...JoeWrightss:patch-1?expand=1#diff-21ece680a29b03664c2e243e1b7cbf37), "api server" has only appear once, but others are "API server", please keep them consistent.