### PR TITLE
Add waiter to kinder

### DIFF
--- a/kinder/cmd/kinder/do/do.go
+++ b/kinder/cmd/kinder/do/do.go
@@ -20,6 +20,7 @@ package do
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -35,6 +36,7 @@ type flagpole struct {
 	UsePhases      bool
 	UpgradeVersion string
 	CopyCerts      bool
+	Wait           time.Duration
 }
 
 // NewCommand returns a new cobra.Command for exec
@@ -59,7 +61,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&flags.UsePhases, "use-phases", false, "use the kubeadm phases subcommands insted of the the kubeadm top-level commands")
 	cmd.Flags().StringVar(&flags.UpgradeVersion, "upgrade-version", "", "defines the target upgrade version (it should match the version of upgrades binaries)")
 	cmd.Flags().BoolVar(&flags.CopyCerts, "automatic-copy-certs", false, "use automatic copy certs instead of manual copy certs when joining new control-plane nodes")
-
+	cmd.Flags().DurationVar(&flags.Wait, "wait", time.Duration(5*time.Minute), "Wait for cluster state to converge after action")
 	return cmd
 }
 
@@ -67,6 +69,7 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	actionFlags := kcluster.ActionFlags{
 		UsePhases: flags.UsePhases,
 		CopyCerts: flags.CopyCerts,
+		Wait:      flags.Wait,
 	}
 
 	//TODO: upgrade version mandatory for updates

--- a/kinder/hack/ci/workflows/upgrade-stable-to-master.yml
+++ b/kinder/hack/ci/workflows/upgrade-stable-to-master.yml
@@ -9,14 +9,16 @@ vars:
   controlPlaneNodes: 1
   workerNodes: 2
 tasks:
-- description: | 
+- name: pull-node-image
+  description: | 
     pulls kindest/node image with Kubernetes version release/stable 
     from the docker registry
   cmd: docker 
   args:
     - pull
     - kindest/node:{{ .vars.stable }}
-- description: | 
+- name: add-kubernetes
+  description: | 
     creates a node-image-variant by adding a Kubernetes version ci/latest
     to be used later when executing kinder do kubeadm-upgrade
   cmd: kinder 
@@ -28,7 +30,8 @@ tasks:
     #- --with-upgrade-artifacts=tmp/{{ .vars.latest }}/
     - --with-upgrade-artifacts={{ .vars.latest }}
     - --loglevel=debug
-#- description: | 
+#- name: add-etcd
+#  description: | 
 #    adds new etcd image
 #  cmd: kinder 
 #  args:
@@ -36,9 +39,10 @@ tasks:
 #    - node-image-variant 
 #    - --base-image=kindest/node:test
 #    - --image=kindest/node:test
-#    - --with-images tmp/etcd/etcd-3.3.10.tar
+#    - --with-images=tmp/etcd/etcd-3.3.10.tar
 #    - --loglevel=debug
-- description: | 
+- name: create-cluster
+  description: | 
     create a set of nodes ready for hosting the Kubernetes cluster
   cmd: kinder 
   args:
@@ -47,78 +51,74 @@ tasks:
     - --image=kindest/node:test
     - --control-plane-nodes={{ .vars.controlPlaneNodes }}
     - --worker-nodes={{ .vars.workerNodes }}
-- description: | 
+- name: init
+  description: | 
     Initializes the Kubernetes cluster with version release/stable 
     by starting the boostrap control-plane nodes
   cmd: kinder 
   args:
     - do 
     - kubeadm-init
-- description: | 
+- name: join
+  description: | 
     Join the other nodes to the Kubernetes cluster
   cmd: kinder 
   args:
     - do 
     - kubeadm-join
-- description: | 
-    Waits for all the pods to start
-    NB. this is a temporary hack while we implement a more robust solution as part of
-        kinder do kubeadm-init/kubeadm-join
-  cmd: sleep 
-  args:
-    - 30
-- description: | 
+- name: e2e-kubeadm-before
+  description: | 
     Runs kubeadm e2e test on the cluster with version release/stable 
   cmd: kinder 
   args:
     - test 
     - e2e-kubeadm
-    - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-kubeadm-before-upgrade
-- description: | 
+    - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=01-e2e-kubeadm-before-upgrade
+- name: upgrade
+  description: | 
     upgrades the cluster to ci/latest release
   cmd: kinder 
   args:
     - do 
     - kubeadm-upgrade
     - --upgrade-version={{ .vars.latest }}
-  timeout: 10m
-- description: | 
-    Waits for all the pods to restart
-    NB. this is a temporary hack while we implement a more robust solution as part of
-        kinder do kubeadm-upgrade
-  cmd: sleep 
-  args:
-    - 30
-- description: | 
+- name: e2e-kubeadm-after
+  description: | 
     Runs kubeadm e2e test on the cluster with version ci/latest 
   cmd: kinder 
   args:
     - test 
     - e2e-kubeadm
-    - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-kubeadm-after-upgrade
-- description: | 
+    - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=02-e2e-kubeadm-after-upgrade
+- name: e2e-after
+  description: | 
     Runs kubeadm e2e test on the cluster with version ci/latest 
   cmd: kinder 
   args:
     - test 
     - e2e
-    - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-after-upgrade
-- description: | 
-    Runs kubeadm e2e test on the cluster with version release/stable 
+    - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=03-e2e-after-upgrade
+    - --parallel
+  timeout: 25m
+- name: get-logs
+  description: | 
+    Collects all the test logs
   cmd: kinder
   args:
     - export
     - logs
     - "{{ .env.ARTIFACTS }}"
   force: true
-- description: | 
-    Exec kubeadm reset before the cluster
+- name: reset
+  description: | 
+    Exec kubeadm reset
   cmd: kinder 
   args:
     - do 
     - kubeadm-reset
   force: true
-- description: | 
+- name: delete
+  description: | 
     Deletes the cluster
   cmd: kinder 
   args:

--- a/kinder/pkg/actions/kubeadm-init.go
+++ b/kinder/pkg/actions/kubeadm-init.go
@@ -78,7 +78,7 @@ func runInit(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.ActionF
 	}
 
 	if err := postInit(
-		kctx, kn,
+		kctx, kn, flags,
 	); err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func runInitPhases(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.A
 	}
 
 	if err := postInit(
-		kctx, kn,
+		kctx, kn, flags,
 	); err != nil {
 		return err
 	}

--- a/kinder/pkg/actions/kubeadm-join.go
+++ b/kinder/pkg/actions/kubeadm-join.go
@@ -78,6 +78,10 @@ func runJoinWorkers(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.
 		return err
 	}
 
+	if err := waitNewWorkerNodeReady(kctx, kn, flags); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -123,6 +127,10 @@ func runJoinWorkersPhases(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcl
 	//	return err
 	//}
 
+	if err := waitNewWorkerNodeReady(kctx, kn, flags); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -160,6 +168,10 @@ func runJoinControlPlane(kctx *kcluster.KContext, kn *kcluster.KNode, flags kclu
 		"==> kubeadm join control plane 🚀",
 		"kubeadm", joinArgs...,
 	); err != nil {
+		return err
+	}
+
+	if err := waitNewControlPlaneNodeReady(kctx, kn, flags); err != nil {
 		return err
 	}
 
@@ -227,6 +239,10 @@ func runJoinControlPlanePhases(kctx *kcluster.KContext, kn *kcluster.KNode, flag
 		"==> kubeadm join phase control-plane-join all 🚀",
 		"kubeadm", "join", "phase", "control-plane-join", "all", "--experimental-control-plane",
 	); err != nil {
+		return err
+	}
+
+	if err := waitNewControlPlaneNodeReady(kctx, kn, flags); err != nil {
 		return err
 	}
 

--- a/kinder/pkg/actions/util.go
+++ b/kinder/pkg/actions/util.go
@@ -50,7 +50,7 @@ func copyKubeConfigToHost(kctx *kcluster.KContext, kn *kcluster.KNode) error {
 
 // executes postInit tasks, including copying the admin.conf file to the host,
 // installing the CNI plugin, and eventually remove the master taint
-func postInit(kctx *kcluster.KContext, kn *kcluster.KNode) error {
+func postInit(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.ActionFlags) error {
 
 	if err := copyKubeConfigToHost(
 		kctx, kn,
@@ -80,15 +80,11 @@ func postInit(kctx *kcluster.KContext, kn *kcluster.KNode) error {
 	if err := addDefaultStorageClass(node); err != nil {
 		return errors.Wrap(err, "failed to add default storage class")
 	}
-
-	// Wait for the control plane node to reach Ready status.
-	isReady := nodes.WaitForReady(node, time.Now().Add(ec.waitForReady))
-	if ec.waitForReady > 0 {
-		if !isReady {
-			log.Warn("timed out waiting for control plane to be ready")
-		}
-	}
 	*/
+
+	if err := waitNewControlPlaneNodeReady(kctx, kn, flags); err != nil {
+		return err
+	}
 
 	fmt.Printf(
 		"Cluster creation complete. You can now use the cluster with:\n\n"+

--- a/kinder/pkg/actions/waiter.go
+++ b/kinder/pkg/actions/waiter.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actions
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	kcluster "k8s.io/kubeadm/kinder/pkg/cluster"
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+// waitNewControlPlaneNodeReady waits for a new control plane node reaching the target state after init/join
+func waitNewControlPlaneNodeReady(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.ActionFlags) error {
+	fmt.Printf("==> Waiting for Node and control-plane Pods to become Ready (timeout %s) 📦\n", flags.Wait)
+	if pass := waitFor(kctx, kn, flags.Wait,
+		nodeIsReady,
+		staticPodIsReady("kube-apiserver"),
+		staticPodIsReady("kube-controller-manager"),
+		staticPodIsReady("kube-scheduler"),
+	); !pass {
+		return errors.New("timeout: Node and control-plane did not reach target state")
+	}
+	fmt.Println()
+	return nil
+}
+
+// waitControlPlaneUpgraded waits for a control plane node reaching the target state after upgrade
+func waitControlPlaneUpgraded(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.ActionFlags) error {
+	version := flags.UpgradeVersion.String()
+
+	fmt.Printf("==> Waiting for control-plane Pods to restart with the new version (timeout %s) 📦\n", flags.Wait)
+	if pass := waitFor(kctx, kn, flags.Wait,
+		staticPodHasVersion("kube-apiserver", version),
+		staticPodHasVersion("kube-controller-manager", version),
+		staticPodHasVersion("kube-scheduler", version),
+	); !pass {
+		return errors.New("timeout: control-plane did not reach target state")
+	}
+	fmt.Println()
+	return nil
+}
+
+// waitKubeletUpgraded waits for a node reaching the target state after upgrade
+func waitKubeletUpgraded(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.ActionFlags) error {
+	version := flags.UpgradeVersion.String()
+
+	fmt.Printf("==> Waiting for Node to restart with the new version (timeout %s) 📦\n", flags.Wait)
+	if pass := waitFor(kctx, kn, flags.Wait,
+		nodeHasKubernetesVersion(version),
+	); !pass {
+		return errors.New("timeout: node did not reach target state")
+	}
+	fmt.Println()
+	return nil
+}
+
+// waitNewWorkerNodeReady waits for a new control plane node reaching the target state after join
+func waitNewWorkerNodeReady(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.ActionFlags) error {
+	fmt.Printf("==> Waiting for Node to become Ready (timeout %s) 📦\n", flags.Wait)
+	if pass := waitFor(kctx, kn, flags.Wait,
+		nodeIsReady,
+	); !pass {
+		return errors.New("timeout: Node did not reach target state")
+	}
+	fmt.Println()
+	return nil
+}
+
+// waitKubeletHasRBAC waits for the kubelet to have access to the expected config map
+// please note that this is a temporary workaround for a problem we are observing on upgrades while
+// executing node upgrades immediately after control-plane upgrade.
+func waitKubeletHasRBAC(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.ActionFlags) error {
+	fmt.Printf("==> Waiting for kubelet RBAC validation - workaround (timeout %s) 📦\n", flags.Wait)
+	if pass := waitFor(kctx, kn, flags.Wait,
+		kubeletHasRBAC(flags.UpgradeVersion.Major(), flags.UpgradeVersion.Minor()),
+	); !pass {
+		return errors.New("timeout: Node did not reach target state")
+	}
+	fmt.Println()
+	return nil
+}
+
+// try defines a function that test a condition to be waited for
+type try func(*kcluster.KContext, *kcluster.KNode) bool
+
+// waitFor implements the waiter core logic that is responsible for testing all the given contitions
+// until are satisfied or a timeout are reached
+func waitFor(kctx *kcluster.KContext, kn *kcluster.KNode, timeout time.Duration, conditions ...try) bool {
+	// if timeout is 0 or no conditions are defined, exit fast
+	if timeout == time.Duration(0) || len(conditions) == 0 {
+		fmt.Println("Nothing to wait for, moving on")
+		return true
+	}
+
+	// sets the timeout timer
+	timer := time.NewTimer(timeout)
+
+	// runs all the conditions in parallel
+	pass := make(chan bool)
+	for _, c := range conditions {
+		// clone the condition func to make the closure point to right value
+		// even after the for loop moves to the next condition
+		x := c
+
+		// run the condition in a go routine until it pass
+		go func() {
+			for {
+				if x(kctx, kn) {
+					pass <- true
+					break
+				}
+				// add a little delay before retry
+				time.Sleep(500)
+			}
+		}()
+	}
+
+	// wait for all the conditions to pass or for a timeout
+	passed := 0
+	for {
+		select {
+		case <-pass:
+			passed++
+			if passed == len(conditions) {
+				return true
+			}
+		case <-timer.C:
+			return false
+		}
+	}
+}
+
+// nodeIsReady implement a function that test when a node is ready
+func nodeIsReady(kctx *kcluster.KContext, kn *kcluster.KNode) bool {
+	output := kubectlOutput(kctx.BootStrapControlPlane(),
+		"get",
+		"nodes",
+		"--kubeconfig=/etc/kubernetes/admin.conf",
+		// check for the selected node
+		fmt.Sprintf("-l=kubernetes.io/hostname=%s", kn.Name()),
+		// check for status.conditions type:Ready
+		"-o=jsonpath='{.items..status.conditions[?(@.type == \"Ready\")].status}'",
+	)
+	if strings.Contains(output, "True") {
+		fmt.Printf("Node %s is ready\n", kn.Name())
+		return true
+	}
+	return false
+}
+
+// nodeHasKubernetesVersion implement a function that if a node is has the given Kubernetes version
+func nodeHasKubernetesVersion(version string) func(kctx *kcluster.KContext, kn *kcluster.KNode) bool {
+	return func(kctx *kcluster.KContext, kn *kcluster.KNode) bool {
+		output := kubectlOutput(kctx.BootStrapControlPlane(),
+			"get",
+			"nodes",
+			"--kubeconfig=/etc/kubernetes/admin.conf",
+			// check for the selected node
+			fmt.Sprintf("-l=kubernetes.io/hostname=%s", kn.Name()),
+			// check for the kubelet version
+			"-o=jsonpath='{.items..status.nodeInfo.kubeletVersion}'",
+		)
+		if strings.Contains(output, version) {
+			fmt.Printf("Node %s has Kubernetes version %s\n", kn.Name(), version)
+			return true
+		}
+		return false
+	}
+}
+
+// staticPodIsReady implement a function that test when a static pod is ready
+func staticPodIsReady(pod string) func(kctx *kcluster.KContext, kn *kcluster.KNode) bool {
+	return func(kctx *kcluster.KContext, kn *kcluster.KNode) bool {
+		output := kubectlOutput(kctx.BootStrapControlPlane(),
+			"get",
+			"pods",
+			"--kubeconfig=/etc/kubernetes/admin.conf",
+			"-n=kube-system",
+			// check for static pods existing on the selected node
+			fmt.Sprintf("%s-%s", pod, kn.Name()),
+			// check for status.conditions type:Ready
+			"-o=jsonpath='{.status.conditions[?(@.type == \"Ready\")].status}'",
+		)
+		if strings.Contains(output, "True") {
+			fmt.Printf("Pod %s-%s is ready\n", pod, kn.Name())
+			return true
+		}
+		return false
+	}
+}
+
+// staticPodHasVersion implement a function that if a static pod is has the given Kubernetes version
+func staticPodHasVersion(pod, version string) func(kctx *kcluster.KContext, kn *kcluster.KNode) bool {
+	return func(kctx *kcluster.KContext, kn *kcluster.KNode) bool {
+		output := kubectlOutput(kctx.BootStrapControlPlane(),
+			"get",
+			"pods",
+			"--kubeconfig=/etc/kubernetes/admin.conf",
+			"-n=kube-system",
+			// check for static pods existing on the selected node
+			fmt.Sprintf("%s-%s", pod, kn.Name()),
+			// check for the node image
+			// NB. this assumes the Pod has only one container only
+			// which is true for the control plane pods
+			"-o=jsonpath='{.spec.containers[0].image}'",
+		)
+		if strings.Contains(output, version) {
+			fmt.Printf("Pod %s-%s has Kubernetes version %s\n", pod, kn.Name(), version)
+			return true
+		}
+		return false
+	}
+}
+
+// kubeletHasRBAC is a test checking that kubelet has access to the expected config map
+func kubeletHasRBAC(major, minor uint) func(kctx *kcluster.KContext, kn *kcluster.KNode) bool {
+	return func(kctx *kcluster.KContext, kn *kcluster.KNode) bool {
+		for i := 0; i < 5; i++ {
+			output := kubectlOutput(kctx.BootStrapControlPlane(),
+				"get",
+				"cm",
+				fmt.Sprintf("kubelet-config-%d.%d", major, minor),
+				"--kubeconfig=/etc/kubernetes/kubelet.conf",
+				"-n=kube-system",
+				"-o=jsonpath='{.metadata.name}'",
+			)
+			if output != "" {
+				time.Sleep(1 * time.Second)
+				continue
+			}
+			return false
+		}
+
+		fmt.Println("kubelet has access to expected config maps")
+		return true
+	}
+}
+
+// kubectlOutput implements a utility function that runs a kubectl command on the given node
+// and captures the command output
+func kubectlOutput(kn *kcluster.KNode, args ...string) string {
+	cmd := kn.Command(
+		"kubectl",
+		args...,
+	)
+	lines, err := exec.CombinedOutputLines(cmd)
+	if err != nil {
+		return ""
+	}
+	if len(lines) != 1 {
+		return ""
+	}
+
+	return lines[0]
+}

--- a/kinder/pkg/cluster/context.go
+++ b/kinder/pkg/cluster/context.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"sigs.k8s.io/kind/pkg/cluster/constants"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
@@ -205,6 +206,7 @@ type ActionFlags struct {
 	UsePhases      bool
 	UpgradeVersion *version.Version
 	CopyCerts      bool
+	Wait           time.Duration
 }
 
 // Do actions on kubernetes-in-docker cluster

--- a/kinder/pkg/test/workflow/workflow.go
+++ b/kinder/pkg/test/workflow/workflow.go
@@ -118,13 +118,17 @@ func NewWorkflow(file string) (*Workflow, error) {
 	// For each task
 	for i, t := range w.Tasks {
 		// if a task name is not defined, assign a default task name
+		// otherwise prepend a prefix in order to get task logs ordered
 		if t.Name == "" {
 			t.Name = fmt.Sprintf("task-%d", i)
+		} else {
+			t.Name = fmt.Sprintf("task-%d-%s", i, t.Name)
 		}
 
 		// if a timeout is not defined, assign a default one
+		// nb. we are assigning a fairly long timeout to avoid flakes in testgrid
 		if t.Timeout == 0 {
-			t.Timeout = time.Duration(1 * time.Minute)
+			t.Timeout = time.Duration(5 * time.Minute)
 		}
 
 		// check if the task defines a cmd


### PR DESCRIPTION
This PR implements a waiter that blocks kinder actions waiting for nodes to get ready, pods to restart or to get upgraded etc. with the ultimate goal to make test workflows more stable and avoid flakes

It includes also a few small improvements to the test workflow manager (in a separated commit)

/kind feature
/priority important-longterm

/assign @neolit123

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews