### PR TITLE
fix E2E test upgrade-1-12-1-13

### DIFF
--- a/kinder/ci/workflows/upgrade-1.12-1.13.yaml
+++ b/kinder/ci/workflows/upgrade-1.12-1.13.yaml
@@ -8,5 +8,6 @@ vars:
   initVersion: "{{ resolve `ci/latest-1.12` }}"
   upgradeVersion: "{{ resolve `ci/latest-1.13` }}"
   controlPlaneNodes: 3
+  externalEtcd: true
 tasks:
 - import: upgrade-tasks.yaml

--- a/kinder/ci/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-tasks.yaml
@@ -9,6 +9,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 1
   workerNodes: 2
+  externalEtcd: false
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-upgrade
@@ -49,6 +50,7 @@ tasks:
     - --image={{ .vars.image }}
     - --control-plane-nodes={{ .vars.controlPlaneNodes }}
     - --worker-nodes={{ .vars.workerNodes }}
+    - --external-etcd={{ .vars.externalEtcd }}
     - --loglevel=debug
   timeout: 5m
 - name: init


### PR DESCRIPTION
this PR fix failingE2E test upgrade-1-12-1-13 
error: "unable to add a new control plane instance on a cluster that doesn't use an external etcd"