### PR TITLE
kinder: avoid polution of the output of "kubeadm config images list"

### DIFF
--- a/kinder/ci/workflows/external-etcd.yaml
+++ b/kinder/ci/workflows/external-etcd.yaml
@@ -40,6 +40,7 @@ tasks:
     - --control-plane-nodes=3
     - --worker-nodes=2
     - --external-etcd
+    - --loglevel=debug
   timeout: 5m
 - name: init
   description: |
@@ -51,6 +52,7 @@ tasks:
     - kubeadm-init
     - --automatic-copy-certs
     - --name={{ .vars.clusterName }}
+    - --loglevel=debug
   timeout: 5m
 - name: join
   description: |
@@ -61,6 +63,7 @@ tasks:
     - kubeadm-join
     - --automatic-copy-certs
     - --name={{ .vars.clusterName }}
+    - --loglevel=debug
   timeout: 5m
 - name: e2e-kubeadm
   description: |
@@ -71,6 +74,7 @@ tasks:
     - e2e-kubeadm
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-kubeadm-after-cluster-creation
     - --name={{ .vars.clusterName }}
+    - --loglevel=debug
 - name: e2e
   description: |
     Runs e2e tests
@@ -81,6 +85,7 @@ tasks:
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-after-cluster-creation
     - --parallel
     - --name={{ .vars.clusterName }}
+    - --loglevel=debug
   timeout: 25m
 - name: get-logs
   description: |
@@ -106,6 +111,7 @@ tasks:
     - do
     - kubeadm-reset
     - --name={{ .vars.clusterName }}
+    - --loglevel=debug
   force: true
 - name: delete
   description: |
@@ -115,4 +121,5 @@ tasks:
     - delete
     - cluster
     - --name={{ .vars.clusterName }}
+    - --loglevel=debug
   force: true

--- a/kinder/pkg/cluster/etcd.go
+++ b/kinder/pkg/cluster/etcd.go
@@ -63,7 +63,7 @@ func CreateExternalEtcd(name, nodeImage string) (ip string, err error) {
 	}
 	var etcdVersionBuf bytes.Buffer
 	cmder := docker.ContainerCmder(containerName)
-	cmd := cmder.Command("/bin/sh", "-c", "kubeadm config images list | grep etcd")
+	cmd := cmder.Command("/bin/sh", "-c", "kubeadm config images list 2> /dev/null | grep etcd")
 	cmd.SetStdout(&etcdVersionBuf)
 	if err := cmd.Run(); err != nil {
 		return "", errors.Wrap(err, "failed to get etcd version from the temporary node container")


### PR DESCRIPTION
In etcd.go when we try to get the propper version of etcd
to use from "kubeadm config images list", if the version
of kubeadm is much older than "stable-1" (which is the default label
in kubeadm), the ouput shows a warning to stderr e.g.:

```
  I0626 02:54:47.931193    3673 version.go:240] remote version
  is much newer: v1.15.0; falling back to: stable-1.14
```

For some reason this output becomes part of the "etcdVersionBuf"
which is supposed to only contain stdout (cmd.SetStdout(&etcdVersionBuf)).

Omit this ouput by piping stderr to /dev/null and only
catch the etcd image string - e.g.:

```
  k8s.gcr.io/etcd:3.3.10
```

Once kubeadm supports machine readable output we can parse
this output properly without workarounds.

-----
fixes failures for the external etcd 1.14 test:
https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-etcd-1.14

second commit enables debug output for the kinder external etcd worfkflows.

/assign @ereslibre 
cc @fabriziopandini 
/kind failing-test
/priority important-soon
