### PR TITLE
tests/e2e/manifests: fix bug in `conformance' image test

### DIFF
--- a/tests/e2e/manifests/verify_manifest_lists.go
+++ b/tests/e2e/manifests/verify_manifest_lists.go
@@ -307,7 +307,7 @@ func getImageVersions(ver *version.Version, images map[string]string) error {
 	images["hyperkube"] = k8sVersionV
 	images["cloud-controller-manager"] = k8sVersionV
 	// test the conformance image, but only for newer versions as it was added in v1.13.0-alpha.2
-	conformanceMinVer := version.MustParseGeneric("v1.13.0-alpha.2")
+	conformanceMinVer := version.MustParseSemantic("v1.13.0-alpha.2")
 	if ver.AtLeast(conformanceMinVer) {
 		images["conformance"] = k8sVersionV
 	}


### PR DESCRIPTION
Use MustParseSemantic() otherwise the pre-release will be
discarded.

---

in my last PR here:
https://github.com/kubernetes/kubeadm/pull/1338

i've made a mistake of using MustParseGeneric().
this time tested locally.

/kind bug
/area testing
/priority important-longterm
/assign @fabriziopandini 
