### PR TITLE
add -v flag to kinder do command

### DIFF
--- a/kinder/cmd/kinder/do/do.go
+++ b/kinder/cmd/kinder/do/do.go
@@ -37,6 +37,7 @@ type flagpole struct {
 	KubeDNS            bool
 	OnlyNode           string
 	DryRun             bool
+	VLevel             int
 	Wait               time.Duration
 }
 
@@ -93,6 +94,11 @@ func NewCommand() *cobra.Command {
 		"wait", time.Duration(5*time.Minute),
 		"Wait for cluster state to converge after action",
 	)
+	cmd.Flags().IntVarP(
+		&flags.VLevel,
+		"kubeadm-verbosity", "v", 0,
+		"Number for the log level verbosity for the kubeadm commands",
+	)
 	return cmd
 }
 
@@ -132,6 +138,7 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) (err error) {
 		actions.KubeDNS(flags.KubeDNS),
 		actions.Wait(flags.Wait),
 		actions.UpgradeVersion(upgradeVersion),
+		actions.VLevel(flags.VLevel),
 	)
 	if err != nil {
 		return errors.Wrapf(err, "failed to exec action %s", action)

--- a/kinder/pkg/cluster/manager/actions/actions.go
+++ b/kinder/pkg/cluster/manager/actions/actions.go
@@ -44,16 +44,16 @@ var actionRegistry = map[string]func(*status.Cluster, *RunOptions) error{
 		return KubeadmConfig(c, flags.kubeDNS, flags.automaticCopyCerts)
 	},
 	"kubeadm-init": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmInit(c, flags.usePhases, flags.automaticCopyCerts, flags.wait)
+		return KubeadmInit(c, flags.usePhases, flags.automaticCopyCerts, flags.wait, flags.vLevel)
 	},
 	"kubeadm-join": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmJoin(c, flags.usePhases, flags.automaticCopyCerts, flags.wait)
+		return KubeadmJoin(c, flags.usePhases, flags.automaticCopyCerts, flags.wait, flags.vLevel)
 	},
 	"kubeadm-upgrade": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmUpgrade(c, flags.upgradeVersion, flags.wait)
+		return KubeadmUpgrade(c, flags.upgradeVersion, flags.wait, flags.vLevel)
 	},
 	"kubeadm-reset": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmReset(c)
+		return KubeadmReset(c, flags.vLevel)
 	},
 	"copy-certs": func(c *status.Cluster, flags *RunOptions) error {
 		return CopyCertificates(c)
@@ -116,6 +116,13 @@ func UpgradeVersion(upgradeVersion *K8sVersion.Version) Option {
 	}
 }
 
+// VLevel option sets the number for the log level verbosity for the kubeadm commands
+func VLevel(vLevel int) Option {
+	return func(r *RunOptions) {
+		r.vLevel = vLevel
+	}
+}
+
 // RunOptions holds options supplied to actions.Run
 type RunOptions struct {
 	kubeDNS            bool
@@ -123,6 +130,7 @@ type RunOptions struct {
 	automaticCopyCerts bool
 	wait               time.Duration
 	upgradeVersion     *K8sVersion.Version
+	vLevel             int
 }
 
 // Run executes one action

--- a/kinder/pkg/cluster/manager/actions/kubeadm-reset.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-reset.go
@@ -17,15 +17,17 @@ limitations under the License.
 package actions
 
 import (
+	"fmt"
+
 	"k8s.io/kubeadm/kinder/pkg/cluster/status"
 )
 
 // KubeadmReset executes the kubeadm reset workflow
-func KubeadmReset(c *status.Cluster) error {
+func KubeadmReset(c *status.Cluster, vLevel int) error {
 	//TODO: implements kubeadm reset with phases
 	for _, n := range c.K8sNodes() {
 		if err := n.Command(
-			"kubeadm", "reset", "--force",
+			"kubeadm", "reset", "--force", fmt.Sprintf("--v=%d", vLevel),
 		).RunWithEcho(); err != nil {
 			return err
 		}

--- a/kinder/pkg/cluster/status/node.go
+++ b/kinder/pkg/cluster/status/node.go
@@ -218,7 +218,7 @@ func (n *Node) EtcdImage() (string, error) {
 		return n.etcdImage, nil
 	}
 
-	kubeadmVersion, err := n.KubeVersion()
+	kubeVersion, err := n.KubeVersion()
 	if err != nil {
 		return "", err
 	}
@@ -226,7 +226,7 @@ func (n *Node) EtcdImage() (string, error) {
 	lines, err := cmd.NewProxyCmd(
 		n.Name(),
 		"/bin/sh", "-c",
-		fmt.Sprintf("kubeadm config images list --kubernetes-version=%s 2> /dev/null | grep etcd", kubeadmVersion),
+		fmt.Sprintf("kubeadm config images list --kubernetes-version=%s 2> /dev/null | grep etcd", kubeVersion),
 	).Silent().RunAndCapture()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get the etcd image")


### PR DESCRIPTION
This PR adds a `-v` flag to the `kinder do` command; this flag is forwarded to all the kubeadm command thus allowing to increase the verbosity of logs for E2E tests 
/assign @neolit123 