### PR TITLE
kinder: v1.15 CLI changes

### DIFF
--- a/kinder/pkg/actions/kubeadm-init.go
+++ b/kinder/pkg/actions/kubeadm-init.go
@@ -64,8 +64,13 @@ func runInit(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.ActionF
 			return errors.Wrapf(err, "--automatic-copy-certs can't be used")
 		}
 
+		// before v1.15, upload-certs require the experimental prefix
+		uploadCertsFlag := "--upload-certs"
+		if err := atLeastKubeadm(kn, "v1.15.0-0"); err != nil {
+			uploadCertsFlag = "--experimental-upload-certs"
+		}
 		initArgs = append(initArgs,
-			"--experimental-upload-certs",
+			uploadCertsFlag,
 			fmt.Sprintf("--certificate-key=%s", CertificateKey),
 		)
 	}
@@ -149,10 +154,15 @@ func runInitPhases(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.A
 			return errors.Wrapf(err, "--automatic-copy-certs can't be used")
 		}
 
+		uploadCertsFlag := "--upload-certs"
+		if err := atLeastKubeadm(kn, "v1.15.0-0"); err != nil {
+			uploadCertsFlag = "--experimental-upload-certs"
+		}
+
 		if err := kn.DebugCmd(
 			"==> kubeadm init phase upload-certs 🚀",
 			"kubeadm", "init", "phase", "upload-certs", "--config=/kind/kubeadm.conf",
-			"--experimental-upload-certs", fmt.Sprintf("--certificate-key=%s", CertificateKey),
+			uploadCertsFlag, fmt.Sprintf("--certificate-key=%s", CertificateKey),
 		); err != nil {
 			return err
 		}

--- a/kinder/pkg/actions/kubeadm-join.go
+++ b/kinder/pkg/actions/kubeadm-join.go
@@ -156,8 +156,14 @@ func runJoinControlPlane(kctx *kcluster.KContext, kn *kcluster.KNode, flags kclu
 		return err
 	}
 
+	// before v1.15, control-plane require the experimental prefix
+	controlPlaneFlag := "--control-plane"
+	if err := atLeastKubeadm(kn, "v1.15.0-0"); err != nil {
+		controlPlaneFlag = "--experimental-control-plane"
+	}
+
 	joinArgs := []string{
-		"join", joinAddress, "--experimental-control-plane", "--token", Token, "--discovery-token-unsafe-skip-ca-verification", "--ignore-preflight-errors=all",
+		"join", joinAddress, controlPlaneFlag, "--token", Token, "--discovery-token-unsafe-skip-ca-verification", "--ignore-preflight-errors=all",
 	}
 	if flags.CopyCerts {
 		joinArgs = append(joinArgs,
@@ -198,8 +204,14 @@ func runJoinControlPlanePhases(kctx *kcluster.KContext, kn *kcluster.KNode, flag
 		return err
 	}
 
+	// before v1.15, control-plane require the experimental prefix
+	controlPlaneFlag := "--control-plane"
+	if err := atLeastKubeadm(kn, "v1.15.0-0"); err != nil {
+		controlPlaneFlag = "--experimental-control-plane"
+	}
+
 	preflightArgs := []string{
-		"join", "phase", "preflight", joinAddress, "--experimental-control-plane", "--token", Token, "--discovery-token-unsafe-skip-ca-verification", "--ignore-preflight-errors=all",
+		"join", "phase", "preflight", joinAddress, controlPlaneFlag, "--token", Token, "--discovery-token-unsafe-skip-ca-verification", "--ignore-preflight-errors=all",
 	}
 	if flags.CopyCerts {
 		preflightArgs = append(preflightArgs,
@@ -214,7 +226,7 @@ func runJoinControlPlanePhases(kctx *kcluster.KContext, kn *kcluster.KNode, flag
 	}
 
 	prepareArgs := []string{
-		"join", "phase", "control-plane-prepare", "all", joinAddress, "--experimental-control-plane", "--discovery-token", Token, "--discovery-token-unsafe-skip-ca-verification",
+		"join", "phase", "control-plane-prepare", "all", joinAddress, controlPlaneFlag, "--discovery-token", Token, "--discovery-token-unsafe-skip-ca-verification",
 	}
 	if flags.CopyCerts {
 		prepareArgs = append(prepareArgs,
@@ -237,7 +249,7 @@ func runJoinControlPlanePhases(kctx *kcluster.KContext, kn *kcluster.KNode, flag
 
 	if err := kn.DebugCmd(
 		"==> kubeadm join phase control-plane-join all 🚀",
-		"kubeadm", "join", "phase", "control-plane-join", "all", "--experimental-control-plane",
+		"kubeadm", "join", "phase", "control-plane-join", "all", controlPlaneFlag,
 	); err != nil {
 		return err
 	}

--- a/kinder/pkg/actions/kubeadm-upgrade.go
+++ b/kinder/pkg/actions/kubeadm-upgrade.go
@@ -135,11 +135,21 @@ func runKubeadmUpgradeControlPlane(kctx *kcluster.KContext, kn *kcluster.KNode, 
 		return err
 	}
 
-	if err := kn.DebugCmd(
-		"==> kubeadm upgrade node experimental-control-plane 🚀",
-		"kubeadm", "upgrade", "node", "experimental-control-plane",
-	); err != nil {
-		return err
+	// starting from v1.15 there is a unique command for upgrading nodes (after kubeadm upgrade apply was executed on a first control-plane node)
+	if err := atLeastKubeadm(kn, "v1.15.0-0"); err == nil {
+		if err := kn.DebugCmd(
+			"==> kubeadm upgrade node 🚀",
+			"kubeadm", "upgrade", "node",
+		); err != nil {
+			return err
+		}
+	} else {
+		if err := kn.DebugCmd(
+			"==> kubeadm upgrade node experimental-control-plane 🚀",
+			"kubeadm", "upgrade", "node", "experimental-control-plane",
+		); err != nil {
+			return err
+		}
 	}
 
 	if err := waitControlPlaneUpgraded(kctx, kn, flags); err != nil {
@@ -157,11 +167,21 @@ func runKubeadmUpgradeWorkers(kctx *kcluster.KContext, kn *kcluster.KNode, flags
 		return err
 	}
 
-	if err := kn.DebugCmd(
-		"==> kubeadm upgrade node config 🚀",
-		"kubeadm", "upgrade", "node", "config", "--kubelet-version", fmt.Sprintf("v%s", flags.UpgradeVersion),
-	); err != nil {
-		return err
+	// starting from v1.15 there is a unique command for upgrading nodes (after kubeadm upgrade apply was executed on a first control-plane node)
+	if err := atLeastKubeadm(kn, "v1.15.0-0"); err == nil {
+		if err := kn.DebugCmd(
+			"==> kubeadm upgrade node 🚀",
+			"kubeadm", "upgrade", "node",
+		); err != nil {
+			return err
+		}
+	} else {
+		if err := kn.DebugCmd(
+			"==> kubeadm upgrade node config 🚀",
+			"kubeadm", "upgrade", "node", "config", "--kubelet-version", fmt.Sprintf("v%s", flags.UpgradeVersion),
+		); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Implements the first set of changes for considering CLI changes introduced in v1.15
Nb. change for `--certificate-key` that can't anymore be combined with `--config` is not included

/kind feature
/assign @neolit123