### PR TITLE
Fix image preload

### DIFF
--- a/kinder/pkg/build/bits/binaryBits.go
+++ b/kinder/pkg/build/bits/binaryBits.go
@@ -42,7 +42,7 @@ func NewBinaryBits(src, binaryName string) Installer {
 }
 
 // Get implements Installer.Get
-func (b *binaryBits) Prepare(c *BuildContext) error {
+func (b *binaryBits) Prepare(c *BuildContext) (map[string]string, error) {
 	// Creates an extractor instance, that will read the binary bit from the src,
 	// where source can be one of version/build-label/file or folder containing the binary,
 	// and save it to the HostBitsPath
@@ -53,8 +53,7 @@ func (b *binaryBits) Prepare(c *BuildContext) error {
 	)
 
 	// Extracts the binary bit
-	_, err := e.Extract()
-	return err
+	return e.Extract()
 }
 
 // Install implements bits.Install

--- a/kinder/pkg/build/bits/initBits.go
+++ b/kinder/pkg/build/bits/initBits.go
@@ -43,11 +43,11 @@ func NewInitBits(arg string) Installer {
 }
 
 // Get implements Installer.Get
-func (b *initBits) Prepare(c *BuildContext) error {
+func (b *initBits) Prepare(c *BuildContext) (map[string]string, error) {
 	// ensure the dest path exists on host/inside the HostBitsPath
 	dst := filepath.Join(c.HostBitsPath(), "init")
 	if err := os.Mkdir(dst, 0777); err != nil {
-		return errors.Wrap(err, "failed to make bits dir")
+		return nil, errors.Wrap(err, "failed to make bits dir")
 	}
 
 	// Creates an extractor instance, that will read binaries & images required for init from the src,
@@ -58,9 +58,7 @@ func (b *initBits) Prepare(c *BuildContext) error {
 	)
 
 	// Extracts the binaries & images
-	_, err := e.Extract()
-
-	return err
+	return e.Extract()
 }
 
 // Install implements Installer.Install

--- a/kinder/pkg/build/bits/installer.go
+++ b/kinder/pkg/build/bits/installer.go
@@ -28,7 +28,7 @@ import (
 // Installer interface defines the behaviour of a type in charge of installing a specific set of bits (files/artifacts)
 type Installer interface {
 	// Prepare a set of bits into the temporary folder on the host machine
-	Prepare(*BuildContext) error
+	Prepare(*BuildContext) (map[string]string, error)
 	// Install should install (deploy) the bits on the image being altered
 	Install(*BuildContext) error
 }

--- a/kinder/pkg/build/bits/upgradeBits.go
+++ b/kinder/pkg/build/bits/upgradeBits.go
@@ -42,11 +42,11 @@ func NewUpgradeBits(arg string) Installer {
 }
 
 // Get implements bits.Get
-func (b *upgradeBits) Prepare(c *BuildContext) error {
+func (b *upgradeBits) Prepare(c *BuildContext) (map[string]string, error) {
 	// ensure the dest path exists on host/inside the HostBitsPath
 	dst := filepath.Join(c.HostBitsPath(), "upgrade")
 	if err := os.Mkdir(dst, 0777); err != nil {
-		return errors.Wrap(err, "failed to make bits dir")
+		return nil, errors.Wrap(err, "failed to make bits dir")
 	}
 
 	// Creates an extractor instance, that will read binaries & images required from upgrades from the src,
@@ -58,8 +58,7 @@ func (b *upgradeBits) Prepare(c *BuildContext) error {
 	)
 
 	// Extracts the binary bit
-	_, err := e.Extract()
-	return err
+	return e.Extract()
 }
 
 // Install implements bits.Install

--- a/kinder/pkg/cluster/manager/actions/images.go
+++ b/kinder/pkg/cluster/manager/actions/images.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"k8s.io/kubeadm/kinder/pkg/cluster/status"
+	"k8s.io/kubeadm/kinder/pkg/cri"
+)
+
+// checkImagesForVersion pre-loaded images available on the node (this will report missing images, if any)
+func checkImagesForVersion(n *status.Node, version string) error {
+	n.Infof("Checking pre-loaded images")
+
+	// gets the list of images kubeadm is going to use
+	expected, err := n.Command(
+		"kubeadm", "config", "images", "list", fmt.Sprintf("--kubernetes-version=%s", version),
+	).Silent().RunAndCapture()
+	if err != nil {
+		return errors.Wrapf(err, "failed to read expected images for version %s from %s", version, n.Name())
+	}
+	log.Debugf("List of images kubeadm is going to use %s\n", expected)
+
+	// gets the list of images already pre-loaded in the node
+	nodeCRI, err := n.CRI()
+	if err != nil {
+		return err
+	}
+
+	actionHelper, err := cri.NewActionHelper(nodeCRI)
+	if err != nil {
+		return err
+	}
+
+	current, err := actionHelper.GetImages(n)
+	if err != nil {
+		return err
+	}
+	log.Debugf("List of images already pre-loaded in the node %s\n", current)
+
+	// Compare expected and current image and report result
+	var currentMap = map[string]string{}
+	for _, c := range current {
+		currentMap[c] = c
+	}
+
+	var missing = []string{}
+	for _, e := range expected {
+		if _, ok := currentMap[e]; ok {
+			continue
+		}
+
+		missing = append(missing, e)
+	}
+
+	if len(missing) > 0 {
+		fmt.Printf("Some of the required images are not pre-loaded into the container runtime:\n%s\n", strings.Join(missing, "\n"))
+		return nil
+	}
+
+	fmt.Println("All the requested images are already pre-loaded into the container runtime")
+	return nil
+}

--- a/kinder/pkg/cluster/manager/actions/kubeadm-init.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-init.go
@@ -42,6 +42,16 @@ func KubeadmInit(c *status.Cluster, usePhases, automaticCopyCerts bool, wait tim
 		return errors.Wrapf(err, "--automatic-copy-certs can't be used with kubeadm older than v1.14")
 	}
 
+	// checks pre-loaded images available on the node (this will report missing images, if any)
+	kubeVersion, err := cp1.KubeVersion()
+	if err != nil {
+		return err
+	}
+
+	if err := checkImagesForVersion(cp1, kubeVersion); err != nil {
+		return err
+	}
+
 	// execs the kubeadm init workflow
 	if usePhases {
 		err = kubeadmInitWithPhases(cp1, automaticCopyCerts, vLevel)

--- a/kinder/pkg/cluster/manager/actions/kubeadm-join.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-join.go
@@ -53,6 +53,16 @@ func joinControlPlanes(c *status.Cluster, usePhases, automaticCopyCerts bool, wa
 			}
 		}
 
+		// checks pre-loaded images available on the node (this will report missing images, if any)
+		kubeVersion, err := cp2.KubeVersion()
+		if err != nil {
+			return err
+		}
+
+		if err := checkImagesForVersion(cp2, kubeVersion); err != nil {
+			return err
+		}
+
 		// executes the kubeadm join control-plane workflow
 		if usePhases {
 			err = kubeadmJoinControlPlaneWithPhases(cp2, automaticCopyCerts, vLevel)
@@ -178,6 +188,16 @@ func joinWorkers(c *status.Cluster, usePhases bool, wait time.Duration, vLevel i
 	for _, w := range c.Workers() {
 		if usePhases && !w.MustKubeadmVersion().AtLeast(constants.V1_14) {
 			return errors.New("--automatic-copy-certs can't be used with kubeadm older than v1.14")
+		}
+
+		// checks pre-loaded images available on the node (this will report missing images, if any)
+		kubeVersion, err := w.KubeVersion()
+		if err != nil {
+			return err
+		}
+
+		if err := checkImagesForVersion(w, kubeVersion); err != nil {
+			return err
 		}
 
 		// executes the kubeadm join workflow

--- a/kinder/pkg/cluster/manager/actions/kubeadm-upgrade.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-upgrade.go
@@ -91,6 +91,12 @@ func preloadUpgradeImages(c *status.Cluster, upgradeVersion *K8sVersion.Version)
 			fmt.Printf("error PreLoadUpgradeImages: %v", err)
 			continue
 		}
+
+		// checks pre-loaded images available on the node (this will report missing images, if any)
+		if err := checkImagesForVersion(n, upgradeVersion.String()); err != nil {
+			fmt.Printf("error ReportImages: %v", err)
+			continue
+		}
 	}
 }
 

--- a/kinder/pkg/cri/actionhelper.go
+++ b/kinder/pkg/cri/actionhelper.go
@@ -46,3 +46,14 @@ func (h *ActionHelper) PreLoadUpgradeImages(n *status.Node, srcFolder string) er
 	}
 	return errors.Errorf("unknown cri: %s", h.cri)
 }
+
+// GetImages prints the images available in the node
+func (h *ActionHelper) GetImages(n *status.Node) ([]string, error) {
+	switch h.cri {
+	case status.ContainerdRuntime:
+		return containerd.GetImages(n)
+	case status.DockerRuntime:
+		return docker.GetImages(n)
+	}
+	return nil, errors.Errorf("unknown cri: %s", h.cri)
+}

--- a/kinder/pkg/extract/extract.go
+++ b/kinder/pkg/extract/extract.go
@@ -53,7 +53,9 @@ const (
 
 var (
 	allKubernetesBinaries = []string{kubeletBinary, kubectlBinary, kubeadmBinary}
-	allKubernetesImages   = []string{"kube-apiserver.tar", "kube-controller-manager.tar", "kube-scheduler.tar", "kube-proxy.tar"}
+
+	// AllKubernetesImages defines of image tarballs included in a K8s release
+	AllKubernetesImages = []string{"kube-apiserver.tar", "kube-controller-manager.tar", "kube-scheduler.tar", "kube-proxy.tar"}
 
 	// AllImagesPattern defines a pattern for searching all the images in a folder
 	AllImagesPattern = []string{"*.tar"}
@@ -135,7 +137,7 @@ func OnlyKubernetesBinaries(onlyBinaries bool) Option {
 func OnlyKubernetesImages(onlyImages bool) Option {
 	return func(b *Extractor) {
 		if onlyImages {
-			b.files = allKubernetesImages
+			b.files = AllKubernetesImages
 			// disable addVersionFileToDst when we are reading only a subset of files
 			b.addVersionFileToDst = false
 		}
@@ -174,7 +176,7 @@ type Extractor struct {
 func NewExtractor(src, dst string, options ...Option) (extractor *Extractor) {
 	extractor = &Extractor{
 		src:                 src,
-		files:               append(allKubernetesBinaries, allKubernetesImages...),
+		files:               append(allKubernetesBinaries, AllKubernetesImages...),
 		dst:                 dst,
 		dstMutator:          fileNameMutator{},
 		addVersionFileToDst: true,


### PR DESCRIPTION
This PR fixes the E2E tests failing after https://github.com/kubernetes/kubernetes/pull/80047 merged

The PR has two commits:
- `fix-image-tar that` introduces the actual fix, adjusting the image name with `-amd64` suffix during the alter image process
- `add check prepulled images` that introduces a new check before main kubeadm commands; the check compares the images kubeadm is going to use with the images already existing on the node and reports what is missing. In normal conditions, the output should be something similar to:
```
kinder-upgrade-control-plane2:$ Checking pre-loaded images
Some of the required images are not pre-loaded into the container runtime:
k8s.gcr.io/pause:3.1
k8s.gcr.io/etcd:3.3.10
k8s.gcr.io/coredns:1.3.1
```
if also the control plane images are missing, this is a signal something is wrong...

/assign @neolit123 