### PR TITLE
Fix broken links to Kinder reference docs

### DIFF
--- a/kinder/doc/e2e-test.md
+++ b/kinder/doc/e2e-test.md
@@ -22,7 +22,7 @@ Main flags supported by the command are:
 - `--conformance` as a shortcut for instructing the ginkgo test suite run only conformance tests
 - `--parallel` as a shortcut for instructing the ginkgo to run test in parallel
 
-See [Kinder reference](doc/reference.md) for more options
+See [Kinder reference](reference.md) for more options
 
 ## E2E kubeadm
 
@@ -44,4 +44,4 @@ Main flags supported by the command are:
 - `--single-node` as a shortcut for instructing the ginkgo test suite to skip test labeled with [multi-node]
 - `--automatic-copy-certs` as a shortcut for instructing the ginkgo test suite to skip test labeled with [copy-certs]
 
-See [Kinder reference](doc/reference.md) for more options
+See [Kinder reference](reference.md) for more options

--- a/kinder/doc/prepare-for-tests.md
+++ b/kinder/doc/prepare-for-tests.md
@@ -67,7 +67,7 @@ Please note that `kinder build node-image-variant` accepts as input:
 
 It is also possible to get Kubernetes artifacts locally using `kinder get artifacts`.
 
-See [Kinder reference](doc/reference.md) for more detail.
+See [Kinder reference](reference.md) for more detail.
 
 ## Customize a node-image
 
@@ -110,4 +110,4 @@ Please note that `kinder build node-image-variant` accepts as input:
 
 It is also possible to get Kubernetes artifacts locally using `kinder get artifacts`.
 
-See [Kinder reference](doc/reference.md) for more detail.
+See [Kinder reference](reference.md) for more detail.

--- a/kinder/doc/test-XonY.md
+++ b/kinder/doc/test-XonY.md
@@ -20,7 +20,7 @@ kinder build node-image-variant --base-image kindest/node:vY --image kindest/nod
 ```
 
 > `kinder build node-image-variant` accepts in input a version, a release or ci build label,
-> a remote repository or a local folder. see [Kinder reference](doc/reference.md) for more info.
+> a remote repository or a local folder. see [Kinder reference](reference.md) for more info.
 
 See [Prepare for tests](prepare-for-tests.md) for more detail
 

--- a/kinder/doc/test-upgrades.md
+++ b/kinder/doc/test-upgrades.md
@@ -20,7 +20,7 @@ kinder build node-image-variant --base-image kindest/node:vX --image kindest/nod
 ```
 
 > `kinder build node-image-variant` accepts in input a version, a release or ci build label,
-> a remote repository or a local folder. see [Kinder reference](doc/reference.md) for more info.
+> a remote repository or a local folder. see [Kinder reference](reference.md) for more info.
 
 > vY artifacts will be saved in the `/kinder/upgrades/vy` folder; those binaries will be used
 > by the kinder `kubeadm-upgrade` action.


### PR DESCRIPTION
Several docs inside the `doc/` folder are using `doc/reference.md` leading in broken links