### PR TITLE
add kinder get artifacts command

### DIFF
--- a/kinder/cmd/kinder/get/artifacts/artifacts.go
+++ b/kinder/cmd/kinder/get/artifacts/artifacts.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package artifacts implements the `artifacts` command
+package artifacts
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+
+	kextract "k8s.io/kubeadm/kinder/pkg/extract"
+)
+
+const (
+	onlyKubeadmFlagName  = "only-kubeadm"
+	onlyKubeletFlagName  = "only-kubelet"
+	onlyBinariesFlagName = "only-binaries"
+	onlyImagesFLagName   = "only-images"
+)
+
+type flagpole struct {
+	OnlyKubeadm  bool
+	OnlyKubelet  bool
+	OnlyBinaries bool
+	OnlyImages   bool
+}
+
+// NewCommand returns a new cobra.Command for exec
+func NewCommand() *cobra.Command {
+	flags := &flagpole{}
+	cmd := &cobra.Command{
+		Args: cobra.RangeArgs(1, 2),
+		Use: "artifacts [flags] KUBERNETES_VERSION [DESTINATION_PATH]\n\n" +
+			"Args:\n" +
+			"  KUBERNETES_VERSION is one of:\n" +
+			"    release/LABEL    where label can be stable[-major[.minor]] or latest[-major[.minor]]\n" +
+			"    ci/LABEL         where label can be latest[-major[.minor]]\n" +
+			"    release/VERSION  where VERSION is a semantic version\n" +
+			"    ci/VERSION       where VERSION is a semantic version\n" +
+			"    VERSION          as shortcut to release/VERSION if build metadata are empty, else to ci/VERSION\n" +
+			"    URL              an http or http server where release artifacts are available\n" +
+			"    PATH             a local folder (file:// schema can be use to disambiguate release/ or ci/ folder)\n" +
+			"  DESTINATION_PATH should be a local path; if missing the current path will be used",
+		Aliases: []string{"build-artifacts", "release-artifacts", "ci-artifacts"},
+		Short:   "Gets ci/release artifacts for a given Kubernetes version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags, cmd, args)
+		},
+	}
+
+	cmd.Flags().BoolVar(&flags.OnlyKubeadm, onlyKubeadmFlagName, false, "Gets only the kubeadm binary (instead of all artifacts)")
+	cmd.Flags().BoolVar(&flags.OnlyKubelet, onlyKubeletFlagName, false, "Gets only the kubelet binary (instead of all artifacts)")
+	cmd.Flags().BoolVar(&flags.OnlyBinaries, onlyBinariesFlagName, false, "Gets only the kubeadm, kubelet, kubectl binaries (instead of all artifacts)")
+	cmd.Flags().BoolVar(&flags.OnlyImages, onlyImagesFLagName, false, "Gets only the kube-apiserver, kube-scheduler, kube-controller-manager and kube-proxy image tarballs (instead of all artifacts)")
+
+	return cmd
+}
+
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	//checks that mutually exclusive flags are not set at the same time
+	exclusiveFlags := []string{onlyKubeadmFlagName, onlyKubeletFlagName, onlyBinariesFlagName, onlyImagesFLagName}
+	if checkExclusiveFlags(cmd.Flags(), exclusiveFlags) == false {
+		return errors.Errorf("flags [%s] are mutually exclusive, please set only one of them", strings.Join(exclusiveFlags, ", "))
+	}
+
+	// retrive src and dst from arguments
+	src := args[0]
+	dst := ""
+	if len(args) > 1 {
+		dst = args[1]
+	}
+
+	// Build an artifact extractor customized with the command options
+	e := kextract.NewExtractor(src, dst,
+		kextract.OnlyKubeadm(flags.OnlyKubeadm),
+		kextract.OnlyKubelet(flags.OnlyKubelet),
+		kextract.OnlyBinaries(flags.OnlyBinaries),
+		kextract.OnlyImages(flags.OnlyImages),
+	)
+
+	// Extracts the artifacts from the source
+	_, err := e.Extract()
+	if err != nil {
+		return errors.Wrapf(err, "failed to gets build artifacts for %s version", src)
+	}
+
+	return nil
+}
+
+func checkExclusiveFlags(flags *flag.FlagSet, exclusiveFlags []string) bool {
+	n := 0
+	for _, f := range exclusiveFlags {
+		if flags.Changed(f) {
+			n++
+		}
+	}
+	return n <= 1
+}

--- a/kinder/cmd/kinder/get/get.go
+++ b/kinder/cmd/kinder/get/get.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package get implements the `get` command
+package get
+
+import (
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kind/cmd/kind/get/clusters"
+	"sigs.k8s.io/kind/cmd/kind/get/kubeconfigpath"
+	"sigs.k8s.io/kind/cmd/kind/get/nodes"
+
+	kartifacts "k8s.io/kubeadm/kinder/cmd/kinder/get/artifacts"
+)
+
+// NewCommand returns a new cobra.Command for get
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Args: cobra.NoArgs,
+		// TODO(bentheelder): more detailed usage
+		Use:   "get",
+		Short: "Gets one of [clusters, nodes, kubeconfig-path, build-artifacts]",
+		Long:  "Gets one of [clusters, nodes, kubeconfig-path, build-artifacts]",
+	}
+
+	// add kind top level subcommands re-used without changes
+	cmd.AddCommand(clusters.NewCommand())
+	cmd.AddCommand(nodes.NewCommand())
+	cmd.AddCommand(kubeconfigpath.NewCommand())
+
+	// add kinder only commands
+	cmd.AddCommand(kartifacts.NewCommand())
+	return cmd
+}

--- a/kinder/cmd/kinder/kinder.go
+++ b/kinder/cmd/kinder/kinder.go
@@ -30,10 +30,10 @@ import (
 	kcreate "k8s.io/kubeadm/kinder/cmd/kinder/create"
 	kdo "k8s.io/kubeadm/kinder/cmd/kinder/do"
 	kexec "k8s.io/kubeadm/kinder/cmd/kinder/exec"
+	kget "k8s.io/kubeadm/kinder/cmd/kinder/get"
 	kversion "k8s.io/kubeadm/kinder/cmd/kinder/version"
 	"sigs.k8s.io/kind/cmd/kind/delete"
 	"sigs.k8s.io/kind/cmd/kind/export"
-	"sigs.k8s.io/kind/cmd/kind/get"
 	"sigs.k8s.io/kind/cmd/kind/load"
 )
 
@@ -75,13 +75,13 @@ func NewCommand() *cobra.Command {
 	// add kind top level subcommands re-used without changes
 	cmd.AddCommand(delete.NewCommand())
 	cmd.AddCommand(export.NewCommand())
-	cmd.AddCommand(get.NewCommand())
 	cmd.AddCommand(load.NewCommand())
 
 	// add kind commands commands customized in kind
 	cmd.AddCommand(kbuild.NewCommand())
 	cmd.AddCommand(kcreate.NewCommand())
 	cmd.AddCommand(kversion.NewCommand())
+	cmd.AddCommand(kget.NewCommand())
 
 	// add kinder only commands
 	cmd.AddCommand(kcp.NewCommand())

--- a/kinder/doc/prepare-for-tests.md
+++ b/kinder/doc/prepare-for-tests.md
@@ -72,3 +72,6 @@ kinder build node-variant \
      --image kindest/node:vX-variant \
      --with-upgrade-binaries $mylocalbinaries/vY
 ```
+
+Please note that it is possible to get Kubernetes artifact locally using `kinder get artifacts` and
+use them for building node-variant without accessing internet.

--- a/kinder/go.mod
+++ b/kinder/go.mod
@@ -1,9 +1,14 @@
 module k8s.io/kubeadm/kinder
 
 require (
+	github.com/google/pprof v0.0.0-20190309163659-77426154d546 // indirect
+	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.0
 	github.com/spf13/cobra v0.0.3
+	github.com/spf13/pflag v1.0.2
+	golang.org/x/arch v0.0.0-20190312162104-788fe5ffcd8c // indirect
+	golang.org/x/tools v0.0.0-20190402200628-202502a5a924 // indirect
 	k8s.io/apimachinery v0.0.0-20190320104356-82cbdc1b6ac2
 	sigs.k8s.io/kind v0.0.0-20190320191144-d4ff13e4808e
 )

--- a/kinder/go.sum
+++ b/kinder/go.sum
@@ -112,6 +112,7 @@ github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeq
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/pprof v0.0.0-20190309163659-77426154d546 h1:r3n/h1Zh7Wpk29Q/b+FdrNjDAmr28WaPcxlI0c4NaeA=
 github.com/google/pprof v0.0.0-20190309163659-77426154d546/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/googleapis/gax-go v0.0.0-20161107002406-da06d194a00e/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
@@ -133,6 +134,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.8.4/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 h1:UDMh68UUwekSh5iP2OMhRRZJiiBccgV7axzUG8vi56c=
+github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
@@ -182,6 +185,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -256,6 +260,7 @@ github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
@@ -264,6 +269,8 @@ go.opencensus.io v0.19.1/go.mod h1:gug0GbSHa8Pafr0d2urOSgoXHZ6x/RUlaiT0d9pqb4A=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org v0.0.0-20190218023631-ce4c26f7be8e/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org v0.0.0-20190313082347-94abd6928b1d/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
+golang.org/x/arch v0.0.0-20190312162104-788fe5ffcd8c h1:Rx/HTKi09myZ25t1SOlDHmHOy/mKxNAcu0hP1oPX9qM=
+golang.org/x/arch v0.0.0-20190312162104-788fe5ffcd8c/go.mod h1:flIaEI6LNU6xOCD5PaJvn9wGP0agmIOqjrtsKGRguv4=
 golang.org/x/build v0.0.0-20190111050920-041ab4dc3f9d/go.mod h1:OWs+y06UdEOHN4y+MfF/py+xQ/tYqIWW03b70/CG9Rw=
 golang.org/x/build v0.0.0-20190311235527-86650285478d/go.mod h1:LS5++pZInCkeGSsPGP/1yB0yvU9gfqv2yD1PQgIbDYI=
 golang.org/x/build v0.0.0-20190313044741-1b471b8bf26e/go.mod h1:LS5++pZInCkeGSsPGP/1yB0yvU9gfqv2yD1PQgIbDYI=
@@ -325,6 +332,7 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181218192612-074acd46bca6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313 h1:pczuHS43Cp2ktBEEmLwScxgjWsBSzdaQiKzUyf3DTTc=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -337,6 +345,7 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20180911133044-677d2ff680c1 h1:dzEuQYa6+a3gROnSlgly5ERUm4SZKJt+dh+4iSbO+bI=
 golang.org/x/tools v0.0.0-20180911133044-677d2ff680c1/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030000716-a0a13e073c7b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -346,6 +355,8 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190402200628-202502a5a924 h1:XgD7l1aFq63td2d4omZwFUpt50/DxIpXW3yrk+V4EOc=
+golang.org/x/tools v0.0.0-20190402200628-202502a5a924/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 google.golang.org/api v0.0.0-20170206182103-3d017632ea10/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
@@ -422,6 +433,7 @@ k8s.io/kube-openapi v0.0.0-20190306001800-15615b16d372/go.mod h1:BXM9ceUBTj2QnfH
 k8s.io/kubeadm v0.0.0-20190212133445-79b49271d4dd h1:mpr8m8yaAUsCeNv8THAWjmXs6a+GqfKon4MYfrmEk4g=
 k8s.io/utils v0.0.0-20181115163542-0d26856f57b3/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
+rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sigs.k8s.io/kind v0.0.0-20190223144119-c64da77e4150 h1:qxVG0hUkStZJAcD4gt9hMYV4vQ3U14VV219UelOFwkk=
 sigs.k8s.io/kind v0.0.0-20190223144119-c64da77e4150/go.mod h1:J6Zyw2Z8Fkr3M+dJvT0VDr+tpqLfoZjCOa16SQQhaGQ=
 sigs.k8s.io/kind v0.0.0-20190307044858-45ed3d230167 h1:0C/UenQivP94yXDcZ871zuApJSQSiDEZXqZlAGuZfTA=

--- a/kinder/pkg/extract/extract.go
+++ b/kinder/pkg/extract/extract.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package extract implements the `extract` library; please note that this
+// packages should be replace by the same capability offered by kind/by a
+// shared library as soon as available
+package extract
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	versionutil "k8s.io/apimachinery/pkg/util/version"
+)
+
+const (
+	ciBuildRepository       = "https://storage.googleapis.com/kubernetes-release-dev/ci"
+	releaseBuildURepository = "https://storage.googleapis.com/kubernetes-release/release"
+)
+
+var (
+	kubeadmBinary = "kubeadm"
+	kubeletBinary = "kubelet"
+	allBinaries   = append([]string{"kubelet", "kubectl"}, kubeadmBinary)
+	allImages     = []string{"kube-apiserver.tar", "kube-controller-manager.tar", "kube-scheduler.tar", "kube-proxy.tar"}
+)
+
+type SourceType int
+
+const (
+	// ReleaseLabelOrVersionSource describe a src that should read from releaseBuildURepository
+	ReleaseLabelOrVersionSource SourceType = iota + 1
+
+	// CILabelOrVersionSource describe a src that should read from ciBuildRepository
+	CILabelOrVersionSource
+
+	// RemoteRepositorySource describe a src that should read from a remote http/https repository
+	RemoteRepositorySource
+
+	// LocalRepositorySource describe a src that should read from repository hosted in a local folder
+	LocalRepositorySource
+)
+
+// GetSourceType returns the src type descriptor
+func GetSourceType(src string) SourceType {
+	if strings.HasPrefix(src, "file://") {
+		return LocalRepositorySource
+	} else if strings.HasPrefix(src, "release/") {
+		return ReleaseLabelOrVersionSource
+	} else if strings.HasPrefix(src, "ci/") {
+		return CILabelOrVersionSource
+	} else if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
+		return RemoteRepositorySource
+	} else if v, err := versionutil.ParseSemantic(src); err == nil {
+		if v.BuildMetadata() != "" {
+			return CILabelOrVersionSource
+		}
+		return ReleaseLabelOrVersionSource
+	}
+	return LocalRepositorySource
+}
+
+// Option is an Extractor configuration option supplied to NewExtractor
+type Option func(*Extractor)
+
+// OnlyKubeadm option instructs the Extractor for retriving kubeadm only
+func OnlyKubeadm(onlyKubeadm bool) Option {
+	return func(b *Extractor) {
+		if onlyKubeadm {
+			b.files = []string{kubeadmBinary}
+		}
+	}
+}
+
+// OnlyKubelet option instructs the Extractor for retriving kubelet only
+func OnlyKubelet(onlyKubelet bool) Option {
+	return func(b *Extractor) {
+		if onlyKubelet {
+			b.files = []string{kubeletBinary}
+		}
+	}
+}
+
+// OnlyBinaries option instructs the Extractor for retriving kubeadm, kubectl and kubelet binaries only
+func OnlyBinaries(onlyBinaries bool) Option {
+	return func(b *Extractor) {
+		if onlyBinaries {
+			b.files = allBinaries
+		}
+	}
+}
+
+// OnlyImages option instructs the Extractor for retriving images tarballs only
+func OnlyImages(onlyImages bool) Option {
+	return func(b *Extractor) {
+		if onlyImages {
+			b.files = allImages
+		}
+	}
+}
+
+// Extractor defines attributes for a Kubernetes artifact extractor
+type Extractor struct {
+	// src is the source from where to extract file
+	src string
+	// files is the list of files to extract
+	files []string
+	dst   string
+}
+
+// NewExtractor returns a new extractor configured with the given options
+func NewExtractor(src, dst string, options ...Option) (extractor *Extractor) {
+	extractor = &Extractor{
+		src:   src,
+		dst:   dst,
+		files: append(allBinaries, allImages...),
+	}
+
+	// apply user options
+	for _, option := range options {
+		option(extractor)
+	}
+
+	return extractor
+}
+
+// extractFunc define a function that implements an extractor method
+type extractFunc func(string, []string, string) (map[string]string, error)
+
+// Extract Kubernetes artifacts from the given source
+func (e *Extractor) Extract() (paths map[string]string, err error) {
+	var f extractFunc
+
+	switch GetSourceType(e.src) {
+	case ReleaseLabelOrVersionSource:
+		f = extractFromReleaseBuild
+	case CILabelOrVersionSource:
+		f = extractFromCIBuild
+	case RemoteRepositorySource:
+		f = extractFromHTTP
+	case LocalRepositorySource:
+		f = extractFromLocalDir
+	default:
+		errors.Errorf("source %s did not resolve to a valid source type", e.src)
+	}
+
+	return f(e.src, e.files, e.dst)
+}
+
+func extractFromCIBuild(src string, files []string, dst string) (paths map[string]string, err error) {
+	// cleanup the src from the prefix, if any
+	src = strings.TrimPrefix(src, "ci/")
+
+	// gets the Kubernetes version from the src
+	version, err := versionutil.ParseSemantic(src)
+	if err != nil {
+		version, err = resolveLabel(ciBuildRepository, src)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// sets the url for downloading the requested ci version and triggers the extraction
+	src = fmt.Sprintf("%s/v%s", ciBuildRepository, version)
+	return extractFromHTTP(src, files, dst)
+}
+
+func extractFromReleaseBuild(src string, files []string, dst string) (paths map[string]string, err error) {
+	// cleanup the source src the prefix, if any
+	src = strings.TrimPrefix(src, "release/")
+
+	// gets the Kubernetes version from the src
+	version, err := versionutil.ParseSemantic(src)
+	if err != nil {
+		version, err = resolveLabel(releaseBuildURepository, src)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// sets the url for downloading the requested release version and triggers the extraction
+	src = fmt.Sprintf("%s/v%s", releaseBuildURepository, version)
+
+	return extractFromHTTP(src, files, dst)
+}
+
+func extractFromHTTP(src string, files []string, dst string) (paths map[string]string, err error) {
+	dst, _ = filepath.Abs(dst)
+	if _, err := os.Stat(dst); os.IsNotExist(err) {
+		return nil, errors.Errorf("destination path %s does not exists", dst)
+	}
+
+	// Build the URIs to the image archives and binaries.
+	srcBinDirPath := fmt.Sprintf("%s/bin/linux/amd64", src)
+
+	// Download the files.
+	for _, f := range files {
+		srcFilePath := fmt.Sprintf("%s/%s", srcBinDirPath, f)
+		fmt.Printf("Downloading %s\n", srcFilePath)
+		dstFilePath := path.Join(dst, f)
+		if err := copyFromURI(srcFilePath, dstFilePath); err != nil {
+			return nil, errors.Wrapf(err, "failed to copy %s to %s", srcFilePath, dstFilePath)
+		}
+	}
+
+	return extractFromLocalDir(dst, files, dst)
+}
+
+func extractFromLocalDir(src string, files []string, dst string) (paths map[string]string, err error) {
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		return nil, errors.Errorf("source path %s does not exists", src)
+	}
+
+	paths = map[string]string{}
+	for _, f := range files {
+		srcFilePath := path.Join(src, f)
+		if _, err := os.Stat(srcFilePath); err != nil {
+			return nil, errors.Wrapf(err, "cannot access %s at %s", f, srcFilePath)
+		}
+		paths[f] = srcFilePath
+	}
+
+	return paths, nil
+}
+
+func resolveLabel(repository, label string) (version *versionutil.Version, err error) {
+	// labels are .txt file containing a release version
+
+	// Gets the uri of the label file
+	uri := fmt.Sprintf("%s/%s", repository, label)
+	if !strings.HasSuffix(uri, ".txt") {
+		uri = uri + ".txt"
+	}
+
+	// Do an HTTP GET and read the version from the txt file.
+	_, r, err := httpGet(uri)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid version URI: %s", uri)
+	}
+	defer r.Close()
+	buf, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading version from %s", uri)
+	}
+
+	labelValue := url.PathEscape(string(bytes.TrimSpace(buf)))
+	version, err = versionutil.ParseSemantic(labelValue)
+	if err != nil {
+		return nil, errors.Wrapf(err, "label %s returned invalid version: %s", label, labelValue)
+	}
+
+	return version, nil
+}
+
+func httpGet(uri string) (int64, io.ReadCloser, error) {
+	resp, err := http.Get(uri)
+	if err != nil {
+		return 0, nil, errors.Wrapf(err, "HTTP GET %s failed", uri)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, nil, errors.Errorf("HTTP GET %s failed: %s", uri, resp.Status)
+	}
+	return resp.ContentLength, resp.Body, nil
+}
+
+func copyFromURI(src, dst string) error {
+	size, r, err := httpGet(src)
+	if err != nil {
+		return errors.Wrapf(err, "error getting reader for %s", src)
+	}
+	defer r.Close()
+
+	// If the file already exists and has the same size as the remote
+	// content then do not redownload it.
+	if f, err := os.Stat(dst); err == nil {
+		if size == f.Size() {
+			return nil
+		}
+	}
+
+	w, err := os.Create(dst)
+	if err != nil {
+		return errors.Wrapf(err, "error creating %s", dst)
+	}
+	defer w.Close()
+
+	if _, err := io.Copy(w, r); err != nil {
+		return errors.Wrapf(err, "error copying %s to %s", src, dst)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds the new `kinder get artifacts` that allows to retrive Kubernetes build artifacts from different sources

This is a useful feature and also an initial step for implementing kinder build node-variant from build artifacts, that is a piece of the puzzle for getting E2E tests on kubeadm upgrades

/kind feature
/priority important-longterm

/assign @neolit123

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews