### PR TITLE
WIP: enable terraform as deploy-tool on libvirt-kvm

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,3 @@
+# Kubeadm Playground (terraform)
+
+The kubeadm playground consists of one or more terraform libvirt  machines where you can experiment kubeadm and eventually test a local build of kubeadm itself.


### PR DESCRIPTION
This pr is a proposal to use in addition to vagrant the terraform-libvirt provider which i'm co-maintainting  on https://github.com/dmacvicar/terraform-provider-libvirt.

I proposing it as wip for gathering some ideas and interest first before i do the project.

I wil follow the same structure as `vagrant` and tooling etc.

We could do it similar to https://github.com/MalloZup/ceph-open-terrarium/tree/master/examples/libvirt with all distro supported in longterm.

