### PR TITLE
Update kubeadm OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,23 +1,26 @@
 # See the OWNERS file documentation:
 #  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
+
 approvers:
 - luxas
 - timothysc
 - fabriziopandini
 - neolit123
+- rosti
 reviewers:
 - luxas
 - timothysc
 - fabriziopandini
 - kad
-- xiangpengzhao
-- stealthybox
 - liztio
 - chuckha
 - detiber
 - dixudx
 - neolit123
-# Might want to add @kargakis, @jamiehannaford, @krousey and/or @dmmcquay back in the future
+- rosti
+- yagonobre
+- ereslibre 
+# Might want to add @xiangpengzhao, @stealthybox, @kargakis, @jamiehannaford, @krousey and/or @dmmcquay back in the future
 labels: 
 - area/kubeadm
 - sig/cluster-lifecycle


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Align OWNER file to what we have in K/K. More specifically
- Graduates @rosti to approver (and reviewer) 🎉
- Adds @ereslibre @yagonobre as reviewers 🎉
- Removes @stealthybox & @xiangpengzhao 👋

Thanks for your contributions, and hopefully we'll see you
around again @stealthybox & @xiangpengzhao!

Congrats new reviewers and approvers!
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/sig cluster-lifecycle
/area kubeadm
/priority backlog

@kubernetes/sig-cluster-lifecycle
/assign @luxas @timothysc @fabriziopandini @neolit123 