### PR TITLE
kinder: update calico manifest to latest stable

### DIFF
--- a/kinder/pkg/actions/util.go
+++ b/kinder/pkg/actions/util.go
@@ -61,8 +61,7 @@ func postInit(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.Action
 	if err := kn.DebugCmd(
 		"==> install cni 🗻",
 		"/bin/sh", "-c", //use shell to get $(...) resolved into the container
-		"kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml && "+
-			"kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml",
+		"kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f https://docs.projectcalico.org/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml",
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
We should consider how we track this going forward.
With every release of calico the url will change.

A potential solution is to track github.io/kube-flannel.yaml instead as
there are fewer moving parts and it will track master in the flannel
repo.

Signed-off-by: Duffie Cooley <dcooley@heptio.com>