### PR TITLE
Kinder: add support for testing kubeadm-kustomize

### DIFF
--- a/kinder/ci/kubeadm-periodic.tests.md
+++ b/kinder/ci/kubeadm-periodic.tests.md
@@ -82,7 +82,16 @@ the minimal supported version that is tested for external etcd.
 ### Discovery tests
 
 Kubeadm discovery tests are meant for testing alternative discovery methods for kubeadm join. Currently, master is
-the minimal supported version that is tested for external discovery variants.
+the minimal supported version that is tested for join discovery variants.
+
+| Version                                | e.g.              |
+| -------------------------------------- | ------            |
+| master<br />(ci/latest)                | v1.16.0-alpha...  |
+
+### Kustomize tests
+
+Kubeadm kustomize tests are meant for testing usage of kustomize patches with kubeadm init, join and kubeadm upgrade.
+Currently, master is the minimal supported version that is tested for kustomize.
 
 | Version                                | e.g.              |
 | -------------------------------------- | ------            |

--- a/kinder/ci/workflows/kustomize-master.yaml
+++ b/kinder/ci/workflows/kustomize-master.yaml
@@ -1,0 +1,208 @@
+version: 1
+summary: |
+  This workflow implements a sequence of tasks used for testing alternative
+  discovery methods for kubeadm join.
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest` }}"
+  baseImage: kindest/base:v20190403-1ebf15f
+  image: kindest/node:test
+  clusterName: kinder-kustomize
+tasks:
+  - name: pull-base-image
+    description: |
+      pulls kindest/base image with docker in docker and all the prerequisites necessary for running kind(er)
+    cmd: docker
+    args:
+      - pull
+      - "{{ .vars.baseImage }}"
+  - name: add-kubernetes-versions
+    description: |
+      creates a node-image-variant by adding Kubernetes version "kubernetesVersion"
+      to be used when executing "kinder do kubeadm-init"
+    cmd: kinder
+    args:
+      - build
+      - node-image-variant
+      - --base-image={{ .vars.baseImage }}
+      - --image={{ .vars.image }}
+      - --with-init-artifacts={{ .vars.kubernetesVersion }}
+      - --with-upgrade-artifacts={{ .vars.kubernetesVersion }}
+      - --loglevel=debug
+    timeout: 10m
+  - name: create-cluster
+    description: |
+      create a set of nodes ready for hosting the Kubernetes cluster
+    cmd: kinder
+    args:
+      - create
+      - cluster
+      - --name={{ .vars.clusterName }}
+      - --image={{ .vars.image }}
+      - --control-plane-nodes=2
+      - --worker-nodes=1
+      - --loglevel=debug
+    timeout: 5m
+  - name: prepare kustomize pathches
+    cmd: /bin/sh
+    args:
+      - -c
+      - |
+        mkdir -p /tmp/kubeadm-patches
+
+        cat <<EOF >/tmp/kubeadm-patches/patch1.yaml
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: kube-apiserver
+          namespace: kube-system
+          annotations:
+            kustomize: kube-apiserver
+        EOF
+
+        cat <<EOF >/tmp/kubeadm-patches/patch2.yaml
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: kube-controller-manager
+          namespace: kube-system
+          annotations:
+            kustomize: kube-controller-manager
+        EOF
+
+        cat <<EOF >/tmp/kubeadm-patches/patch3.yaml
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: kube-scheduler
+          namespace: kube-system
+          annotations:
+            kustomize: kube-scheduler
+        EOF
+
+        cat <<EOF >/tmp/kubeadm-patches/patch4.yaml
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: etcd
+          namespace: kube-system
+          annotations:
+            kustomize: etcd
+        EOF
+  - name: prepare verify-kustomize.sh script
+    cmd: /bin/sh
+    args:
+      - -c
+      - |
+        cat <<EOF >/tmp/verify-kustomize.sh
+        #!/usr/bin/env bash
+        res=0
+        for d in /etc/kubernetes/manifests/*.yaml; do
+          if grep -q "kustomize: \$(basename \$d .yaml)" \$d ; then
+              echo "\$d is kustomized!"
+          else
+              echo "ERROR: \$d is not kustomized"
+              res=1
+          fi
+        done
+
+        if [[ "\${res}" = 0 ]]; then
+          echo "All verify checks passed, congrats!"
+          echo ""
+        else
+          echo "One or more verify checks failed! See output above..."
+          echo ""
+          exit 1
+        fi
+        EOF
+
+        chmod +x /tmp/verify-kustomize.sh
+  - name: copy verify-kustomize.sh on controlplane nodes
+    cmd: kinder
+    args:
+      - cp
+      - --name={{ .vars.clusterName }}
+      - /tmp/verify-kustomize.sh
+      - "@cp*:/kinder/verify-kustomize.sh"
+  - name: init
+    description: |
+      Initializes the Kubernetes cluster with version "kubernetesVersion"
+      by starting the bootstrap control-plane node
+    cmd: kinder
+    args:
+      - do
+      - kubeadm-init
+      - --name={{ .vars.clusterName }}
+      - -k=/tmp/kubeadm-patches
+      - --loglevel=debug
+    timeout: 5m
+  - name: join
+    description: |
+      Join a node using file discovery (without authentication credentials)
+    cmd: kinder
+    args:
+      - do
+      - kubeadm-join
+      - --name={{ .vars.clusterName }}
+      - -k=/tmp/kubeadm-patches
+      - --loglevel=debug
+    timeout: 5m
+  - name: run verify-kustomize.sh on controlplane nodes before upgrades
+    cmd: kinder
+    args:
+      - exec
+      - --name={{ .vars.clusterName }}
+      - "@cp*"
+      - /kinder/verify-kustomize.sh
+  - name: upgrade
+    description: |
+      upgrades the cluster to Kubernetes "upgradeVersion"
+    cmd: kinder
+    args:
+      - do
+      - kubeadm-upgrade
+      - --upgrade-version={{ .vars.kubernetesVersion }}
+      - -k=/tmp/kubeadm-patches
+      - --name={{ .vars.clusterName }}
+  - name: run verify-kustomize.sh on controlplane nodes after upgrades
+    cmd: kinder
+    args:
+      - exec
+      - --name={{ .vars.clusterName }}
+      - "@cp*"
+      - /kinder/verify-kustomize.sh
+  - name: get-logs
+    description: |
+      Collects all the test logs
+    cmd: kinder
+    args:
+      - export
+      - logs
+      - --loglevel=debug
+      - --name={{ .vars.clusterName }}
+      - "{{ .env.ARTIFACTS }}"
+    force: true
+    timeout: 5m
+    # kind export log is know to be flaky, so we are temporary ignoring errors in order
+    # to make the test pass in case everything else passed
+    # see https://github.com/kubernetes-sigs/kind/issues/456
+    ignoreError: true
+  - name: reset
+    description: |
+      Exec kubeadm reset
+    cmd: kinder
+    args:
+      - do
+      - kubeadm-reset
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+    force: true
+  - name: delete
+    description: |
+      Deletes the cluster
+    cmd: kinder
+    args:
+      - delete
+      - cluster
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+    force: true

--- a/kinder/cmd/kinder/do/do.go
+++ b/kinder/cmd/kinder/do/do.go
@@ -40,6 +40,7 @@ type flagpole struct {
 	OnlyNode           string
 	DryRun             bool
 	VLevel             int
+	KustomizeDir       string
 	Wait               time.Duration
 }
 
@@ -96,7 +97,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(
 		&flags.Discovery,
 		"discovery-mode", flags.Discovery,
-		fmt.Sprintf("defines the discovery mode to be used for join; use one of %s", actions.KnownDiscoveryMode()),
+		fmt.Sprintf("the discovery mode to be used for join; use one of %s", actions.KnownDiscoveryMode()),
 	)
 	cmd.Flags().DurationVar(
 		&flags.Wait,
@@ -107,6 +108,11 @@ func NewCommand() *cobra.Command {
 		&flags.VLevel,
 		"kubeadm-verbosity", "v", 0,
 		"Number for the log level verbosity for the kubeadm commands",
+	)
+	cmd.Flags().StringVarP(
+		&flags.KustomizeDir,
+		"kustomize-dir", "k", flags.KustomizeDir,
+		"the kustomize folder to be used for init,join and upgrade",
 	)
 	return cmd
 }
@@ -154,6 +160,7 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) (err error) {
 		actions.Wait(flags.Wait),
 		actions.UpgradeVersion(upgradeVersion),
 		actions.VLevel(flags.VLevel),
+		actions.KustomizeDir(flags.KustomizeDir),
 	)
 	if err != nil {
 		return errors.Wrapf(err, "failed to exec action %s", action)

--- a/kinder/cmd/kinder/exec/exec.go
+++ b/kinder/cmd/kinder/exec/exec.go
@@ -68,7 +68,7 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	// execute the command on selected target nodes
 	err = o.ExecCommand(args[0], args[1:])
 	if err != nil {
-		return errors.Wrap(err, "failed to copy files")
+		return errors.Wrap(err, "failed to exec command")
 	}
 
 	return nil

--- a/kinder/pkg/cluster/manager/actions/actions.go
+++ b/kinder/pkg/cluster/manager/actions/actions.go
@@ -42,13 +42,13 @@ var actionRegistry = map[string]func(*status.Cluster, *RunOptions) error{
 		return KubeadmConfig(c, flags.kubeDNS, flags.automaticCopyCerts, flags.discoveryMode, c.K8sNodes().EligibleForActions()...)
 	},
 	"kubeadm-init": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmInit(c, flags.usePhases, flags.kubeDNS, flags.automaticCopyCerts, flags.wait, flags.vLevel)
+		return KubeadmInit(c, flags.usePhases, flags.kubeDNS, flags.automaticCopyCerts, flags.kustomizeDir, flags.wait, flags.vLevel)
 	},
 	"kubeadm-join": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmJoin(c, flags.usePhases, flags.automaticCopyCerts, flags.discoveryMode, flags.wait, flags.vLevel)
+		return KubeadmJoin(c, flags.usePhases, flags.automaticCopyCerts, flags.discoveryMode, flags.kustomizeDir, flags.wait, flags.vLevel)
 	},
 	"kubeadm-upgrade": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmUpgrade(c, flags.upgradeVersion, flags.wait, flags.vLevel)
+		return KubeadmUpgrade(c, flags.upgradeVersion, flags.kustomizeDir, flags.wait, flags.vLevel)
 	},
 	"kubeadm-reset": func(c *status.Cluster, flags *RunOptions) error {
 		return KubeadmReset(c, flags.vLevel)
@@ -128,6 +128,13 @@ func VLevel(vLevel int) Option {
 	}
 }
 
+// KustomizeDir option sets the kustomize dir for the kubeadm commands
+func KustomizeDir(kustomizeDir string) Option {
+	return func(r *RunOptions) {
+		r.kustomizeDir = kustomizeDir
+	}
+}
+
 // RunOptions holds options supplied to actions.Run
 type RunOptions struct {
 	kubeDNS            bool
@@ -137,6 +144,7 @@ type RunOptions struct {
 	wait               time.Duration
 	upgradeVersion     *K8sVersion.Version
 	vLevel             int
+	kustomizeDir       string
 }
 
 // DiscoveryMode defines discovery mode supported by kubeadm join

--- a/kinder/pkg/cluster/manager/actions/copy-certs.go
+++ b/kinder/pkg/cluster/manager/actions/copy-certs.go
@@ -80,10 +80,7 @@ func copyCertificatesToNode(c *status.Cluster, n *status.Node) error {
 		).Silent().Run(); err != nil {
 			return errors.Wrapf(err, "failed to write %s", constants.KubeadmConfigPath)
 		}
-
 	}
-
-	fmt.Println()
 
 	return nil
 }

--- a/kinder/pkg/cluster/manager/actions/kubeadm-config.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-config.go
@@ -447,14 +447,15 @@ func setPatchNames(patches []string, jsonPatches []kindkustomize.PatchJSON6902) 
 // removeMetadata trims out the metadata.name we put in the config for kustomize matching,
 // kubeadm will complain about this otherwise
 func removeMetadata(kustomized string) string {
-	return strings.Replace(
-		kustomized,
-		`metadata:
-  name: config
-`,
-		"",
-		-1,
-	)
+	lines := strings.Split(kustomized, "\n")
+	out := []string{}
+	for _, l := range lines {
+		if strings.Contains(l, "metadata:") || (strings.Contains(l, "name:") && strings.Contains(l, "config")) {
+			continue
+		}
+		out = append(out, l)
+	}
+	return strings.Join(out, "\n")
 }
 
 const yamlSeparator = "---\n"

--- a/kinder/pkg/cluster/manager/actions/kubeadm-upgrade.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-upgrade.go
@@ -35,7 +35,7 @@ import (
 //
 // The implementation assumes that the kubeadm/kubelet/kubectl binaries and all the necessary images
 // for the new kubernetes version are available in the /kinder/upgrade/{version} folder.
-func KubeadmUpgrade(c *status.Cluster, upgradeVersion *K8sVersion.Version, wait time.Duration, vLevel int) (err error) {
+func KubeadmUpgrade(c *status.Cluster, upgradeVersion *K8sVersion.Version, kustomizeDir string, wait time.Duration, vLevel int) (err error) {
 	if upgradeVersion == nil {
 		return errors.New("kubeadm-upgrade actions requires the --upgrade-version parameter to be set")
 	}
@@ -44,14 +44,26 @@ func KubeadmUpgrade(c *status.Cluster, upgradeVersion *K8sVersion.Version, wait 
 
 	for _, n := range c.K8sNodes().EligibleForActions() {
 
+		// fail fast if required to use kustomize and kubeadm less than v1.16
+		if kustomizeDir != "" && n.MustKubeadmVersion().LessThan(constants.V1_16) {
+			return errors.New("--kustomize-dir can't be used with kubeadm older than v1.16")
+		}
+
+		// if kustomize copy patches to the node
+		if kustomizeDir != "" {
+			if err := copyPatchesToNode(n, kustomizeDir); err != nil {
+				return err
+			}
+		}
+
 		if err := upgradeKubeadmBinary(n, upgradeVersion); err != nil {
 			return err
 		}
 
 		if n.Name() == c.BootstrapControlPlane().Name() {
-			err = kubeadmUpgradeApply(c, n, upgradeVersion, wait, vLevel)
+			err = kubeadmUpgradeApply(c, n, upgradeVersion, kustomizeDir, wait, vLevel)
 		} else {
-			err = kubeadmUpgradeNode(c, n, upgradeVersion, wait, vLevel)
+			err = kubeadmUpgradeNode(c, n, upgradeVersion, kustomizeDir, wait, vLevel)
 		}
 		if err != nil {
 			return err
@@ -114,9 +126,15 @@ func upgradeKubeadmBinary(n *status.Node, upgradeVersion *K8sVersion.Version) er
 	return nil
 }
 
-func kubeadmUpgradeApply(c *status.Cluster, cp1 *status.Node, upgradeVersion *K8sVersion.Version, wait time.Duration, vLevel int) error {
+func kubeadmUpgradeApply(c *status.Cluster, cp1 *status.Node, upgradeVersion *K8sVersion.Version, kustomizeDir string, wait time.Duration, vLevel int) error {
+	applyArgs := []string{
+		"upgrade", "apply", "-f", fmt.Sprintf("v%s", upgradeVersion), fmt.Sprintf("--v=%d", vLevel),
+	}
+	if kustomizeDir != "" {
+		applyArgs = append(applyArgs, fmt.Sprintf("--k=%s", constants.KustomizeDir))
+	}
 	if err := cp1.Command(
-		"kubeadm", "upgrade", "apply", "-f", fmt.Sprintf("v%s", upgradeVersion), fmt.Sprintf("--v=%d", vLevel),
+		"kubeadm", applyArgs...,
 	).RunWithEcho(); err != nil {
 		return err
 	}
@@ -128,7 +146,7 @@ func kubeadmUpgradeApply(c *status.Cluster, cp1 *status.Node, upgradeVersion *K8
 	return nil
 }
 
-func kubeadmUpgradeNode(c *status.Cluster, n *status.Node, upgradeVersion *K8sVersion.Version, wait time.Duration, vLevel int) error {
+func kubeadmUpgradeNode(c *status.Cluster, n *status.Node, upgradeVersion *K8sVersion.Version, kustomizeDir string, wait time.Duration, vLevel int) error {
 	// waitKubeletHasRBAC waits for the kubelet to have access to the expected config map
 	// please note that this is a temporary workaround for a problem we are observing on upgrades while
 	// executing node upgrades immediately after control-plane upgrade.
@@ -141,8 +159,14 @@ func kubeadmUpgradeNode(c *status.Cluster, n *status.Node, upgradeVersion *K8sVe
 	// before two actions where required
 	if n.MustKubeadmVersion().AtLeast(constants.V1_15) {
 		// kubeadm upgrade node
+		nodeArgs := []string{
+			"upgrade", "node", fmt.Sprintf("--v=%d", vLevel),
+		}
+		if kustomizeDir != "" {
+			nodeArgs = append(nodeArgs, fmt.Sprintf("--k=%s", constants.KustomizeDir))
+		}
 		if err := n.Command(
-			"kubeadm", "upgrade", "node", fmt.Sprintf("--v=%d", vLevel),
+			"kubeadm", nodeArgs...,
 		).RunWithEcho(); err != nil {
 			return err
 		}

--- a/kinder/pkg/cluster/manager/actions/waiter.go
+++ b/kinder/pkg/cluster/manager/actions/waiter.go
@@ -134,16 +134,16 @@ func waitFor(c *status.Cluster, n *status.Node, timeout time.Duration, condition
 
 		// run the condition in a go routine until it pass
 		go func() {
-			// creates an arbitrary skew before startig a wait loop
-			time.Sleep(time.Duration(rand.Intn(250)) * time.Millisecond)
+			// creates an arbitrary skew before starting a wait loop
+			time.Sleep(time.Duration(rand.Intn(500)) * time.Millisecond)
 
 			for {
 				if x(c, n) {
 					pass <- true
 					break
 				}
-				// add a little delay before retry
-				time.Sleep(250 * time.Millisecond)
+				// add a little delay + jitter before retry
+				time.Sleep(1*time.Second + time.Duration(rand.Intn(500))*time.Millisecond)
 			}
 		}()
 	}

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -92,6 +92,9 @@ const (
 
 	// DiscoveryFile defines the path to a discovery file stored on nodes
 	DiscoveryFile = "/kinder/discovery.conf"
+
+	// KustomizeDir defines the path to patches stored on node
+	KustomizeDir = "/kinder/kustomize"
 )
 
 // kubernetes releases, used for branching code according to K8s release or kubeadm release version
@@ -110,6 +113,9 @@ var (
 
 	// V1.15 minor version
 	V1_15 = K8sVersion.MustParseSemantic("v1.15.0-0")
+
+	// V1.16 minor version
+	V1_16 = K8sVersion.MustParseSemantic("v1.16.0-0")
 )
 
 // other constants


### PR DESCRIPTION
This PR implements the required changes in order to use kinder for testing kubeadm-kustomize feature

/assign @neolit123 
