### PR TITLE
Local environment setup improvement

### DIFF
--- a/vagrant/Pipfile
+++ b/vagrant/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pyyaml = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "2.7"

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -46,11 +46,11 @@ cd ~/go/src/k8s.io
 git clone https://github.com/kubernetes/kubeadm.git
 ```
 
-In order to make the `kubeadm-playground` command easily accessible from other locations,
-open your `.bashrc` file and append the following line:
+To make the `kubeadm-playground` command easily accessible from other directories, throw this alias
+in your shell script (.bashrc, .zshrc, etc.) of choice:
 
 ```bash
-alias kubeadm-playground='~/go/src/k8s.io/kubeadm/vagrant/kubeadm-playground'
+alias kubeadm-playground=`PIPENV_PIPFILE=/path/to/pipfile pipenv run /path/to/kubeadm-playground`
 ```
 
 ## Getting started


### PR DESCRIPTION
2 changes here to improve getting set up for kubeadm-playground development.

1. Added a stock `Pipfile` with the required `pyyaml` package and Python version to make local development less fraught with missing dependencies.

2. Updated the alias for `kubeadm-playground` to make sure it allows `pipenv` to pick up on the correct path to the `Pipfile`.

