### PR TITLE
OWNERS: remove redundant area/kubeadm label

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -19,8 +19,7 @@ reviewers:
 - neolit123
 - rosti
 - yagonobre
-- ereslibre 
+- ereslibre
 # Might want to add @xiangpengzhao, @stealthybox, @kargakis, @jamiehannaford, @krousey and/or @dmmcquay back in the future
-labels: 
-- area/kubeadm
+labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
The label is not needed for this repository as the
repository implies that this PR or ticket is already related
to kubeadm.

Having the label causes errors in the "owners-label" plugin:
fixes https://github.com/kubernetes/kubeadm/issues/1547
