### PR TITLE
verify_manifest_lists: skip cloud-controller-manager for 1.16

### DIFF
--- a/tests/e2e/manifests/verify_manifest_lists.go
+++ b/tests/e2e/manifests/verify_manifest_lists.go
@@ -305,7 +305,10 @@ func getImageVersions(ver *version.Version, images map[string]string) error {
 	images["k8s-dns-dnsmasq-nanny"] = ""
 	// images outside the scope of kubeadm, but still using the k8s version
 	images["hyperkube"] = k8sVersionV
-	images["cloud-controller-manager"] = k8sVersionV
+	// the cloud-controller-manager image was removed for version v1.16
+	if ver.Major() == 1 && ver.Minor() < 16 {
+		images["cloud-controller-manager"] = k8sVersionV
+	}
 	// test the conformance image, but only for newer versions as it was added in v1.13.0-alpha.2
 	conformanceMinVer := version.MustParseSemantic("v1.13.0-alpha.2")
 	if ver.AtLeast(conformanceMinVer) {

--- a/tests/e2e/manifests/verify_manifest_lists.sh
+++ b/tests/e2e/manifests/verify_manifest_lists.sh
@@ -36,7 +36,7 @@ curl -sS "https://raw.githubusercontent.com/kubernetes/apimachinery/master/pkg/u
 popd
 
 # set GOPATH to the local directory
-export GOPATH=`readlink -e ./`
+export GOMODULE=on
 
 # run unit tests
 go test -v ./$VERSION_PATH/version.go ./$VERSION_PATH/version_test.go


### PR DESCRIPTION
xref https://github.com/kubernetes/kubernetes/pull/81029/files

The CCM image was removed for the release of 1.16.
Skip checking this image for versions 1.16*.

Also use go modules for running the test using the shell script, which makes things much faster if e.g. once has the apimachinery module locally already.
