### PR TITLE
kinder: obtain the etcd version from the node-image

### DIFF
--- a/kinder/cmd/kinder/create/cluster/createcluster.go
+++ b/kinder/cmd/kinder/create/cluster/createcluster.go
@@ -120,7 +120,7 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 		fmt.Printf("Creating external etcd for the cluster %q ...\n", flags.Name)
 
 		var err error
-		externalEtcdIP, err = kcluster.CreateExternalEtcd(flags.Name)
+		externalEtcdIP, err = kcluster.CreateExternalEtcd(flags.Name, flags.ImageName)
 		if err != nil {
 			return errors.Wrap(err, "failed to create cluster")
 		}


### PR DESCRIPTION
When an external etcd node is created, ideally it needs the
etcd version that kubeadm "ships".

To be able to obtain the etcd version (image tag):
- Create a temporary node-image
- Exec "kubeadm config image list | grep etcd" to obtain etcd image:tag
- Remove the temporary node-image
- Pre-pull the etcd image:tag if needed.

should fix failing jobs:
https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-etcd-master
and
https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-etcd-1.14

```
Creating external etcd for the cluster "kinder-external-etcd" ...
Error: failed to create cluster: failed to create external etcd container: failed to get container id, output did not match: [Unable to find image 'k8s.gcr.io/etcd:3.2.24' locally 3.2.24: Pulling from etcd 8c5a7da1afbc: Pulling fs layer 0d363128e48e: Pulling fs layer 1ba5e77f0f6e: Pulling fs layer 8c5a7da1afbc: Verifying Checksum 8c5a7da1afbc: Download complete 8c5a7da1afbc: Pull complete 1ba5e77f0f6e: Verifying Checksum 1ba5e77f0f6e: Download complete 0d363128e48e: Verifying Checksum 0d363128e48e: Download complete 0d363128e48e: Pull complete 1ba5e77f0f6e: Pull complete Digest: sha256:905d7ca17fd02bc24c0eba9a062753aba15db3e31422390bc3238eb762339b20 Status: Downloaded newer image for k8s.gcr.io/etcd:3.2.24 391871454e64bc7b4fd9f2fbdbb1ec89ff44dc074b9985209c3a65a4de3ed774]
```

with this patch it should run the etcd container with the image that was pre-pulled during build and the one kubeadm uses. however, if the kubeadm binary was modified it will pre-pull the etcd image that the kubeadm "ships".
