### PR TITLE
Rename `ha-cert-copy-with-external-etcd` to `external-etcd`

### DIFF
--- a/kinder/ci/kubeadm-periodic.tests.md
+++ b/kinder/ci/kubeadm-periodic.tests.md
@@ -74,5 +74,5 @@ kubeadm secret copy feature among control planes and then verify the cluster con
 
 | Version          | e.g.   |                                                              |
 | ---------------- | ------ | ------------------------------------------------------------ |
-| master<br />(master branch) | v1.15.0-alpha...  | The release under current development |
-| current<br />(release-1.14 branch) | v1.14.2-alpha...  | Current GA release |
+| master<br />(ci/latest) | v1.15.0-alpha...  | The release under current development |
+| current<br />(ci/latest-1.14) | v1.14.2-alpha...  | Current GA release |

--- a/kinder/ci/workflows/external-etcd-1.14.yaml
+++ b/kinder/ci/workflows/external-etcd-1.14.yaml
@@ -6,6 +6,6 @@ summary: |
   config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
   config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
 vars:
-  kubernetesVersion: "{{ resolve `ci/latest` }}"
+  kubernetesVersion: "{{ resolve `ci/latest-1.14` }}"
 tasks:
-- import: ha-cert-copy-with-external-etcd.yaml
+- import: external-etcd.yaml

--- a/kinder/ci/workflows/external-etcd-master.yaml
+++ b/kinder/ci/workflows/external-etcd-master.yaml
@@ -6,6 +6,6 @@ summary: |
   config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
   config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
 vars:
-  kubernetesVersion: "{{ resolve `ci/latest-1.14` }}"
+  kubernetesVersion: "{{ resolve `ci/latest` }}"
 tasks:
-- import: ha-cert-copy-with-external-etcd.yaml
+- import: external-etcd.yaml

--- a/kinder/ci/workflows/external-etcd.yaml
+++ b/kinder/ci/workflows/external-etcd.yaml
@@ -6,7 +6,7 @@ vars:
   kubernetesVersion: v1.14.1
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
-  clusterName: kinder-ha-external-etcd
+  clusterName: kinder-external-etcd
 tasks:
 - name: pull-base-image
   description: |


### PR DESCRIPTION
Also, improve the kubeadm periodic tests documentation to explicitly
mention that those jobs use `ci/latest` and `ci/latest-1.14`.