### PR TITLE
Add workflow for HA cert copy with external etcd

### DIFF
--- a/kinder/ci/kubeadm-periodic.tests.md
+++ b/kinder/ci/kubeadm-periodic.tests.md
@@ -66,3 +66,13 @@ X on Y tests are meant to verify the proper functioning of kubeadm version X wit
 | current -2/minor<br />(ci/latest-1.12) | V1.12.9-alpha... | current -3/minor<br />(ci/latest-1.11) | V1.11.10-alpha... |
 
 TODO: currently tests are not consistent with regards to the selection of from/to versions (some ci on stable, others ci on ci). Define if/how to rationalize
+
+### External etcd with secret copy tests
+
+Kubeadm external etcd tests are meant to create a cluster with `kubeadm init`, `kubeadm join` using an external etcd cluster, using
+kubeadm secret copy feature among control planes and then verify the cluster conformance.
+
+| Version          | e.g.   |                                                              |
+| ---------------- | ------ | ------------------------------------------------------------ |
+| master<br />(master branch) | v1.15.0-alpha...  | The release under current development |
+| current<br />(release-1.14 branch) | v1.14.2-alpha...  | Current GA release |

--- a/kinder/ci/workflows/ha-cert-copy-with-external-etcd-1.14.yaml
+++ b/kinder/ci/workflows/ha-cert-copy-with-external-etcd-1.14.yaml
@@ -1,0 +1,11 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of deploying an HA
+  cluster with secret copy using an external etcd cluster
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-all#kubeadm-kinder
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.14` }}"
+tasks:
+- import: ha-cert-copy-with-external-etcd.yaml

--- a/kinder/ci/workflows/ha-cert-copy-with-external-etcd-master.yaml
+++ b/kinder/ci/workflows/ha-cert-copy-with-external-etcd-master.yaml
@@ -1,0 +1,11 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of deploying an HA
+  cluster with secret copy using an external etcd cluster
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-all#kubeadm-kinder
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest` }}"
+tasks:
+- import: ha-cert-copy-with-external-etcd.yaml

--- a/kinder/ci/workflows/ha-cert-copy-with-external-etcd.yaml
+++ b/kinder/ci/workflows/ha-cert-copy-with-external-etcd.yaml
@@ -1,0 +1,118 @@
+version: 1
+summary: |
+  This workflow implements a sequence of tasks used for creating a HA
+  cluster with an external etcd cluster.
+vars:
+  kubernetesVersion: v1.14.1
+  baseImage: kindest/base:v20190403-1ebf15f
+  image: kindest/node:test
+  clusterName: kinder-ha-external-etcd
+tasks:
+- name: pull-base-image
+  description: |
+    pulls kindest/base image with docker in docker and all the prerequisites necessary for running kind(er)
+  cmd: docker
+  args:
+    - pull
+    - "{{ .vars.baseImage }}"
+- name: add-kubernetes-versions
+  description: |
+    creates a node-image-variant by adding Kubernetes version "kubernetesVersion"
+    to be used when executing "kinder do kubeadm-init"
+  cmd: kinder
+  args:
+    - build
+    - node-image-variant
+    - --base-image={{ .vars.baseImage }}
+    - --image={{ .vars.image }}
+    - --with-init-artifacts={{ .vars.kubernetesVersion }}
+    - --loglevel=debug
+  timeout: 10m
+- name: create-cluster
+  description: |
+    create a set of nodes ready for hosting the Kubernetes cluster
+  cmd: kinder
+  args:
+    - create
+    - cluster
+    - --name={{ .vars.clusterName }}
+    - --image={{ .vars.image }}
+    - --control-plane-nodes=3
+    - --worker-nodes=2
+    - --external-etcd
+  timeout: 5m
+- name: init
+  description: |
+    Initializes the Kubernetes cluster with version "kubernetesVersion"
+    by starting the bootstrap control-plane node
+  cmd: kinder
+  args:
+    - do
+    - kubeadm-init
+    - --automatic-copy-certs
+    - --name={{ .vars.clusterName }}
+  timeout: 5m
+- name: join
+  description: |
+    Join the other nodes to the Kubernetes cluster
+  cmd: kinder
+  args:
+    - do
+    - kubeadm-join
+    - --automatic-copy-certs
+    - --name={{ .vars.clusterName }}
+  timeout: 5m
+- name: e2e-kubeadm
+  description: |
+    Runs kubeadm e2e tests
+  cmd: kinder
+  args:
+    - test
+    - e2e-kubeadm
+    - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-kubeadm-after-cluster-creation
+    - --name={{ .vars.clusterName }}
+- name: e2e
+  description: |
+    Runs e2e tests
+  cmd: kinder
+  args:
+    - test
+    - e2e
+    - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-after-cluster-creation
+    - --parallel
+    - --name={{ .vars.clusterName }}
+  timeout: 25m
+- name: get-logs
+  description: |
+    Collects all the test logs
+  cmd: kinder
+  args:
+    - export
+    - logs
+    - --loglevel=debug
+    - --name={{ .vars.clusterName }}
+    - "{{ .env.ARTIFACTS }}"
+  force: true
+  timeout: 5m
+  # kind export log is know to be flaky, so we are temporary ignoring errors in order
+  # to make the test pass in case everything else passed
+  # see https://github.com/kubernetes-sigs/kind/issues/456
+  ignoreError: true
+- name: reset
+  description: |
+    Exec kubeadm reset
+  cmd: kinder
+  args:
+    - do
+    - kubeadm-reset
+    - --name={{ .vars.clusterName }}
+  force: true
+- name: delete
+  description: |
+    Deletes the cluster
+  cmd: kinder
+  args:
+    - delete
+    - cluster
+    - --name={{ .vars.clusterName }}
+  force: true


### PR DESCRIPTION
Create two new workflows to deploy an HA cluster with secret copy and external etcd.

/assign @fabriziopandini

`test-infra` related change: https://github.com/kubernetes/test-infra/compare/master...ereslibre:ha-kubeadm-kinder, will submit a PR there when this one merges.