### PR TITLE
Add --with-init-artifacts flag to kinder build node-variant command

### DIFF
--- a/kinder/cmd/kinder/build/nodevariant/nodevariant.go
+++ b/kinder/cmd/kinder/build/nodevariant/nodevariant.go
@@ -27,6 +27,7 @@ import (
 type flagpole struct {
 	Image            string
 	BaseImage        string
+	InitArtifacts    string
 	ImageTars        []string
 	ImageNamePrefix  string
 	UpgradeArtifacts string
@@ -55,7 +56,12 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(
 		&flags.BaseImage, "base-image",
 		node.DefaultImage,
-		"name:tag of the base image to use for the build",
+		"name:tag of the base image to use for the build; this can be a kindest/base image or kindest/node image",
+	)
+	cmd.Flags().StringVar(
+		&flags.InitArtifacts, "with-init-artifacts",
+		"",
+		"version/build-label/path to a folder with Kubernetes binaries & image tarballs to be used for the kubeadm init workflow",
 	)
 	cmd.Flags().StringSliceVar(
 		&flags.ImageTars, "with-images",
@@ -70,7 +76,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(
 		&flags.UpgradeArtifacts, "with-upgrade-artifacts",
 		"",
-		"version/build-label/path to a folder with kubernetes binaries & image tarballs to be used for testing the kubeadm-upgrade workflow",
+		"version/build-label/path to a folder with Kubernetes binaries & image tarballs to be used for testing the kubeadm-upgrade workflow",
 	)
 	cmd.Flags().StringVar(
 		&flags.Kubeadm, "with-kubeadm",
@@ -91,10 +97,11 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 		alter.WithImage(flags.Image),
 		alter.WithBaseImage(flags.BaseImage),
 		// bits to be added to the image
-		alter.WithImageTars(flags.ImageTars),
-		alter.WithUpgradeArtifacts(flags.UpgradeArtifacts),
+		alter.WithInitArtifacts(flags.InitArtifacts),
 		alter.WithKubeadm(flags.Kubeadm),
 		alter.WithKubelet(flags.Kubelet),
+		alter.WithImageTars(flags.ImageTars),
+		alter.WithUpgradeArtifacts(flags.UpgradeArtifacts),
 		// bits options
 		alter.WithImageNamePrefix(flags.ImageNamePrefix),
 	)

--- a/kinder/doc/prepare-for-tests.md
+++ b/kinder/doc/prepare-for-tests.md
@@ -8,6 +8,8 @@ pack whatever you need during your test in the node-images.
 kind gives already you what you need in most cases (kubeadm, Kubernetes binaries, pre-pulled images); kinder
 on top of that allows to build node variants for addressing following use cases:
 
+- Adding a Kubernetes version to be used for initializing the cluster (as an alternative to `build node-image
+  --type`(s) already supported by kind)
 - Adding new pre-loaded images that will be made available on all nodes at cluster creation time
 - Replacing the kubeadm binary installed in the cluster, e.g. with a locally build version of kubeadm
 - Replacing the kubelet binary installed in the cluster, e.g. with a locally build version of kubelet
@@ -27,11 +29,13 @@ docker pull kindest/node:vX
 For building a node image you can refer to kind documentation; below a short recap of necessary steps:
 
 Build a base-image (or download one from docker hub)
+
 ```bash
 kinder build base-image --image kindest/base:latest
 ```
 
-Build a node-image starting from the above node image
+Build a node-image starting from the above base image using `build node-image --type`(s) supported by kind
+
 ```bash
 # To build a node-image using latest Kubernetes apt packages available
 kinder build node-image --base-image kindest/base:latest --image kindest/node:vX --type apt
@@ -40,8 +44,30 @@ kinder build node-image --base-image kindest/base:latest --image kindest/node:vX
 kinder build node-image --base-image kindest/base:latest --image kindest/node:vX --type bazel
 ```
 
->  NB see https://github.com/kubernetes/kubeadm/blob/master/testing-pre-releases.md#change-the-target-version-number-when-building-a-local-release for overriding
+> NB see <https://github.com/kubernetes/kubeadm/blob/master/testing-pre-releases.md#change-the-target-version-number-when-building-a-local-release> for overriding
 the build version in case of `--type bazel`
+
+As an alternative, it is possible to pick an existing base image and customize it by adding a Kubernetes
+version with:
+
+```bash
+kinder build node-image-variant \
+     --base-image kindest/base:vX \
+     --image kindest/node:vX-variant \
+     --with-init-artifacts $mylocalbinary/kubeadm
+```
+
+Please note that `kinder build node-image-variant` accepts as input:
+
+- a version, e.g. v1.14.0
+- a release build label, e.g. release/stable, release/stable-1.13, release/latest-14.
+- a ci build label, e.g. ci/latest, ci/latest-14.
+- a remote repository, e.g. <http://k8s.mycompany.com/>
+- a local folder, as shown in the examples above.
+
+It is also possible to get Kubernetes artifacts locally using `kinder get artifacts`.
+
+See [Kinder reference](doc/reference.md) for more detail.
 
 ## Customize a node-image
 
@@ -56,7 +82,7 @@ kinder build node-image-variant \
      --with-kubeadm $mylocalbinary/kubeadm
 ```
 
-2. adding/overriding the pre loaded images in the `/kind/images` folder
+1. adding/overriding the pre loaded images in the `/kind/images` folder
 
 ```bash
 kinder build node-image-variant \
@@ -65,7 +91,7 @@ kinder build node-image-variant \
      --with-images $mylocalimages/nginx.tar
 ```
 
-3. adding a second Kubernetes version in the `/kinder/upgrades` folder for testing upgrades
+1. adding a second Kubernetes version in the `/kinder/upgrades` folder for testing upgrades
 
 ```bash
 kinder build node-image-variant \
@@ -74,14 +100,14 @@ kinder build node-image-variant \
      --with-upgrade-artifacts $mylocalbinaries/vY
 ```
 
-Please note that `kinder build node-image-variant` accepts in input:
+Please note that `kinder build node-image-variant` accepts as input:
 
 - a version, e.g. v1.14.0
 - a release build label, e.g. release/stable, release/stable-1.13, release/latest-14.
 - a ci build label, e.g. ci/latest, ci/latest-14.
-- a remote repository, e.g. http://k8s.mycompany.com/
+- a remote repository, e.g. <http://k8s.mycompany.com/>
 - a local folder, as shown in the examples above.
 
-It is also possible to get Kubernetes artifact locally using `kinder get artifacts`.
+It is also possible to get Kubernetes artifacts locally using `kinder get artifacts`.
 
 See [Kinder reference](doc/reference.md) for more detail.

--- a/kinder/doc/reference.md
+++ b/kinder/doc/reference.md
@@ -161,12 +161,14 @@ kinder cp \
 
 > Please note that,  `docker cp` or `kinder cp`  allows you to replace the kubeadm binary on existing nodes. If you want to replace the kubeadm binary on nodes that you create in future, please check altering node images paragraph
 
-## Altering node images
+## Altering images
 
 Kind can be extremely efficient when the node image contains all the necessary artifacts.
 
-kinder allows kubeadm contributor to exploit this feature by implementing the `kinder build node-image-variant` command, that takes a node-image and allows to build variants by:
+kinder allows kubeadm contributor to exploit this feature by implementing the `kinder build node-image-variant` command, that takes a node-image (or a bare base image) and allows to build variants by:
 
+- Adding a Kubernetes version to be used for initializing the cluster (as an alternative to `build node-image
+  --type`(s) already supported by kind)
 - Adding new pre-loaded images that will be made available on all nodes at cluster creation time
 - Replacing the kubeadm binary installed in the cluster, e.g. with a locally build version of kubeadm
 - Replacing the kubelet binary installed in the cluster, e.g. with a locally build version of kubelet
@@ -177,8 +179,30 @@ kinder allows kubeadm contributor to exploit this feature by implementing the `k
 - a version, e.g. v1.14.0 or v1.15.0-alpha.0.100+78573805a7292a
 - a release build label, e.g. release/stable, release/stable-1.13, release/latest-14
 - a ci build label, e.g. ci/latest, ci/latest-1.14
-- a remote repository, e.g. http://k8s.mycompany.com/
+- a remote repository, e.g. <http://k8s.mycompany.com/>
 - a local folder, as shown in the examples above.
+
+### Add init packages
+
+```bash
+kinder build node-image-variant \
+     --base-image kindest/base:latest \
+     --image kindest/node:PR12345 \
+     --with-init-artifacts v1.14.0
+
+kinder build node-image-variant \
+     --base-image kindest/base:latest \
+     --image kindest/node:PR12345 \
+     --with-init-artifacts $my-local-packages/v1.12.2/
+```
+
+When reading from a local folder or from a remote repository, a `version` file should exist in the source.
+
+Init artifacts will be placed in a well know folders, `kind/bin` and `kind/images`, and `kubelet` service
+will be configured, thus making the container derived from the image ready for `kinder do kubeadm-init`
+action (or for direct invocation of `kubeadm init`).
+
+If necessary, it is possible to add more than one Kubernetes version e.g. for testing upgrade sequences.
 
 ### Add images
 
@@ -243,7 +267,7 @@ kinder build node-image-variant \
 When reading from a local folder or from a remote repository, a `version` file should exist in the source.
 
 Upgrade artifacts for will be placed in a well know folder, `kinder/upgrade/{version}` that will be used by
-`kinder do kubeadm-upgrade` action.
+`kinder do kubeadm-upgrade` action (or for direct invocation of `kubeadm upgrade`).
 
 If necessary, it is possible to add more than one Kubernetes version e.g. for testing upgrade sequences.
 
@@ -254,7 +278,7 @@ It is also possible to get Kubernetes artifact locally using `kinder get artifac
 - a version, e.g. v1.14.0 or v1.15.0-alpha.0.100+78573805a7292a
 - a release build label, e.g. release/stable, release/stable-1.13, release/latest-14
 - a ci build label, e.g. ci/latest, ci/latest-1.14
-- a remote repository, e.g. http://k8s.mycompany.com/
+- a remote repository, e.g. <http://k8s.mycompany.com/>
 - a local folder
 
 Flags `--only-kubeadm`, `--only-kubelet`, `--only-binaries`, and `--only-images` can be used to limit the number of files read from the source.

--- a/kinder/pkg/build/alter/alter.go
+++ b/kinder/pkg/build/alter/alter.go
@@ -43,6 +43,7 @@ const AlterContainerLabelKey = "io.k8s.sigs.kinder.alter"
 type Context struct {
 	baseImage           string
 	image               string
+	initArtifactsSrc    string
 	imageSrcs           []string
 	imageNamePrefix     string
 	upgradeArtifactsSrc string
@@ -52,6 +53,13 @@ type Context struct {
 
 // Option is Context configuration option supplied to NewContext
 type Option func(*Context)
+
+// WithInitArtifacts configures a NewContext to include binaries & images for init
+func WithInitArtifacts(src string) Option {
+	return func(b *Context) {
+		b.initArtifactsSrc = src
+	}
+}
 
 // WithImage configures a NewContext to tag the built image with `image`
 func WithImage(image string) Option {
@@ -120,6 +128,10 @@ func NewContext(options ...Option) (ctx *Context, err error) {
 func (c *Context) Alter() (err error) {
 	// initialize bits
 	var bits []bits
+
+	if c.initArtifactsSrc != "" {
+		bits = append(bits, newInitBits(c.initArtifactsSrc))
+	}
 
 	if c.kubeadmSrc != "" {
 		bits = append(bits, newBinaryBits(c.kubeadmSrc, "kubeadm"))

--- a/kinder/pkg/build/alter/initBits.go
+++ b/kinder/pkg/build/alter/initBits.go
@@ -1,0 +1,321 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alter
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"k8s.io/kubeadm/kinder/pkg/extract"
+)
+
+// initBits implements bits that allows to add Kubernetes binaries & images to the node image;
+// those artifact will be used by the kinder do kubeadm-init script
+type initBits struct {
+	src string
+}
+
+var _ bits = &initBits{}
+
+func newInitBits(arg string) bits {
+	return &initBits{
+		src: arg,
+	}
+}
+
+// Get implements bits.Getget
+func (b *initBits) Get(c *bitsContext) error {
+	// ensure the dest path exists on host/inside the HostBitsPath
+	dst := filepath.Join(c.HostBitsPath(), "init")
+	if err := os.Mkdir(dst, 0777); err != nil {
+		return errors.Wrap(err, "failed to make bits dir")
+	}
+
+	// Creates an extractor instance, that will read binaries & images required from upgrades from the src,
+	// where source can be one of version/build-label/folder containing the  binaries & images,
+	// and save it to the dst folder
+	e := extract.NewExtractor(
+		b.src, dst,
+	)
+
+	// Extracts the binary bit
+	_, err := e.Extract()
+	return err
+}
+
+// Install implements bits.Install
+func (b *initBits) Install(c *bitsContext) error {
+
+	// install Kubernetes version file for init
+	if err := installInitVersionFile(c); err != nil {
+		return err
+	}
+
+	// install Kubernetes images for init
+	if err := installInitImages(c); err != nil {
+		return err
+	}
+
+	// install Kubernetes binaries for init
+	if err := installInitBinaries(c); err != nil {
+		return err
+	}
+
+	// configure kubelet service with the kubeadm drop in file
+	if err := configureKubelet(c); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func installInitVersionFile(c *bitsContext) error {
+	// The src path is a subfolder into the alterDir, that is mounted in the
+	// container as /alter
+	src := filepath.Join(c.ContainerBitsPath(), "init")
+
+	// The dest path for Kubernetes version file is /kind, a well known folder where kind(er) will
+	// search for this file when looking for image metadata
+	dst := filepath.Join("/kind")
+
+	// create dest folder
+	if err := c.RunInContainer("mkdir", "-p", dst); err != nil {
+		log.Errorf("failed to create %s folder into the image! %v", dst, err)
+		return err
+	}
+
+	// copy image tarballs artifacts into the image
+	srcVersion := filepath.Join(src, "version")
+	dstVersion := filepath.Join(dst, "version")
+	log.Infof("Adding %s file to the image", dstVersion)
+	if err := c.RunInContainer("cp", srcVersion, dstVersion); err != nil {
+		log.Errorf("failed to copy %s into the image! %v", src, err)
+		return err
+	}
+
+	// TODO: someday we might need a different user ...
+	if err := c.RunInContainer("chown", "-R", "root:root", dstVersion); err != nil {
+		log.Errorf("failed to set ownership on %s! %v", dstVersion, err)
+		return err
+	}
+
+	return nil
+}
+
+func installInitImages(c *bitsContext) error {
+	// The src path is a subfolder into the alterDir, that is mounted in the
+	// container as /alter
+	hsrc := filepath.Join(c.HostBitsPath(), "init")
+	csrc := filepath.Join(c.ContainerBitsPath(), "init")
+
+	// The dest path for Kubernetes images is /kind/images, a well known folder where kind(er) will
+	// search for pre-loaded images during `kind(er) create`
+	dst := filepath.Join("/kind", "images")
+
+	// create dest folder
+	if err := c.RunInContainer("mkdir", "-p", dst); err != nil {
+		log.Errorf("failed to create %s folder into the image! %v", dst, err)
+		return err
+	}
+
+	// copy image tarballs artifacts into the image
+	pattern := filepath.Join(hsrc, "*.tar")
+	images, err := filepath.Glob(pattern)
+	log.Debugf("Searching %s", pattern)
+	log.Debugf("Found %s", images)
+	if err != nil {
+		return errors.Wrapf(err, "failed to search for images in %s", hsrc)
+	}
+	for _, image := range images {
+		srcImage := filepath.Join(csrc, filepath.Base(image))
+		dstImage := filepath.Join(dst, filepath.Base(image))
+		log.Infof("Adding %s image tarball to the image", dstImage)
+		if err := c.RunInContainer("cp", srcImage, dstImage); err != nil {
+			log.Errorf("failed to copy %s into the image! %v", srcImage, err)
+			return err
+		}
+
+		// TODO: someday we might need a different user ...
+		if err := c.RunInContainer("chown", "-R", "root:root", dstImage); err != nil {
+			log.Errorf("failed to set ownership on %s! %v", dstImage, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func installInitBinaries(c *bitsContext) error {
+	// The src path is a subfolder into the alterDir, that is mounted in the
+	// container as /alter
+	src := filepath.Join(c.ContainerBitsPath(), "init")
+
+	// The destination path for the Kubernetes binaries is /kind/bin, a well known folder where kind adds Kubernetes binaries when
+	// building node-image using --type bazel or --type docker
+	dst := filepath.Join("/kind", "bin")
+
+	// create dest folder
+	if err := c.RunInContainer("mkdir", "-p", dst); err != nil {
+		log.Errorf("failed to create %s folder into the image! %v", dst, err)
+		return err
+	}
+
+	// copy binary artifacts into the image and symlink the kubernetes binaries into $PATH
+	binaries := []string{"kubeadm", "kubelet", "kubectl"}
+	for _, binary := range binaries {
+		srcBinary := filepath.Join(src, binary)
+		dstBinary := filepath.Join(dst, binary)
+		lnBinary := filepath.Join("/usr", "bin", binary)
+		log.Infof("Adding %s binary to the image and symlink to %s", dstBinary, lnBinary)
+		if err := c.RunInContainer("cp", srcBinary, dstBinary); err != nil {
+			log.Errorf("failed to copy %s into the image! %v", src, err)
+			return err
+		}
+
+		// TODO: someday we might need a different user ...
+		if err := c.RunInContainer("chown", "-R", "root:root", dstBinary); err != nil {
+			log.Errorf("failed to set ownership on %s! %v", dstBinary, err)
+			return err
+		}
+
+		if err := c.RunInContainer("ln", "-sf", dstBinary, lnBinary); err != nil {
+			return errors.Wrapf(err, "failed to symlink %s", dstBinary)
+		}
+	}
+
+	return nil
+}
+
+func configureKubelet(c *bitsContext) error {
+	// files for for the kubelet.service is created on the flight directly into the alter filesystem
+	hsrc := filepath.Join(c.HostBitsPath(), "systemd")
+	if err := os.MkdirAll(hsrc, 0777); err != nil {
+		log.Errorf("failed to create %s folder! %v", hsrc, err)
+		return err
+	}
+	csrc := filepath.Join(c.ContainerBitsPath(), "systemd")
+
+	// The destination path for the kubelet.service file is /kind/systemd,
+	dst := filepath.Join("/kind", "systemd")
+
+	// create dest folder
+	if err := c.RunInContainer("mkdir", "-p", dst); err != nil {
+		log.Errorf("failed to create %s folder into the image! %v", dst, err)
+		return err
+	}
+
+	// write the kubelet.service file
+	hsrcFile := filepath.Join(hsrc, "kubelet.service")
+	csrcFile := filepath.Join(csrc, "kubelet.service")
+	dstFile := filepath.Join(dst, "kubelet.service")
+	log.Infof("Adding %s to the image and enabling the kubelet service", dstFile)
+	if err := ioutil.WriteFile(hsrcFile, kubeletService, 0644); err != nil {
+		log.Errorf("failed to create %s file into the image! %v", dstFile, err)
+		return err
+	}
+
+	if err := c.RunInContainer("cp", csrcFile, dstFile); err != nil {
+		log.Errorf("failed to copy %s into the image! %v", csrcFile, err)
+		return err
+	}
+
+	// TODO: someday we might need a different user ...
+	if err := c.RunInContainer("chown", "-R", "root:root", dstFile); err != nil {
+		log.Errorf("failed to set ownership on %s! %v", dstFile, err)
+		return err
+	}
+
+	// enable the kubelet service
+	if err := c.RunInContainer("systemctl", "enable", dstFile); err != nil {
+		return errors.Wrap(err, "failed to enable kubelet service")
+	}
+
+	// The destination path for the kubeadm dropin file is /etc/systemd/system/kubelet.service.d/
+	dst = filepath.Join("/etc", "systemd", "system", "kubelet.service.d")
+
+	// create dest folder
+	if err := c.RunInContainer("mkdir", "-p", dst); err != nil {
+		log.Errorf("failed to create %s folder into the image! %v", dst, err)
+		return err
+	}
+
+	// write the 10-kubeadm.conf file
+	hsrcFile = filepath.Join(hsrc, "10-kubeadm.conf")
+	csrcFile = filepath.Join(csrc, "10-kubeadm.conf")
+	dstFile = filepath.Join(dst, "10-kubeadm.conf")
+	log.Infof("Adding %s to the image", dstFile)
+	if err := ioutil.WriteFile(hsrcFile, kubeadmDropIn, 0644); err != nil {
+		log.Errorf("failed to create %s file into the image! %v", dstFile, err)
+		return err
+	}
+
+	if err := c.RunInContainer("cp", csrcFile, dstFile); err != nil {
+		log.Errorf("failed to copy %s into the image! %v", csrcFile, err)
+		return err
+	}
+
+	// TODO: someday we might need a different user ...
+	if err := c.RunInContainer("chown", "-R", "root:root", dstFile); err != nil {
+		log.Errorf("failed to set ownership on %s! %v", dstFile, err)
+		return err
+	}
+
+	// ensure we don't fail if swap is enabled on the host
+	if err := c.RunInContainer("/bin/sh", "-c",
+		`echo "KUBELET_EXTRA_ARGS=--fail-swap-on=false" >> /etc/default/kubelet`,
+	); err != nil {
+		log.Errorf("failed to set kubelet fail-swap-on! %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// from k/k build/debs/kubelet.service
+var kubeletService = []byte(`
+[Unit]
+Description=kubelet: The Kubernetes Node Agent
+Documentation=http://kubernetes.io/docs/
+
+[Service]
+ExecStart=/usr/bin/kubelet
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+`)
+
+// from k/k build/debs/10-kubeadm.conf
+var kubeadmDropIn = []byte(`
+# Note: This dropin only works with kubeadm and kubelet v1.11+
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
+`)

--- a/kinder/pkg/build/alter/upgradeBits.go
+++ b/kinder/pkg/build/alter/upgradeBits.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubeadm/kinder/pkg/extract"
 )
 
-// upgradeBits implements Bits implements a bits that allows to add new upgrade binaries & images /kinder/upgrade folder into the node image;
+// upgradeBits Bits implements bits that allows to add Kubernetes binaries & images to the /kinder/upgrade folder into the node image;
 // those artifact will be used by the kinder do kubeadm-upgrade script
 type upgradeBits struct {
 	src string
@@ -50,7 +50,7 @@ func (b *upgradeBits) Get(c *bitsContext) error {
 
 	// Creates an extractor instance, that will read binaries & images required from upgrades from the src,
 	// where source can be one of version/build-label/folder containing the  binaries & images,
-	// and save it to the HostBitsPath/version
+	// and save it to the dst folder
 	e := extract.NewExtractor(
 		b.src, dst,
 		extract.WithVersionFolder(true),


### PR DESCRIPTION
This PR adds a new `--with-init-artifacts` flag to `kinder build node-variant` command

NB. this is a temporary replacement for `kind build node-image --type=tar` that seems blocked (see https://github.com/kubernetes-sigs/kind/pull/396)

/assign @neolit123

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews