### PR TITLE
fix junit-runner.xml

### DIFF
--- a/kinder/pkg/test/workflow/taskCmdRunner.go
+++ b/kinder/pkg/test/workflow/taskCmdRunner.go
@@ -44,7 +44,7 @@ type taskCmdRunner struct {
 
 // junitTestSuite implements junit TestSuite standard object
 type junitTestSuite struct {
-	XMLName  xml.Name `xml:"junitTestSuite"`
+	XMLName  xml.Name `xml:"testsuite"`
 	Failures int      `xml:"failures,attr"`
 	Tests    int      `xml:"tests,attr"`
 	Time     float64  `xml:"time,attr"`
@@ -53,7 +53,7 @@ type junitTestSuite struct {
 
 // junitTestCase implements junit TestCase standard object
 type junitTestCase struct {
-	XMLName   xml.Name `xml:"junitTestCase"`
+	XMLName   xml.Name `xml:"testcase"`
 	ClassName string   `xml:"classname,attr"`
 	Name      string   `xml:"name,attr"`
 	Time      float64  `xml:"time,attr"`

--- a/kinder/pkg/test/workflow/workflow.go
+++ b/kinder/pkg/test/workflow/workflow.go
@@ -120,9 +120,9 @@ func NewWorkflow(file string) (*Workflow, error) {
 		// if a task name is not defined, assign a default task name
 		// otherwise prepend a prefix in order to get task logs ordered
 		if t.Name == "" {
-			t.Name = fmt.Sprintf("task-%d", i)
+			t.Name = fmt.Sprintf("task-%02d", i)
 		} else {
-			t.Name = fmt.Sprintf("task-%d-%s", i, t.Name)
+			t.Name = fmt.Sprintf("task-%02d-%s", i, t.Name)
 		}
 
 		// if a timeout is not defined, assign a default one


### PR DESCRIPTION
Fix junit-runner.xml serialization and log file name to get everything sorted properly when navigating the artifact folder

/assign @neolit123

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews