### PR TITLE
kinder: v1beta2 workaround

### DIFF
--- a/kinder/cmd/kinder/create/cluster/createcluster_test.go
+++ b/kinder/cmd/kinder/create/cluster/createcluster_test.go
@@ -37,34 +37,34 @@ func TestNewConfig(t *testing.T) {
 			TestName:             "Default",
 			initVersion:          "v1.15.0",
 			controlPlanes:        1,
-			expectedPatchVersion: "kubeadm.k8s.io/v1beta2",
+			expectedPatchVersion: "kubeadm.k8s.io/v1beta1", // kind does not support v1Beta2 config yet
 		},
 		{
 			TestName:             "More workers",
 			initVersion:          "v1.15.0",
 			controlPlanes:        1,
 			workers:              2,
-			expectedPatchVersion: "kubeadm.k8s.io/v1beta2",
+			expectedPatchVersion: "kubeadm.k8s.io/v1beta1", // kind does not support v1Beta2 config yet
 		},
 		{
 			TestName:             "More control-planes",
 			initVersion:          "v1.15.0",
 			controlPlanes:        2,
-			expectedPatchVersion: "kubeadm.k8s.io/v1beta2",
+			expectedPatchVersion: "kubeadm.k8s.io/v1beta1", // kind does not support v1Beta2 config yet
 		},
 		{
 			TestName:             "Kube dns",
 			initVersion:          "v1.15.0",
 			controlPlanes:        1,
 			kubeDNS:              true,
-			expectedPatchVersion: "kubeadm.k8s.io/v1beta2",
+			expectedPatchVersion: "kubeadm.k8s.io/v1beta1", // kind does not support v1Beta2 config yet
 		},
 		{
 			TestName:             "External etcd",
 			initVersion:          "v1.15.0",
 			controlPlanes:        1,
 			externalEtcdIP:       "https://1.2.3.4:5678",
-			expectedPatchVersion: "kubeadm.k8s.io/v1beta2",
+			expectedPatchVersion: "kubeadm.k8s.io/v1beta1", // kind does not support v1Beta2 config yet
 		},
 		{
 			TestName:             "initVersion v1.14",

--- a/kinder/pkg/cluster/kubeadmconfig.go
+++ b/kinder/pkg/cluster/kubeadmconfig.go
@@ -70,7 +70,8 @@ func getKubeadmConfigVersion(initVersion string) (string, error) {
 		return "v1beta1", nil
 	}
 
-	return "v1beta2", nil
+	// kind does not support v1Beta2 config yet
+	return "v1beta1", nil
 }
 
 const kubeDNSPatchv1beta2 = `apiVersion: kubeadm.k8s.io/v1beta2


### PR DESCRIPTION
This PR implements a workaround for using kinder to test v1beta2 kubeadm config version, even if kind does not support this yet.

It also adapts the init workflow to pass the `certificate-key` using the config file instead of the flag

/kind feature
/assign @neolit123
/assign @rosti 