### PR TITLE
kinder: update calico to the latest version 3.8

### DIFF
--- a/kinder/pkg/actions/util.go
+++ b/kinder/pkg/actions/util.go
@@ -61,7 +61,7 @@ func postInit(kctx *kcluster.KContext, kn *kcluster.KNode, flags kcluster.Action
 	if err := kn.DebugCmd(
 		"==> install cni 🗻",
 		"/bin/sh", "-c", //use shell to get $(...) resolved into the container
-		"kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f https://docs.projectcalico.org/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml",
+		"kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml",
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
This change is required since the 3.8 manifest moves to using
apps/v1 instead of extensions/v1beta1 for types like DaemonSet
and Deployment.

See PR 70672 of k/k.

failing tests:
https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-etcd-master
