### PR TITLE
kinder: add hack/verify-staticcheck.sh

### DIFF
--- a/kinder/cmd/kinder/get/artifacts/artifacts.go
+++ b/kinder/cmd/kinder/get/artifacts/artifacts.go
@@ -87,7 +87,7 @@ func NewCommand() *cobra.Command {
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	//checks that mutually exclusive flags are not set at the same time
 	exclusiveFlags := []string{onlyKubeadmFlagName, onlyKubeletFlagName, onlyBinariesFlagName, onlyImagesFLagName}
-	if checkExclusiveFlags(cmd.Flags(), exclusiveFlags) == false {
+	if !checkExclusiveFlags(cmd.Flags(), exclusiveFlags) {
 		return errors.Errorf("flags [%s] are mutually exclusive, please set only one of them", strings.Join(exclusiveFlags, ", "))
 	}
 

--- a/kinder/hack/verify-all.sh
+++ b/kinder/hack/verify-all.sh
@@ -80,6 +80,12 @@ if [[ "${VERIFY_DEPS:-true}" == "true" ]]; then
   cd "${REPO_PATH}"
 fi
 
+if [[ "${VERIFY_STATICCHECK:-true}" == "true" ]]; then
+  echo "[*] Verifying staticcheck..."
+  hack/verify-staticcheck.sh || res=1
+  cd "${REPO_PATH}"
+fi
+
 if [[ "${VERIFY_GOTEST:-true}" == "true" ]]; then
   echo "[*] Verifying gotest..."
   hack/verify-gotest.sh || res=1

--- a/kinder/hack/verify-staticcheck.sh
+++ b/kinder/hack/verify-staticcheck.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# CI script to run staticcheck
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+
+# cd to the root path
+REPO_PATH=$(get_root_path)
+
+# create a temporary directory
+TMP_DIR=$(mktemp -d)
+
+# cleanup
+exitHandler() (
+  echo "Cleaning up..."
+  rm -rf "${TMP_DIR}"
+)
+trap exitHandler EXIT
+
+# pull the source code and build the binary
+cd "${TMP_DIR}"
+URL="http://github.com/dominikh/go-tools"
+echo "Cloning ${URL} in ${TMP_DIR}..."
+git clone --quiet --depth=1 "${URL}" .
+echo "Building staticcheck..."
+export GO111MODULE=on
+go build -o ./bin/staticheck ./cmd/staticcheck
+
+# run the binary
+cd "${REPO_PATH}"
+echo "Running staticcheck..."
+"${TMP_DIR}/bin/staticheck" ./cmd/... ./pkg/... ./third_party/...

--- a/kinder/pkg/cluster/manager/manage.go
+++ b/kinder/pkg/cluster/manager/manage.go
@@ -30,7 +30,6 @@ import (
 
 // ClusterManager manages kind(er) clusters
 type ClusterManager struct {
-	clusterName string
 	*status.Cluster
 }
 

--- a/kinder/pkg/cluster/status/node.go
+++ b/kinder/pkg/cluster/status/node.go
@@ -42,7 +42,6 @@ type Node struct {
 	kindNode        kindnodes.Node
 	cri             ContainerRuntime
 	kubeadmVersion  *K8sVersion.Version
-	settings        *NodeSettings
 	etcdImage       string
 	skip            bool
 	commandMutators []commandMutator

--- a/kinder/pkg/cri/containerd/actionhelper.go
+++ b/kinder/pkg/cri/containerd/actionhelper.go
@@ -17,8 +17,6 @@ limitations under the License.
 package containerd
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 
 	"k8s.io/kubeadm/kinder/pkg/cluster/status"
@@ -29,7 +27,7 @@ func PreLoadUpgradeImages(n *status.Node, srcFolder string) error {
 	// NB. this code is an extract from "sigs.k8s.io/kind/pkg/build/node"
 	return n.Command(
 		"bash", "-c",
-		`find `+fmt.Sprintf("%s", srcFolder)+` -name *.tar -print0 | xargs -0 -n 1 -P $(nproc) ctr --namespace=k8s.io images import --no-unpack && rm -rf `+fmt.Sprintf("%s", srcFolder)+`/*.tar`,
+		`find `+srcFolder+` -name *.tar -print0 | xargs -0 -n 1 -P $(nproc) ctr --namespace=k8s.io images import --no-unpack && rm -rf `+srcFolder+`/*.tar`,
 	).Silent().Run()
 }
 

--- a/kinder/pkg/cri/docker/actionhelper.go
+++ b/kinder/pkg/cri/docker/actionhelper.go
@@ -17,7 +17,6 @@ limitations under the License.
 package docker
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -29,7 +28,7 @@ import (
 func PreLoadUpgradeImages(n *status.Node, srcFolder string) error {
 	return n.Command(
 		"/bin/bash", "-c",
-		`find `+fmt.Sprintf("%s", srcFolder)+` -name *.tar -print0 | xargs -0 -n 1 -P $(nproc) docker load -i`,
+		`find `+srcFolder+` -name *.tar -print0 | xargs -0 -n 1 -P $(nproc) docker load -i`,
 	).Silent().Run()
 }
 

--- a/kinder/pkg/test/workflow/workflow.go
+++ b/kinder/pkg/test/workflow/workflow.go
@@ -186,13 +186,13 @@ func (w *Workflow) expandImports(file string) error {
 		if len(t.Args) != 0 {
 			return errors.Errorf("invalid workflow file %s: task #%d - args setting can't be combined with import directive", file, i+1)
 		}
-		if t.Force != false {
+		if t.Force {
 			return errors.Errorf("invalid workflow file %s: task #%d - force setting can't be combined with import directive", file, i+1)
 		}
 		if t.Timeout != 0 {
 			return errors.Errorf("invalid workflow file %s: task #%d - timeout setting can't be combined with import directive", file, i+1)
 		}
-		if t.IgnoreError != false {
+		if t.IgnoreError {
 			return errors.Errorf("invalid workflow file %s: task #%d - ignoreError setting can't be combined with import directive", file, i+1)
 		}
 


### PR DESCRIPTION
Enable static checks for .go files which was recently enabled in
the kubernetes/kubernetes repository too.

/kind feature cleanup
/priority backlog
