### PR TITLE
Remove automatic execution of actions during kinder create

### DIFF
--- a/kinder/ci/workflows/external-etcd.yaml
+++ b/kinder/ci/workflows/external-etcd.yaml
@@ -40,7 +40,6 @@ tasks:
     - --control-plane-nodes=3
     - --worker-nodes=2
     - --external-etcd
-    - --automatic-copy-certs  # in v1.15 and after automatic copy certs can be configure in the kubeadm-config (which is generated at create time)
     - --loglevel=debug
   timeout: 5m
 - name: init

--- a/kinder/ci/workflows/skew-1.15-on-1.14.yaml
+++ b/kinder/ci/workflows/skew-1.15-on-1.14.yaml
@@ -50,7 +50,6 @@ tasks:
     - --image={{ .vars.image }}
     - --control-plane-nodes={{ .vars.controlPlaneNodes }}
     - --worker-nodes={{ .vars.workerNodes }}
-    - --automatic-copy-certs  # in v1.15 and after automatic copy certs can be configure in the kubeadm-config (which is generated at create time)
     - --loglevel=debug
   timeout: 5m
 - name: init

--- a/kinder/ci/workflows/skew-master-on-1.15.yaml
+++ b/kinder/ci/workflows/skew-master-on-1.15.yaml
@@ -50,7 +50,6 @@ tasks:
     - --image={{ .vars.image }}
     - --control-plane-nodes={{ .vars.controlPlaneNodes }}
     - --worker-nodes={{ .vars.workerNodes }}
-    - --automatic-copy-certs  # in v1.15 and after automatic copy certs can be configure in the kubeadm-config (which is generated at create time)
     - --loglevel=debug
   timeout: 5m
 - name: init

--- a/kinder/ci/workflows/upgrade-1.15-master.yaml
+++ b/kinder/ci/workflows/upgrade-1.15-master.yaml
@@ -51,7 +51,6 @@ tasks:
     - --image={{ .vars.image }}
     - --control-plane-nodes={{ .vars.controlPlaneNodes }}
     - --worker-nodes={{ .vars.workerNodes }}
-    - --automatic-copy-certs  # in v1.15 and after automatic copy certs can be configure in the kubeadm-config (which is generated at create time)
     - --loglevel=debug
   timeout: 5m
 - name: init

--- a/kinder/cmd/kinder/create/cluster/createcluster.go
+++ b/kinder/cmd/kinder/create/cluster/createcluster.go
@@ -47,8 +47,6 @@ type flagpole struct {
 	Retain               bool
 	ExternalEtcd         bool
 	ExternalLoadBalancer bool
-	KubeDNS              bool
-	AutomaticCopyCerts   bool
 }
 
 // NewCommand returns a new cobra.Command for cluster creation
@@ -103,16 +101,6 @@ func NewCommand() *cobra.Command {
 		externalLoadBalancerFlagName, false,
 		"add an external load balancer to the cluster (implicit if number of control-plane nodes>1)",
 	)
-	cmd.Flags().BoolVar(
-		&flags.KubeDNS,
-		kubeDNSFLagName, false,
-		"setup kubeadm for installing kube-dns instead of CoreDNS",
-	)
-	cmd.Flags().BoolVar(
-		&flags.AutomaticCopyCerts,
-		"automatic-copy-certs", false,
-		"setup kubeadm for using the automatic copy certs instead of manual copy certs when joining new control-plane nodes",
-	)
 
 	return cmd
 }
@@ -153,8 +141,6 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 		cfg,
 		manager.ExternalLoadBalancer(flags.ExternalLoadBalancer),
 		manager.ExternalEtcd(flags.ExternalEtcd),
-		manager.KubeDNS(flags.KubeDNS),
-		manager.AutomaticCopyCerts(flags.AutomaticCopyCerts),
 		manager.Retain(flags.Retain),
 	); err != nil {
 		return errors.Wrap(err, "failed to create cluster")

--- a/kinder/pkg/cluster/manager/actions/actions.go
+++ b/kinder/pkg/cluster/manager/actions/actions.go
@@ -29,22 +29,20 @@ import (
 	"k8s.io/kubeadm/kinder/pkg/cluster/status"
 )
 
-// TODO: make actions name costants, because they are used also in create
-
 // action registry defines the list of available actions and the corresponding entry point.
 var actionRegistry = map[string]func(*status.Cluster, *RunOptions) error{
 	"loadbalancer": func(c *status.Cluster, flags *RunOptions) error {
-		// Nb. this action is invoked automatically at create time, but it is possible
+		// Nb. this action is invoked automatically at kubeadm init/join time, but it is possible
 		// to invoke it separately as well
-		return LoadBalancer(c)
+		return LoadBalancer(c, c.ControlPlanes()...)
 	},
 	"kubeadm-config": func(c *status.Cluster, flags *RunOptions) error {
-		// Nb. this action is invoked automatically at create time, but it is possible
+		// Nb. this action is invoked automatically at kubeadm init/join time, but it is possible
 		// to invoke it separately as well
-		return KubeadmConfig(c, flags.kubeDNS, flags.automaticCopyCerts)
+		return KubeadmConfig(c, flags.kubeDNS, flags.automaticCopyCerts, c.K8sNodes()...)
 	},
 	"kubeadm-init": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmInit(c, flags.usePhases, flags.automaticCopyCerts, flags.wait, flags.vLevel)
+		return KubeadmInit(c, flags.usePhases, flags.kubeDNS, flags.automaticCopyCerts, flags.wait, flags.vLevel)
 	},
 	"kubeadm-join": func(c *status.Cluster, flags *RunOptions) error {
 		return KubeadmJoin(c, flags.usePhases, flags.automaticCopyCerts, flags.wait, flags.vLevel)

--- a/kinder/pkg/cluster/manager/actions/kubeadm-config.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-config.go
@@ -39,7 +39,7 @@ type kubeadmConfigOptions struct {
 // KubeadmConfig action writes the /kind/kubeadm.conf file on all the K8s nodes in the cluster.
 // Please note that this action is automatically executed at create time, but it is possible
 // to invoke it separately as well.
-func KubeadmConfig(c *status.Cluster, kubeDNS bool, automaticCopyCerts bool) error {
+func KubeadmConfig(c *status.Cluster, kubeDNS bool, automaticCopyCerts bool, nodes ...*status.Node) error {
 	cp1 := c.BootstrapControlPlane()
 
 	// get installed kubernetes version from the node image
@@ -81,7 +81,7 @@ func KubeadmConfig(c *status.Cluster, kubeDNS bool, automaticCopyCerts bool) err
 	}
 
 	// writs the kubeadm config file on all the K8s nodes.
-	for _, node := range c.K8sNodes() {
+	for _, node := range nodes {
 		if err := writeKubeadmConfig(c, node, configData, configOptions); err != nil {
 			return err
 		}
@@ -117,7 +117,7 @@ func getControlPlaneAddress(c *status.Cluster) (string, string, int, error) {
 
 // writeKubeadmConfig writes the /kind/kubeadm.conf file on a node
 func writeKubeadmConfig(c *status.Cluster, n *status.Node, data kubeadm.ConfigData, options kubeadmConfigOptions) error {
-	log.Debugf("Writing kubeadm config on %s...", n.Name())
+	n.Infof("Preparing %s", constants.KubeadmConfigPath)
 
 	// Amends the ConfigData struct with node specific settings
 

--- a/kinder/pkg/cluster/manager/actions/loadbalancer.go
+++ b/kinder/pkg/cluster/manager/actions/loadbalancer.go
@@ -32,9 +32,10 @@ import (
 // LoadBalancer action writes the loadbalancer configuration file on the load balancer node.
 // Please note that this action is automatically executed at create time, but it is possible
 // to invoke it separately as well.
-func LoadBalancer(c *status.Cluster) error {
+func LoadBalancer(c *status.Cluster, nodes ...*status.Node) error {
 	// identify external load balancer node
 	lb := c.ExternalLoadBalancer()
+	lb.Infof("Updating load balancer configuration with %d control plane backends", len(nodes))
 
 	// if there's no loadbalancer we're done
 	if lb == nil {
@@ -45,7 +46,7 @@ func LoadBalancer(c *status.Cluster) error {
 
 	// collect info about the existing controlplane nodes
 	var backendServers = map[string]string{}
-	for _, n := range c.ControlPlanes() {
+	for _, n := range nodes {
 		controlPlaneIPv4, controlPlaneIPv6, err := n.IP()
 		if err != nil {
 			return errors.Wrapf(err, "failed to get IP for node %s", n.Name())


### PR DESCRIPTION
This PR remove calls to `kubeadm-config` and `loadbalancer` actions during `kinder create`; instead those actions will be automatically executed before `kubeadm init/join` on per-node basis.

This change resulted in cleaner the UX for `kinder create` and, most importantly, it enables joining node with different discovery modes on the same cluster

/assign @neolit123