### PR TITLE
kubeadm e2e test for HA

### DIFF
--- a/tests/e2e/kind/multi-cp/multi-cp.yaml
+++ b/tests/e2e/kind/multi-cp/multi-cp.yaml
@@ -1,0 +1,9 @@
+# a single control-plane cluster with 3 workers
+kind: Config
+apiVersion: kind.sigs.k8s.io/v1alpha2
+nodes:
+- role: external-load-balancer
+- role: control-plane
+  replicas: 2
+- role: worker
+  replicas: 3


### PR DESCRIPTION
This PR adds a config file for testing kubeadm HA when executing E2E test jobs implemented with kind (kubeadm regular test)

rif https://github.com/kubernetes/kubeadm/issues/1567

NB. In case I'm out of sync with other helping to this effort, feel free to close.

/kind test
/assign @neolit123
/cc @RA489 

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews