### PR TITLE
Kinder: CRI autodetection

### DIFF
--- a/kinder/ci/workflows/external-etcd.yaml
+++ b/kinder/ci/workflows/external-etcd.yaml
@@ -26,7 +26,6 @@ tasks:
     - --base-image={{ .vars.baseImage }}
     - --image={{ .vars.image }}
     - --with-init-artifacts={{ .vars.kubernetesVersion }}
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --loglevel=debug
   timeout: 10m
 - name: create-cluster
@@ -42,7 +41,6 @@ tasks:
     - --worker-nodes=2
     - --external-etcd
     - --automatic-copy-certs  # in v1.15 and after automatic copy certs can be configure in the kubeadm-config (which is generated at create time)
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --loglevel=debug
   timeout: 5m
 - name: init

--- a/kinder/ci/workflows/skew-1.15-on-1.14.yaml
+++ b/kinder/ci/workflows/skew-1.15-on-1.14.yaml
@@ -37,7 +37,6 @@ tasks:
     - --image={{ .vars.image }}
     - --with-init-artifacts={{ .vars.kubernetesVersion }}
     - --with-kubeadm={{ .vars.kubeadmVersion }}
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --loglevel=debug
   timeout: 10m
 - name: create-cluster
@@ -51,7 +50,6 @@ tasks:
     - --image={{ .vars.image }}
     - --control-plane-nodes={{ .vars.controlPlaneNodes }}
     - --worker-nodes={{ .vars.workerNodes }}
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --automatic-copy-certs  # in v1.15 and after automatic copy certs can be configure in the kubeadm-config (which is generated at create time)
     - --loglevel=debug
   timeout: 5m

--- a/kinder/ci/workflows/skew-master-on-1.15.yaml
+++ b/kinder/ci/workflows/skew-master-on-1.15.yaml
@@ -37,7 +37,6 @@ tasks:
     - --image={{ .vars.image }}
     - --with-init-artifacts={{ .vars.kubernetesVersion }}
     - --with-kubeadm={{ .vars.kubeadmVersion }}
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --loglevel=debug
   timeout: 10m
 - name: create-cluster
@@ -51,7 +50,6 @@ tasks:
     - --image={{ .vars.image }}
     - --control-plane-nodes={{ .vars.controlPlaneNodes }}
     - --worker-nodes={{ .vars.workerNodes }}
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --automatic-copy-certs  # in v1.15 and after automatic copy certs can be configure in the kubeadm-config (which is generated at create time)
     - --loglevel=debug
   timeout: 5m

--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -36,7 +36,6 @@ tasks:
     - --image={{ .vars.image }}
     - --with-init-artifacts={{ .vars.kubernetesVersion }}
     - --with-kubeadm={{ .vars.kubeadmVersion }}
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --loglevel=debug
   timeout: 10m
 - name: create-cluster
@@ -50,7 +49,6 @@ tasks:
     - --image={{ .vars.image }}
     - --control-plane-nodes={{ .vars.controlPlaneNodes }}
     - --worker-nodes={{ .vars.workerNodes }}
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --loglevel=debug
   timeout: 5m
 - name: init

--- a/kinder/ci/workflows/upgrade-1.14-1.15.yaml
+++ b/kinder/ci/workflows/upgrade-1.14-1.15.yaml
@@ -37,7 +37,6 @@ tasks:
     - --image={{ .vars.image }}
     - --with-init-artifacts={{ .vars.initVersion }}
     - --with-upgrade-artifacts={{ .vars.upgradeVersion }}
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --loglevel=debug
   timeout: 10m
 - name: create-cluster
@@ -51,7 +50,6 @@ tasks:
     - --image={{ .vars.image }}
     - --control-plane-nodes={{ .vars.controlPlaneNodes }}
     - --worker-nodes={{ .vars.workerNodes }}
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --loglevel=debug
   timeout: 5m
 - name: init

--- a/kinder/ci/workflows/upgrade-1.15-master.yaml
+++ b/kinder/ci/workflows/upgrade-1.15-master.yaml
@@ -38,7 +38,6 @@ tasks:
     - --image={{ .vars.image }}
     - --with-init-artifacts={{ .vars.initVersion }}
     - --with-upgrade-artifacts={{ .vars.upgradeVersion }}
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --loglevel=debug
   timeout: 10m
 - name: create-cluster
@@ -52,7 +51,6 @@ tasks:
     - --image={{ .vars.image }}
     - --control-plane-nodes={{ .vars.controlPlaneNodes }}
     - --worker-nodes={{ .vars.workerNodes }}
-    - --cri=docker            # this is temporary, until kinder will autodetect the CRI runtime installed into the node image
     - --automatic-copy-certs  # in v1.15 and after automatic copy certs can be configure in the kubeadm-config (which is generated at create time)
     - --loglevel=debug
   timeout: 5m

--- a/kinder/ci/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-tasks.yaml
@@ -36,7 +36,6 @@ tasks:
     - --image={{ .vars.image }}
     - --with-init-artifacts={{ .vars.initVersion }}
     - --with-upgrade-artifacts={{ .vars.upgradeVersion }}
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --loglevel=debug
   timeout: 10m
 - name: create-cluster
@@ -50,7 +49,6 @@ tasks:
     - --image={{ .vars.image }}
     - --control-plane-nodes={{ .vars.controlPlaneNodes }}
     - --worker-nodes={{ .vars.workerNodes }}
-    - --cri=docker           # this is temporary, until kinder will autodetect the CRI runtime installed into the base image
     - --loglevel=debug
   timeout: 5m
 - name: init

--- a/kinder/cmd/kinder/build/nodevariant/nodevariant.go
+++ b/kinder/cmd/kinder/build/nodevariant/nodevariant.go
@@ -33,7 +33,6 @@ type flagpole struct {
 	UpgradeArtifacts string
 	Kubeadm          string
 	Kubelet          string
-	CRI              string
 }
 
 // NewCommand returns a new cobra.Command for building the node image
@@ -69,12 +68,6 @@ func NewCommand() *cobra.Command {
 		nil,
 		"version/build-label/path to images tar or folder with images tars to be added to the images",
 	)
-	//TODO: remove this as soon CRI autodetection is implemented
-	cmd.Flags().StringVar(
-		&flags.CRI, "cri",
-		"",
-		"specifies the cri installed inside the base image",
-	)
 	cmd.Flags().StringVar(
 		&flags.ImageNamePrefix, "image-name-prefix",
 		"",
@@ -99,17 +92,9 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
-	// check the cri flag
-	var err error
-	cri := flags.CRI
-	if cri == "" {
-		return errors.Wrap(err, "Please use the --cri flag to specify the container runtime installed inside the base image")
-	}
-
 	ctx, err := alter.NewContext(
 		// base build options
 		alter.WithBaseImage(flags.BaseImage),
-		alter.WithCRI(cri),
 		alter.WithImage(flags.Image),
 		// bits to be added to the image
 		alter.WithInitArtifacts(flags.InitArtifacts),

--- a/kinder/cmd/kinder/create/cluster/createcluster.go
+++ b/kinder/cmd/kinder/create/cluster/createcluster.go
@@ -49,7 +49,6 @@ type flagpole struct {
 	ExternalLoadBalancer bool
 	KubeDNS              bool
 	AutomaticCopyCerts   bool
-	CRI                  string
 }
 
 // NewCommand returns a new cobra.Command for cluster creation
@@ -104,13 +103,6 @@ func NewCommand() *cobra.Command {
 		externalLoadBalancerFlagName, false,
 		"add an external load balancer to the cluster (implicit if number of control-plane nodes>1)",
 	)
-	//TODO: remove this as soon CRI autodetection is implemented
-	cmd.Flags().StringVar(
-		&flags.CRI,
-		"cri", "",
-		"specifies the cri installed inside the base image",
-	)
-
 	cmd.Flags().BoolVar(
 		&flags.KubeDNS,
 		kubeDNSFLagName, false,
@@ -140,12 +132,6 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 		return errors.Errorf("flags --%s and --%s should not be a negative number", controlPlaneNodesFlagName, workerNodesFLagName)
 	}
 
-	// check the cri flag
-	cri := flags.CRI
-	if cri == "" {
-		return errors.Wrap(err, "Please use the --cri flag to specify the container runtime installed inside the base image")
-	}
-
 	// gets the kind config, which is prebuild by kinder in accordance to the CLI flags
 	cfg, err := NewConfig(flags.ControlPlanes, flags.Workers, flags.ImageName)
 	if err != nil {
@@ -165,7 +151,6 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	if err = manager.CreateCluster(
 		flags.Name,
 		cfg,
-		manager.CRI(cri),
 		manager.ExternalLoadBalancer(flags.ExternalLoadBalancer),
 		manager.ExternalEtcd(flags.ExternalEtcd),
 		manager.KubeDNS(flags.KubeDNS),

--- a/kinder/pkg/build/alter/alter.go
+++ b/kinder/pkg/build/alter/alter.go
@@ -291,27 +291,23 @@ func (c *Context) alterImage(bitsInstallers []bits.Installer, bc *bits.BuildCont
 
 	runtime, err := status.InspectCRIinContainer(containerID)
 	if err != nil {
-		log.Errorf("Error detecting CRI! %v", err)
-		return err
+		return errors.Wrap(err, "Error detecting CRI!")
 	}
 	log.Infof("Detected %s as container runtime", runtime)
 
 	alterHelper, err := cri.NewAlterHelper(runtime)
 	if err != nil {
-		log.Errorf("Image alter Failed! %v", err)
 		return err
 	}
 
 	log.Info("Pre loading images ...")
 	if err := alterHelper.PreLoadInitImages(bc); err != nil {
-		log.Errorf("Image build Failed! Failed to load images into %s %v", runtime, err)
-		return err
+		return errors.Wrapf(err, "Image build Failed! Failed to load images into %s", runtime)
 	}
 
 	log.Infof("Commit to %s ...", c.image)
 	if err = alterHelper.Commit(containerID, c.image); err != nil {
-		log.Errorf("Image alter Failed! %v", err)
-		return err
+		return errors.Wrap(err, "Image alter Failed! Failed to commit image")
 	}
 
 	log.Info("Image alter completed.")

--- a/kinder/pkg/build/alter/alter.go
+++ b/kinder/pkg/build/alter/alter.go
@@ -27,6 +27,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"k8s.io/kubeadm/kinder/pkg/build/bits"
+	"k8s.io/kubeadm/kinder/pkg/cluster/status"
 	"k8s.io/kubeadm/kinder/pkg/cri"
 	"k8s.io/kubeadm/kinder/pkg/extract"
 	kinddocker "sigs.k8s.io/kind/pkg/container/docker"
@@ -44,7 +45,6 @@ const DefaultImage = DefaultBaseImage
 // alter configuration
 type Context struct {
 	baseImage           string
-	cri                 string
 	image               string
 	initArtifactsSrc    string
 	imageSrcs           []string
@@ -75,13 +75,6 @@ func WithImage(image string) Option {
 func WithBaseImage(image string) Option {
 	return func(b *Context) {
 		b.baseImage = image
-	}
-}
-
-// WithCRI configures a NewContext to manage the `cri` embedded in the base image
-func WithCRI(cri string) Option {
-	return func(b *Context) {
-		b.cri = cri
 	}
 }
 
@@ -296,7 +289,14 @@ func (c *Context) alterImage(bitsInstallers []bits.Installer, bc *bits.BuildCont
 		}
 	}
 
-	alterHelper, err := cri.NewAlterHelper(c.cri)
+	runtime, err := status.InspectCRIinContainer(containerID)
+	if err != nil {
+		log.Errorf("Error detecting CRI! %v", err)
+		return err
+	}
+	log.Infof("Detected %s as container runtime", runtime)
+
+	alterHelper, err := cri.NewAlterHelper(runtime)
 	if err != nil {
 		log.Errorf("Image alter Failed! %v", err)
 		return err
@@ -304,7 +304,7 @@ func (c *Context) alterImage(bitsInstallers []bits.Installer, bc *bits.BuildCont
 
 	log.Info("Pre loading images ...")
 	if err := alterHelper.PreLoadInitImages(bc); err != nil {
-		log.Errorf("Image build Failed! Failed to load images into %s %v", c.cri, err)
+		log.Errorf("Image build Failed! Failed to load images into %s %v", runtime, err)
 		return err
 	}
 

--- a/kinder/pkg/cluster/manager/actions/kubeadm-config.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-config.go
@@ -175,6 +175,8 @@ func getKubeadmConfig(c *status.Cluster, n *status.Node, data kubeadm.ConfigData
 
 	// add patches for instructing kubeadm to use the CRI runtime engine  installed on a node
 	// NB. this is a no-op in case of containerd, because it is already the default in the raw config
+	// TODO: currently we are always specifying the CRI kubeadm should use; it will be nice in the future to
+	// have the possibility to test the kubeadm CRI autodetection
 	nodeCRI, err := n.CRI()
 	if err != nil {
 		return "", err

--- a/kinder/pkg/cluster/status/cri.go
+++ b/kinder/pkg/cluster/status/cri.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	kinddocker "sigs.k8s.io/kind/pkg/container/docker"
+	kindexec "sigs.k8s.io/kind/pkg/exec"
+)
+
+// NB. code implemented in this package ideally should be in the CRI package, but ATM it is
+// implemented here to avoid circular references. TODO: refactor
+
+// ContainerRuntime defines CRI runtime that are supported inside a kind(er) node
+type ContainerRuntime string
+
+const (
+	// DockerRuntime refers to the docker container runtime
+	DockerRuntime ContainerRuntime = "docker"
+	// ContainerdRuntime refers to the containerd container runtime
+	ContainerdRuntime ContainerRuntime = "containerd"
+)
+
+// InspectCRIinImage inspect an image and detects the installed container runtime
+func InspectCRIinImage(image string) (ContainerRuntime, error) {
+	// define docker default args
+	id := "kind-detect-" + uuid.New().String()
+	args := []string{
+		"-d", // make the client exit while the container continues to run
+		"--entrypoint=sleep",
+		"--name=" + id,
+	}
+
+	if err := kinddocker.Run(
+		image,
+		kinddocker.WithRunArgs(
+			args...,
+		),
+		kinddocker.WithContainerArgs(
+			"infinity", // sleep infinitely to keep the container around
+		),
+	); err != nil {
+		return "", errors.Wrap(err, "error creating a temporary container for CRI detection")
+	}
+	defer func() {
+		kindexec.Command("docker", "rm", "-f", id).Run()
+	}()
+
+	return InspectCRIinContainer(id)
+}
+
+// InspectCRIinContainer inspect a running and detects the installed container runtime
+// NB. this method use raw kinddocker/kindexec commands because it is used also during alter and create
+// (before an actual Cluster status exist)
+func InspectCRIinContainer(id string) (ContainerRuntime, error) {
+
+	cmder := kinddocker.ContainerCmder(id)
+
+	cmd := cmder.Command("/bin/sh", "-c",
+		`cat /kinder/cri > /dev/null 2>&1 || true`)
+	lines, err := kindexec.CombinedOutputLines(cmd)
+	if err != nil {
+		return ContainerRuntime(""), errors.Wrap(err, "error detecting CRI")
+	}
+
+	if len(lines) == 1 {
+		return ContainerRuntime(lines[0]), nil
+	}
+
+	cmd = cmder.Command("/bin/sh", "-c",
+		`which docker || true`)
+	lines, err = kindexec.CombinedOutputLines(cmd)
+
+	if err != nil {
+		return ContainerRuntime(""), errors.Wrap(err, "error detecting CRI")
+	}
+
+	if len(lines) == 1 {
+		return DockerRuntime, nil
+	}
+
+	return ContainerdRuntime, nil
+}

--- a/kinder/pkg/cluster/status/cri.go
+++ b/kinder/pkg/cluster/status/cri.go
@@ -65,33 +65,22 @@ func InspectCRIinImage(image string) (ContainerRuntime, error) {
 	return InspectCRIinContainer(id)
 }
 
-// InspectCRIinContainer inspect a running and detects the installed container runtime
-// NB. this method use raw kinddocker/kindexec commands because it is used also during alter and create
+// InspectCRIinContainer inspect a running container and detects the installed container runtime
+// NB. this method use raw kinddocker/kindexec commands because it is used also during "alter" and "create"
 // (before an actual Cluster status exist)
 func InspectCRIinContainer(id string) (ContainerRuntime, error) {
 
 	cmder := kinddocker.ContainerCmder(id)
 
 	cmd := cmder.Command("/bin/sh", "-c",
-		`cat /kinder/cri > /dev/null 2>&1 || true`)
-	lines, err := kindexec.CombinedOutputLines(cmd)
-	if err != nil {
-		return ContainerRuntime(""), errors.Wrap(err, "error detecting CRI")
-	}
-
-	if len(lines) == 1 {
-		return ContainerRuntime(lines[0]), nil
-	}
-
-	cmd = cmder.Command("/bin/sh", "-c",
 		`which docker || true`)
-	lines, err = kindexec.CombinedOutputLines(cmd)
+	lines, err := kindexec.CombinedOutputLines(cmd)
 
-	if err != nil {
+	if err != nil  {
 		return ContainerRuntime(""), errors.Wrap(err, "error detecting CRI")
 	}
 
-	if len(lines) == 1 {
+	if len(lines) > 0 {
 		return DockerRuntime, nil
 	}
 

--- a/kinder/pkg/cri/alterhelper.go
+++ b/kinder/pkg/cri/alterhelper.go
@@ -31,9 +31,9 @@ type AlterHelper struct {
 }
 
 // NewAlterHelper returns a new AlterHelper
-func NewAlterHelper(cri string) (*AlterHelper, error) {
+func NewAlterHelper(cri status.ContainerRuntime) (*AlterHelper, error) {
 	return &AlterHelper{
-		cri: status.ContainerRuntime(cri),
+		cri: cri,
 	}, nil
 }
 


### PR DESCRIPTION
This PR implements autodetection for the CRI runtime installed into base/node images. As a consequence, the temporary `--cri` flag is removed
/assign @neolit123 