### PR TITLE
kinder-workflow: propagate errors to the parent workflow command

### DIFF
--- a/kinder/.gitignore
+++ b/kinder/.gitignore
@@ -1,3 +1,4 @@
 # tmp folder for testing node variants
 /tmp
 /kinder
+/kinder-test-workflow*

--- a/kinder/pkg/test/workflow/workflow.go
+++ b/kinder/pkg/test/workflow/workflow.go
@@ -206,6 +206,7 @@ func (w *Workflow) Run(dryRun, verbose, exitOnError bool, artifacts string) (err
 		tcmds = append(tcmds, tcmd)
 	}
 
+	foundError := false
 	// Executes taskCmds
 	for _, tcmd := range tcmds {
 		fmt.Printf("# %s\n", tcmd.Name)
@@ -214,10 +215,11 @@ func (w *Workflow) Run(dryRun, verbose, exitOnError bool, artifacts string) (err
 		if !dryRun {
 			err := taskCmdRunner.Run(tcmd, artifacts, verbose)
 			if err != nil {
+				foundError = true
 				fmt.Printf(" %v\n\n", err)
 
 				if exitOnError {
-					return nil
+					return err
 				}
 
 				continue
@@ -233,9 +235,13 @@ func (w *Workflow) Run(dryRun, verbose, exitOnError bool, artifacts string) (err
 
 		if err := taskCmdRunner.DumpJUnitRunner(artifacts); err != nil {
 			fmt.Printf("%v\n", err)
-			return nil
+			return err
 		}
 		fmt.Printf("see junit-runner.xml and task logs files for more details\n\n")
+	}
+
+	if foundError {
+		return errors.New("failed executing the workflow")
 	}
 	return nil
 }


### PR DESCRIPTION
```
kinder-workflow: propagate errors to the parent workflow command  …

Even if exitOnError is false, make sure that an error is returned
from the Workflow::Run() function, so that the workflow command's
RunE function causes the process to exit with a non-zero status.
This is done using the foundError flag.

Also always return the causing error instead of nil.
```

```
kinder: ignore kinder-test-workflow* paths in .gitignore  …

This is done so that execution of the kinder command from the
kinder source directory ignores the paths where kinder writes the
logs.
```

/kind cleanup
/priority important-longterm
/assign @fabriziopandini 
