### PR TITLE
Enable verbose log for kinder test

### DIFF
--- a/kinder/ci/kinder-run.sh
+++ b/kinder/ci/kinder-run.sh
@@ -59,4 +59,4 @@ fi
 
 # run the workflow
 KINDER_FLAGS=""
-kinder test workflow "${WORKFLOW_PATH}" "${KINDER_FLAGS}"
+kinder test workflow "${WORKFLOW_PATH}" "${KINDER_FLAGS}" --verbose


### PR DESCRIPTION
Temporary enable verbose log to better understand test infra error

/priority important-longterm
/kind feature
/assign @neolit123 