### PR TITLE
Officially deprecate kubeadm-playground

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,3 +1,10 @@
+
+## WARNING: kubernetes-anywhere is deprecated and will be retired in a future release.
+
+Kubeadm-playground was designed as a tool for helping kubeadm contributors.
+It will be discontinued soon in favor of https://github.com/kubernetes-sigs/kind 
+that could potentially support faster dev/test iterations.
+
 # Kubeadm Playground
 
 The kubeadm playground consists of one or more vagrant machines where you can experiment


### PR DESCRIPTION
As per various discussion at sig level, this PR officially deprecates kubeadm-playground in favour of kind

@kubernetes/sig-cluster-lifecycle-pr-reviews