### PR TITLE
Add kinder e2e command

### DIFF
--- a/kinder/cmd/kinder/kinder.go
+++ b/kinder/cmd/kinder/kinder.go
@@ -31,6 +31,7 @@ import (
 	kdo "k8s.io/kubeadm/kinder/cmd/kinder/do"
 	kexec "k8s.io/kubeadm/kinder/cmd/kinder/exec"
 	kget "k8s.io/kubeadm/kinder/cmd/kinder/get"
+	ktest "k8s.io/kubeadm/kinder/cmd/kinder/test"
 	kversion "k8s.io/kubeadm/kinder/cmd/kinder/version"
 	"sigs.k8s.io/kind/cmd/kind/delete"
 	"sigs.k8s.io/kind/cmd/kind/export"
@@ -87,6 +88,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(kcp.NewCommand())
 	cmd.AddCommand(kdo.NewCommand())
 	cmd.AddCommand(kexec.NewCommand())
+	cmd.AddCommand(ktest.NewCommand())
 
 	return cmd
 }

--- a/kinder/cmd/kinder/test/e2e/e2e.go
+++ b/kinder/cmd/kinder/test/e2e/e2e.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package e2e implements the `e2e` command
+package e2e
+
+import (
+	"regexp"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	ktest "k8s.io/kubeadm/kinder/pkg/test"
+)
+
+type flagpole struct {
+	KubeRoot            string
+	Parallel            bool
+	TestGridConformance bool
+	GinkgoFlags         string
+	TestFlags           string
+}
+
+// NewCommand returns a new cobra.Command for e2e
+func NewCommand() *cobra.Command {
+	flags := &flagpole{}
+	cmd := &cobra.Command{
+		Use:   "e2e",
+		Short: "Runs Kubernetes e2e tests",
+		// TODO: add a long description
+		// TODO: adde examples with flags usage and report-dir
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags, cmd, args)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.KubeRoot, "kube-root", "", "Path to the Kubernetes source directory (if empty, the path is autodetected)")
+	cmd.Flags().BoolVar(&flags.TestGridConformance, "conformance", true, "if set, instruct ginkgo for running only tests required for conformance in testgrid")
+	cmd.Flags().BoolVar(&flags.Parallel, "parallel", false, "if set, instruct ginkgo for running tests in parallel")
+	cmd.Flags().StringVar(&flags.GinkgoFlags, "ginkgo-flags", "", "Space-separated list of arguments to pass to ginkgo test runner")
+	cmd.Flags().StringVar(&flags.TestFlags, "test-flags", "", "Space-separated list of arguments to pass to e2e_kubeadm test")
+	return cmd
+}
+
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	// Create a map with the flag/values to pass to the ginkgo test runner
+	ginkgoFlags, err := ktest.NewGinkgoFlags(flags.GinkgoFlags)
+	if err != nil {
+		return err
+	}
+
+	// if --conformance is set, adds well know flag/values for instructing ginkgo for running only tests required for conformance in testgrid
+	if flags.TestGridConformance {
+		// instruct ginkgo to run only Conformance test as defined in [Display Conformance Tests with Testgrid]
+		// (https://github.com/kubernetes/test-infra/tree/master/testgrid/conformance)
+
+		// see https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md
+		// for description of test labels
+		ginkgoFlags.AddFocusRegex(regexp.QuoteMeta("[Conformance]"))
+		ginkgoFlags.AddSkipRegex("Alpha|Kubectl|\\[(Disruptive|Feature:[^\\]]+|Flaky)\\]")
+	}
+
+	// if --parallel is set, adds well know flag/values for instructing ginkgo for running tests in parallel
+	if flags.Parallel {
+		// please note that this spin-up a default number of test runners (runtime.NumCPU() if runtime.NumCPU() <= 4, otherwise it is runtime.NumCPU() - 1);
+		// if you want to control the level of parallelism, you can use --ginkgo-flags "--nodes=25"
+		// see https://onsi.github.io/ginkgo/#parallel-specs for more info
+		ginkgoFlags["p"] = "true"
+		ginkgoFlags.AddSkipRegex(regexp.QuoteMeta("[Serial]"))
+	}
+
+	// Create a map with the flag/values to pass to the e2e_kubeadm.test binary
+	testFlags, err := ktest.NewSuiteFlags(flags.TestFlags)
+	if err != nil {
+		return err
+	}
+
+	// instruct e2e.test to do not ssh into nodes and dump logs
+	testFlags["disable-log-dump"] = "true"
+
+	// creates a NewKubernetesTestRunner with the desired options and run it
+	testRunner, err := ktest.NewKubernetesTestRunner(
+		ktest.KubeRoot(flags.KubeRoot),
+		ktest.WithGinkgoFlags(ginkgoFlags),
+		ktest.WithSuiteFlags(testFlags),
+	)
+	if err != nil {
+		return errors.Wrapf(err, "failed create test runner")
+	}
+	return testRunner.Run()
+}

--- a/kinder/cmd/kinder/test/e2ekubeadm/e2ekubeadm.go
+++ b/kinder/cmd/kinder/test/e2ekubeadm/e2ekubeadm.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package e2ekubeadm implements the `e2ekubeadm` command
+package e2ekubeadm
+
+import (
+	"regexp"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	ktest "k8s.io/kubeadm/kinder/pkg/test"
+)
+
+type flagpole struct {
+	KubeRoot    string
+	SingleNode  bool
+	CopyCerts   bool
+	GinkgoFlags string
+	TestFlags   string
+}
+
+// NewCommand returns a new cobra.Command for e2e-kubeadm
+func NewCommand() *cobra.Command {
+	flags := &flagpole{}
+	cmd := &cobra.Command{
+		Use:   "e2e-kubeadm",
+		Short: "Runs kubeadm e2e tests",
+		// TODO: add a long description
+		// TODO: adde examples with flags usage and report-dir
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags, cmd, args)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.KubeRoot, "kube-root", "", "Path to the Kubernetes source directory (if empty, the path is autodetected)")
+	cmd.Flags().BoolVar(&flags.SingleNode, "single-node", false, "if set, skips tests labeled with [multi-node]")
+	cmd.Flags().BoolVar(&flags.CopyCerts, "automatic-copy-certs", false, "if set, adds tests labeled with [copy-cert] for validating alpha feature automatic-copy-certs")
+	cmd.Flags().StringVar(&flags.GinkgoFlags, "ginkgo-flags", "", "Space-separated list of arguments to pass to Ginkgo test runner")
+	cmd.Flags().StringVar(&flags.TestFlags, "test-flags", "", "Space-separated list of arguments to pass to node e2e test")
+	return cmd
+}
+
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	// Create a map with the flag/values to pass to the ginkgo test runner
+	ginkgoFlags, err := ktest.NewGinkgoFlags(flags.GinkgoFlags)
+	if err != nil {
+		return err
+	}
+
+	// if --conformance is set, adds well know flag/values for instructing ginkgo to skip tests labeled with [multi-node]
+	if flags.SingleNode {
+		ginkgoFlags.AddSkipRegex(regexp.QuoteMeta("[multi-node]"))
+	}
+
+	// if --automatic-copy-certs is set, adds well know flag/values for instructing ginkgo to skip tests labeled with [copy-cert]
+	if !flags.CopyCerts {
+		ginkgoFlags.AddSkipRegex(regexp.QuoteMeta("[copy-certs]"))
+	}
+
+	// Create a map with the flag/values to pass to e2e.test
+	testFlags, err := ktest.NewSuiteFlags(flags.TestFlags)
+	if err != nil {
+		return err
+	}
+
+	// creates a KubeadmTestRunner with the desired options and run it
+	testRunner, err := ktest.NewKubeadmTestRunner(
+		ktest.KubeRoot(flags.KubeRoot),
+		ktest.WithGinkgoFlags(ginkgoFlags),
+		ktest.WithSuiteFlags(testFlags),
+	)
+	if err != nil {
+		return errors.Wrapf(err, "failed create test runner")
+	}
+	return testRunner.Run()
+}

--- a/kinder/cmd/kinder/test/test.go
+++ b/kinder/cmd/kinder/test/test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package test implements the `test` command
+package test
+
+import (
+	"github.com/spf13/cobra"
+
+	ke2e "k8s.io/kubeadm/kinder/cmd/kinder/test/e2e"
+	ke2ekubeadm "k8s.io/kubeadm/kinder/cmd/kinder/test/e2ekubeadm"
+)
+
+// NewCommand returns a new cobra.Command for running E2E tests on cluster
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "test",
+		Short: "Runs e2e test or e2e-kubeadm on a Kubernetes cluster",
+		Long:  "Runs e2e test or e2e-kubeadm on a Kubernetes cluster",
+	}
+	cmd.AddCommand(ke2e.NewCommand())
+	cmd.AddCommand(ke2ekubeadm.NewCommand())
+	return cmd
+}

--- a/kinder/pkg/test/binary.go
+++ b/kinder/pkg/test/binary.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+// getBinary tries to find a binary, and if not exist it builds it
+func getOrBuildBinary(kubeRoot, name, target string) (string, error) {
+	path, err := findBinary(kubeRoot, name)
+	if err != nil {
+		return "", errors.Errorf("error finding %s binary", name)
+	}
+
+	if path == "" {
+		log.Debugf("%s binary not found, triggering build", name)
+
+		cmd := exec.Command("make", "-C", kubeRoot, fmt.Sprintf("WHAT=%s", target))
+		exec.InheritOutput(cmd)
+		err = cmd.Run()
+		if err != nil {
+			return "", errors.Errorf("error building %s binary - %s target", name, target)
+		}
+	}
+
+	path, err = findBinary(kubeRoot, name)
+	if err != nil {
+		return "", errors.Errorf("error finding build output for %s binary", name)
+	}
+
+	if path != "" {
+		log.Infof("using %s binary: %s", name, path)
+		return path, nil
+	}
+
+	return "", errors.Errorf("unable to find build output for %s binary", name)
+}
+
+// findKubeRoot attempts to locate a kubernetes checkout
+func findKubeRoot() (root string, err error) {
+	goroot := os.Getenv("GOPATH")
+	if goroot == "" {
+		return "", errors.New("unable to get GOPATH env variable. Please provide Kubernetes path source using the --kube-root flag")
+	}
+
+	kubeRoot := filepath.Join(goroot, "src", "k8s.io", "kubernetes")
+	if _, err := os.Stat(kubeRoot); os.IsNotExist(err) {
+		return "", errors.New("$GOPATH/src/k8s.io/kubernetes does not exists. Please provide Kubernetes path source using the --kube-root flag")
+	}
+
+	if !maybeKubeRoot(kubeRoot) {
+		return "", errors.New("$GOPATH/src/k8s.io/kubernetes does not seems a valid Kubernetes source folder. Please provide Kubernetes source path using the --kube-root flag")
+	}
+	return kubeRoot, nil
+}
+
+// maybeKubeRoot returns true if the dir looks plausibly like a kubernetes source directory
+func maybeKubeRoot(dir string) bool {
+	// TODO: consider adding other sanity checks
+	return dir != ""
+}
+
+// findBinary finds a file by name, from a list of well-known output locations
+// When multiple matches are found, the most recent will be returned
+// Based on kube::util::find-binary from kubernetes/kubernetes
+func findBinary(kubeRoot string, name string) (string, error) {
+
+	locations := []string{
+		filepath.Join(kubeRoot, "_output", "bin", name),
+		filepath.Join(kubeRoot, "_output", "dockerized", "bin", name),
+		filepath.Join(kubeRoot, "_output", "local", "bin", name),
+		filepath.Join(kubeRoot, "platforms", runtime.GOOS, runtime.GOARCH, name),
+	}
+
+	bazelBin := filepath.Join(kubeRoot, "bazel-bin")
+	bazelBinExists := true
+	if _, err := os.Stat(bazelBin); os.IsNotExist(err) {
+		bazelBinExists = false
+	}
+
+	if bazelBinExists {
+		err := filepath.Walk(bazelBin, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return errors.Wrapf(err, "error walking %s tree", bazelBin)
+			}
+			if info.Name() != name {
+				return nil
+			}
+			if !strings.Contains(path, runtime.GOOS+"_"+runtime.GOARCH) {
+				return nil
+			}
+			locations = append(locations, path)
+			return nil
+		})
+		if err != nil {
+			return "", err
+		}
+	}
+
+	newestLocation := ""
+	var newestModTime time.Time
+	for _, loc := range locations {
+		stat, err := os.Stat(loc)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", errors.Wrapf(err, "error accessing %s location", loc)
+		}
+		if newestLocation == "" || stat.ModTime().After(newestModTime) {
+			newestModTime = stat.ModTime()
+			newestLocation = loc
+		}
+	}
+
+	if newestLocation == "" {
+		log.Debugf("could not find %s binary, looked in %s", name, locations)
+	}
+
+	return newestLocation, nil
+}

--- a/kinder/pkg/test/e2e.go
+++ b/kinder/pkg/test/e2e.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+// Option is an Runner configuration option supplied to NewRunner
+type Option func(*Runner)
+
+// KubeRoot option sets the kubernetes checkout folder
+func KubeRoot(kubeRoot string) Option {
+	return func(r *Runner) {
+		r.kubeRoot = kubeRoot
+	}
+}
+
+// WithGinkgoFlags option sets flags for ginkgo
+func WithGinkgoFlags(ginkgoFlags GinkgoFlags) Option {
+	return func(r *Runner) {
+		r.ginkgoFlags = ginkgoFlags
+	}
+}
+
+// WithSuiteFlags option sets flags for the test program
+func WithSuiteFlags(suiteFlags SuiteFlags) Option {
+	return func(r *Runner) {
+		r.suiteFlags = suiteFlags
+	}
+}
+
+// Runner defines attributes for a Kubernetes artifact extractor
+type Runner struct {
+	testBinary     string
+	makeBinaryGoal string
+	kubeRoot       string
+	ginkgoFlags    GinkgoFlags
+	suiteFlags     SuiteFlags
+}
+
+// NewKubernetesTestRunner returns a new E2E (Kubernetes) test runner configured with the given options
+func NewKubernetesTestRunner(options ...Option) (runner *Runner, err error) {
+	return newTestRunner("e2e.test", "test/e2e/e2e.test", options...)
+}
+
+// NewKubeadmTestRunner returns a new E2E kubeadm test runner configured with the given options
+func NewKubeadmTestRunner(options ...Option) (runner *Runner, err error) {
+	return newTestRunner("e2e_kubeadm.test", "test/e2e_kubeadm/e2e_kubeadm.test", options...)
+}
+
+// newTestRunner returns a new test runner - using ginkgo and the given test binary - configured with the given options
+func newTestRunner(testBinary, makeBinaryGoal string, options ...Option) (runner *Runner, err error) {
+	runner = &Runner{
+		testBinary:     testBinary,
+		makeBinaryGoal: makeBinaryGoal,
+	}
+
+	// apply user options
+	for _, option := range options {
+		option(runner)
+	}
+
+	// sets kubeRoot if not provided by the user
+	if runner.kubeRoot == "" {
+		runner.kubeRoot, err = findKubeRoot()
+		if err != nil {
+			return nil, errors.Wrap(err, "")
+		}
+		log.Infof("using Kubernetes checkout in %s folder", runner.kubeRoot)
+	}
+
+	return runner, nil
+}
+
+// Run executes tests
+func (r *Runner) Run() error {
+	// find a ginkgo binary or build it if it not exists
+	ginkgoBinary, err := getOrBuildBinary(r.kubeRoot, "ginkgo", "vendor/github.com/onsi/ginkgo/ginkgo")
+	if err != nil {
+		return err
+	}
+
+	// find the binary with the test suites to be executes or build it if it not exists
+	testBinary, err := getOrBuildBinary(r.kubeRoot, r.testBinary, r.makeBinaryGoal)
+	if err != nil {
+		return err
+	}
+
+	// prepare args to be passed to ginkgo test runner:
+	// ginkgo [ginkgo-flags] [test-suite-binary] -- [test-suite-flags]
+	var args []string
+	for k, v := range r.ginkgoFlags {
+		args = append(args, fmt.Sprintf("--%s=%s", k, v))
+	}
+	args = append(args, testBinary, "--")
+	for k, v := range r.suiteFlags {
+		args = append(args, fmt.Sprintf("--%s=%s", k, v))
+	}
+
+	log.Debugf("invoking ginkgo with followiong args: %s", args)
+
+	// executes the command.
+	// TODO: switch to an executor that supports timeout/cancellation
+	cmd := exec.Command(ginkgoBinary, args...)
+	exec.InheritOutput(cmd)
+	err = cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, "error running test")
+	}
+
+	fmt.Println(args)
+
+	return nil
+}

--- a/kinder/pkg/test/flags.go
+++ b/kinder/pkg/test/flags.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// GinkgoFlags defines a type for handling flag/values pairs to be passed to the ginkgo test runner
+type GinkgoFlags map[string]string
+
+// NewGinkgoFlags returns a new GinkgoFlags struct created by parsing the space-separated list of arguments
+func NewGinkgoFlags(flagString string) (GinkgoFlags, error) {
+	ginkgoFlags, err := parseFlagsString(flagString)
+	if err != nil {
+		return nil, err
+	}
+	return ginkgoFlags, nil
+}
+
+// AddFocusRegex allows to add a new regex to pass to ginkgo with the --focus flag.
+// In case the flag is already set, the new regex is appended (existing or new)
+func (g GinkgoFlags) AddFocusRegex(val string) {
+	g.mergeRegex("focus", val)
+}
+
+// AddSkipRegex allows to add a new regex to pass to ginkgo with the --skip flag.
+// In case the flag is already set, the new regex is appended (existing or new)
+func (g GinkgoFlags) AddSkipRegex(val string) {
+	g.mergeRegex("skip", val)
+}
+
+func (g GinkgoFlags) mergeRegex(key, val string) {
+	if exp, ok := g[key]; !ok {
+		g[key] = val
+	} else {
+		g[key] = fmt.Sprintf("%s|%s", exp, val)
+	}
+}
+
+// SuiteFlags defines a type for handling flag/values pairs to be passed to the test suite
+type SuiteFlags map[string]string
+
+// NewSuiteFlags returns a new SuiteFlags struct created by parsing the space-separated list of arguments
+func NewSuiteFlags(flagString string) (SuiteFlags, error) {
+	testFlags, err := parseFlagsString(flagString)
+	if err != nil {
+		return nil, err
+	}
+	return testFlags, nil
+}
+
+// parseFlagsString parse the space-separated list of arguments
+func parseFlagsString(flagString string) (flags map[string]string, err error) {
+	flags = make(map[string]string)
+	if flagString == "" {
+		return
+	}
+	// splits the space-separated list and parse all the --key=value argument
+	for _, arg := range strings.Split(flagString, " ") {
+		key, val, err := parseFlagString(arg)
+		if err != nil {
+			return nil, errors.Errorf("flag %q could not be parsed correctly: %v", arg, err)
+		}
+
+		flags[key] = val
+	}
+	return flags, nil
+}
+
+// parseFlagString parse a --key=value argument in the space-separated list of arguments
+func parseFlagString(arg string) (string, string, error) {
+	if !strings.HasPrefix(arg, "--") {
+		return "", "", errors.New("the argument should start with '--'")
+	}
+	if !strings.Contains(arg, "=") {
+		return "", "", errors.New("the argument should have a '=' between the flag name and the value")
+	}
+	// Remove the starting --
+	arg = strings.TrimPrefix(arg, "--")
+	// Split the string on =. Return only two substrings, since we want only key/value, but the value can include '=' as well
+	keyvalSlice := strings.SplitN(arg, "=", 2)
+
+	// Make sure both a key and value is present
+	if len(keyvalSlice) != 2 {
+		return "", "", errors.New("the argument must have both a key and a value")
+	}
+	if len(keyvalSlice[0]) == 0 {
+		return "", "", errors.New("the argument must have a key")
+	}
+
+	return keyvalSlice[0], keyvalSlice[1], nil
+}


### PR DESCRIPTION
This PR implements `kinder test e2e` and `kinder test e2e-kubeadm` commands
NB. There are few TODO in the code, but this should be enough to get started with the kubeadm upgrade tests

/kind feature
/priority important-longterm

/assign @neolit123

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews