### PR TITLE
updated confusing command help text

### DIFF
--- a/kinder/cmd/kinder/create/create.go
+++ b/kinder/cmd/kinder/create/create.go
@@ -27,8 +27,8 @@ func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
 		Use:   "create",
-		Short: "Creates one of [cluster, worker-node, control-plane-node]",
-		Long:  "Creates one of local Kubernetes cluster (cluster), or nodes in a local kubernetes cluster (worker-node, control-plane-node)",
+		Short: "Creates one of [cluster]",
+		Long:  "Creates one of local Kubernetes cluster (cluster)",
 	}
 	cmd.AddCommand(createcluster.NewCommand())
 	return cmd


### PR DESCRIPTION
I found the help text a little confusing, this command cannot add (that I could figure out) a new node into an existing kind cluster. If we did want to support this I think it would be better suited with an `add-node` command anyhow. What do you think? @fabriziopandini 