### PR TITLE
kinder: move the e2e step after upgrade

### DIFF
--- a/kinder/ci/workflows/upgrade-stable-master.yaml
+++ b/kinder/ci/workflows/upgrade-stable-master.yaml
@@ -88,17 +88,6 @@ tasks:
     - e2e-kubeadm
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=01-e2e-kubeadm-before-upgrade
     - --name={{ .env.KINDER_CLUSTER_NAME }}
-- name: e2e-bofore
-  description: |
-    Runs kubeadm e2e test on the cluster with version ci/latest
-  cmd: kinder
-  args:
-    - test
-    - e2e
-    - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=03-e2e-after-upgrade
-    - --parallel
-    - --name={{ .env.KINDER_CLUSTER_NAME }}
-  timeout: 25m
 - name: upgrade
   description: |
     upgrades the cluster to ci/latest release
@@ -125,6 +114,17 @@ tasks:
     - do
     - cluster-info
     - --name={{ .env.KINDER_CLUSTER_NAME }}
+- name: e2e-after
+  description: |
+    Runs kubeadm e2e test on the cluster with version ci/latest
+  cmd: kinder
+  args:
+    - test
+    - e2e
+    - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=03-e2e-after-upgrade
+    - --parallel
+    - --name={{ .env.KINDER_CLUSTER_NAME }}
+  timeout: 25m
 - name: get-logs
   description: |
     Collects all the test logs
@@ -132,8 +132,8 @@ tasks:
   args:
     - export
     - logs
-    - "{{ .env.ARTIFACTS }}"
     - --name={{ .env.KINDER_CLUSTER_NAME }}
+    - "{{ .env.ARTIFACTS }}"
   force: true
 - name: reset
   description: |


### PR DESCRIPTION
Also move the --name flag of the "get logs" step.

/assign @fabriziopandini 
/kind failing-test
