### PR TITLE
kinder: task ignoreError

### DIFF
--- a/kinder/ci/workflows/upgrade-stable-master.yaml
+++ b/kinder/ci/workflows/upgrade-stable-master.yaml
@@ -134,6 +134,10 @@ tasks:
     - "{{ .env.ARTIFACTS }}"
   force: true
   timeout: 5m
+  # kind export log is know to be flaky, so we are temporary ignoring errors in order
+  # to make the test pass in case everything else passed
+  # see https://github.com/kubernetes-sigs/kind/issues/456
+  ignoreError: true
 - name: reset
   description: |
     Exec kubeadm reset

--- a/kinder/pkg/test/workflow/taskCmdRunner.go
+++ b/kinder/pkg/test/workflow/taskCmdRunner.go
@@ -141,8 +141,8 @@ func (c *taskCmdRunner) Run(t *taskCmd, artifacts string, verbose bool) error {
 	// - the timeout is reached
 	select {
 	case err := <-result:
-		// if the command completed without errors, record the test case success and exits
-		if err == nil {
+		// if the command completed without an error or if we are ignoring errors, record the test case success and exit
+		if err == nil || t.IgnoreError {
 			// record test case timeout as success
 			return c.registerTestCase(t.Name,
 				withDuration(time.Since(start)),

--- a/kinder/pkg/test/workflow/workflow.go
+++ b/kinder/pkg/test/workflow/workflow.go
@@ -89,6 +89,9 @@ type Task struct {
 
 	// Timeout for the current task, by default
 	Timeout time.Duration
+
+	// IgnoreError sets a task to be recorded as successful even if it is actually failed
+	IgnoreError bool `yaml:"ignoreError"`
 }
 
 // NewWorkflow creates a new workflow as defined in a workflow file
@@ -178,6 +181,9 @@ func (w *Workflow) expandImports(file string) error {
 		}
 		if t.Timeout != 0 {
 			return errors.Errorf("invalid workflow file %s: task #%d - timeout setting can't be combined with import directive", file, i+1)
+		}
+		if t.IgnoreError != false {
+			return errors.Errorf("invalid workflow file %s: task #%d - ignoreError setting can't be combined with import directive", file, i+1)
 		}
 
 		// reads the Import file


### PR DESCRIPTION
This PR adds support for setting tasks to ignore errors

This allows to makes test pass if kind get logs flakes but everything else pass

/assign @neolit123

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews