### PR TITLE
make HA test create 3 control-plane nodes

### DIFF
--- a/kinder/ci/workflows/skew-1.14-on-1.13.yaml
+++ b/kinder/ci/workflows/skew-1.14-on-1.13.yaml
@@ -7,6 +7,6 @@ summary: |
 vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.14` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.13` }}"
-  controlPlaneNodes: 2
+  controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-master-on-stable.yaml
+++ b/kinder/ci/workflows/skew-master-on-stable.yaml
@@ -7,7 +7,7 @@ summary: |
 vars:
   kubeadmVersion: "{{ resolve `ci/latest` }}"
   kubernetesVersion: "{{ resolve `release/stable` }}"
-  controlPlaneNodes: 2
+  controlPlaneNodes: 3
   workerNodes: 2
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test

--- a/kinder/ci/workflows/upgrade-1.13-1.14.yaml
+++ b/kinder/ci/workflows/upgrade-1.13-1.14.yaml
@@ -7,6 +7,6 @@ summary: |
 vars:
   initVersion: "{{ resolve `ci/latest-1.13` }}"
   upgradeVersion: "{{ resolve `release/latest-1.14` }}"
-  controlPlaneNodes: 2
+  controlPlaneNodes: 3
 tasks:
 - import: upgrade-tasks.yaml

--- a/kinder/ci/workflows/upgrade-stable-master.yaml
+++ b/kinder/ci/workflows/upgrade-stable-master.yaml
@@ -7,7 +7,7 @@ summary: |
 vars:
   initVersion: "{{ resolve `release/stable` }}"
   upgradeVersion: "{{ resolve `ci/latest` }}"
-  controlPlaneNodes: 2
+  controlPlaneNodes: 3
   workerNodes: 2
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test


### PR DESCRIPTION
As per comment in https://github.com/kubernetes/kubeadm/pull/1580, make E2E jobs for HA create 3 control-plane nodes

/kind test
/assign @neolit123
