### PR TITLE
kinder: fix minor bugs in verify-gofmt.sh

### DIFF
--- a/kinder/hack/verify-gofmt.sh
+++ b/kinder/hack/verify-gofmt.sh
@@ -23,9 +23,10 @@ source "$(dirname "$0")/utils.sh"
 cd_root_path
 
 # check for gofmt diffs
-diff=$(git ls-files | grep "\.go" | grep -v "\/vendor" | xargs gofmt -s -d 2>&1)
+diff=$(git ls-files | grep "\.go" | grep -v "vendor\/" | xargs gofmt -s -d 2>&1)
 if [[ -n "${diff}" ]]; then
   echo "${diff}"
   echo
   echo "Check failed. Please run hack/update-gofmt.sh"
+  exit 1
 fi


### PR DESCRIPTION
the kubeadm bootsrap provider found a minor bug in your verify-gofmt.sh.
the file in kinder needs a fix too.
https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/pull/72