### PR TITLE
kinder make upgrade and skew e2e tests HA ready

### DIFF
--- a/kinder/ci/workflows/skew-1.14-on-1.13.yaml
+++ b/kinder/ci/workflows/skew-1.14-on-1.13.yaml
@@ -7,5 +7,6 @@ summary: |
 vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.14` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.13` }}"
+  controlPlaneNodes: 2
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-master-on-stable.yaml
+++ b/kinder/ci/workflows/skew-master-on-stable.yaml
@@ -7,14 +7,16 @@ summary: |
 vars:
   kubeadmVersion: "{{ resolve `ci/latest` }}"
   kubernetesVersion: "{{ resolve `release/stable` }}"
-  controlPlaneNodes: 1
+  controlPlaneNodes: 2
   workerNodes: 2
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-xony
 tasks:
 # Important! this worflow is using locally defined task instead of the shared skew-x-on-y-tasks.yaml
-# because e2e-kubeadm is executed (nb. e2e-kubeadm was heavily refactored in v1.15 cycle)
+# because:
+# - e2e-kubeadm is executed (nb. e2e-kubeadm was heavily refactored in v1.15 cycle)
+# - it uses the automatic copy certs feature, available in kubeadm since v1.14
 - name: pull-base-image
   description: |
     pulls kindest/base image with docker in docker and all the prerequisites necessary for running kind(er)
@@ -57,6 +59,7 @@ tasks:
     - do
     - kubeadm-init
     - --name={{ .vars.clusterName }}
+    - --automatic-copy-certs
   timeout: 5m
 - name: join
   description: |
@@ -66,6 +69,7 @@ tasks:
     - do
     - kubeadm-join
     - --name={{ .vars.clusterName }}
+    - --automatic-copy-certs
   timeout: 5m
 - name: cluster-info
   description: |

--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -15,7 +15,8 @@ vars:
   clusterName: kinder-xony
 tasks:
 # Important! this workflow differs from stable-on-master because
-# e2-kubeadm is not run (nb. e2e-kubeadm was heavily refactored in v1.15 cycle)
+# - e2-kubeadm is not run (nb. e2e-kubeadm was heavily refactored in v1.15 cycle)
+# - it does not use the automatic copy certs feature, available in kubeadm since v1.14 only
 - name: pull-base-image
   description: |
     pulls kindest/base image with docker in docker and all the prerequisites necessary for running kind(er)

--- a/kinder/ci/workflows/upgrade-1.13-1.14.yaml
+++ b/kinder/ci/workflows/upgrade-1.13-1.14.yaml
@@ -7,5 +7,6 @@ summary: |
 vars:
   initVersion: "{{ resolve `ci/latest-1.13` }}"
   upgradeVersion: "{{ resolve `release/latest-1.14` }}"
+  controlPlaneNodes: 2
 tasks:
 - import: upgrade-tasks.yaml

--- a/kinder/ci/workflows/upgrade-stable-master.yaml
+++ b/kinder/ci/workflows/upgrade-stable-master.yaml
@@ -7,14 +7,16 @@ summary: |
 vars:
   initVersion: "{{ resolve `release/stable` }}"
   upgradeVersion: "{{ resolve `ci/latest` }}"
-  controlPlaneNodes: 1
+  controlPlaneNodes: 2
   workerNodes: 2
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-upgrade
 tasks:
 # Important! this worflow is using locally defined task instead of the shared upgrade-task.yaml
-# because e2e-kubeadm is executed after the upgrade (nb. e2e-kubeadm was heavily refactored in v1.15 cycle)
+# because:
+# - e2e-kubeadm is executed after the upgrade (nb. e2e-kubeadm was heavily refactored in v1.15 cycle)
+# - it uses the automatic copy certs feature, available in kubeadm since v1.14
 - name: pull-base-image
   description: |
     pulls kindest/base image with docker in docker and all the prerequisites necessary for running kind(er)
@@ -58,6 +60,7 @@ tasks:
     - do
     - kubeadm-init
     - --name={{ .vars.clusterName }}
+    - --automatic-copy-certs
   timeout: 5m
 - name: join
   description: |
@@ -67,6 +70,7 @@ tasks:
     - do
     - kubeadm-join
     - --name={{ .vars.clusterName }}
+    - --automatic-copy-certs
   timeout: 5m
 - name: cluster-info-before
   description: |

--- a/kinder/ci/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-tasks.yaml
@@ -14,7 +14,8 @@ vars:
   clusterName: kinder-upgrade
 tasks:
 # Important! this workflow differs from upgrade-stable-master because
-# e2-kubeadm is not run (nb. e2e-kubeadm was heavily refactored in v1.15 cycle)
+# - e2-kubeadm is not run (nb. e2e-kubeadm was heavily refactored in v1.15 cycle)
+# - it does not use the automatic copy certs feature, available in kubeadm since v1.14 only
 - name: pull-base-image
   description: |
     pulls kindest/base image with docker in docker and all the prerequisites necessary for running kind(er)


### PR DESCRIPTION
This PR:
- change upgrade-stable-master job and upgrade-1.13-1.4 to test HA + automatic copy certificates
- change master-on-stable job and 1.14 on 1.13 to test HA + automatic copy certificates

rif https://github.com/kubernetes/kubeadm/issues/1567

NB. In case I'm out of sync with other helping to this effort, feel free to close.

/kind test
/assign @neolit123 

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews