### PR TITLE
kinder: support for building docker base-image

### DIFF
--- a/kinder/cmd/kinder/build/baseimage/baseimage.go
+++ b/kinder/cmd/kinder/build/baseimage/baseimage.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baseimage
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/kubeadm/kinder/pkg/build/base"
+	kindbase "sigs.k8s.io/kind/pkg/build/base"
+)
+
+type flagpole struct {
+	Source string
+	Image  string
+	CRI    string
+}
+
+// NewCommand returns a new cobra.Command for building the base image
+func NewCommand() *cobra.Command {
+	flags := &flagpole{}
+	cmd := &cobra.Command{
+		Args: cobra.NoArgs,
+		// TODO: more detailed usage
+		Use:   "base-image",
+		Short: "build the base node image",
+		Long:  `build the base node image for running nested containers, systemd, and kubernetes components.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags, cmd, args)
+		},
+	}
+	cmd.Flags().StringVar(
+		&flags.Source, "source",
+		"",
+		"path to the base image sources, autodetected by default",
+	)
+	cmd.Flags().StringVar(
+		&flags.Image, "image",
+		kindbase.DefaultImage,
+		"name:tag of the resulting image to be built",
+	)
+	cmd.Flags().StringVar(
+		&flags.CRI, "cri",
+		"containerd",
+		"container runtime to be added to the image. Use one of [docker, containerd]",
+	)
+	return cmd
+}
+
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	switch strings.ToLower(flags.CRI) {
+	case "containerd":
+		// Use build base image from Kind
+		ctx := kindbase.NewBuildContext(
+			kindbase.WithImage(flags.Image),
+			kindbase.WithSourceDir(flags.Source),
+		)
+		if err := ctx.Build(); err != nil {
+			return errors.Wrap(err, "build failed")
+		}
+		return nil
+	case "docker":
+		// Use build base image from kinder
+		ctx := base.NewBuildContext(
+			base.WithImage(flags.Image),
+			base.WithSourceDir(flags.Source),
+		)
+		if err := ctx.Build(); err != nil {
+			return errors.Wrap(err, "build failed")
+		}
+		return nil
+	default:
+		return errors.Errorf("%s container runtime is not supported. Use one of [docker, containerd]", flags.CRI)
+	}
+}

--- a/kinder/cmd/kinder/build/build.go
+++ b/kinder/cmd/kinder/build/build.go
@@ -19,8 +19,8 @@ package build
 import (
 	"github.com/spf13/cobra"
 
+	"k8s.io/kubeadm/kinder/cmd/kinder/build/baseimage"
 	"k8s.io/kubeadm/kinder/cmd/kinder/build/nodevariant"
-	kindbaseimage "sigs.k8s.io/kind/cmd/kind/build/baseimage"
 	kindnodeimage "sigs.k8s.io/kind/cmd/kind/build/nodeimage"
 )
 
@@ -34,7 +34,7 @@ func NewCommand() *cobra.Command {
 		Long:  "Build the base node image (base-image) or the node image (node-image) or node image variants (node-variant)",
 	}
 	// add subcommands
-	cmd.AddCommand(kindbaseimage.NewCommand())
+	cmd.AddCommand(baseimage.NewCommand())
 	cmd.AddCommand(kindnodeimage.NewCommand())
 	cmd.AddCommand(nodevariant.NewCommand())
 	return cmd

--- a/kinder/cmd/kinder/build/build/TODO.md
+++ b/kinder/cmd/kinder/build/build/TODO.md
@@ -1,1 +1,0 @@
-Add code for generating a kind(er) base images with docker container runtime installed internally

--- a/kinder/doc/kind-kinder.md
+++ b/kinder/doc/kind-kinder.md
@@ -78,6 +78,8 @@ back new feautures.
 
 - "sigs.k8s.io/kind/cmd/*" for
     - providing access to kind commands from a single UX
+- "sigs.k8s.io/kind/pkg/build/base" for
+    - building a containerd base image
 - "sigs.k8s.io/kind/pkg/build/node" for
     - `DefaultImage` constant (*)
 - "sigs.k8s.io/kind/pkg/cluster/constants" for

--- a/kinder/images/base/docker/Dockerfile
+++ b/kinder/images/base/docker/Dockerfile
@@ -1,0 +1,98 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# kind cluster base image, built on ubuntu:18.04
+#
+# To this we add systemd and other tools needed to run Kubeadm
+#
+# For systemd + docker configuration used below, see the following references:
+# https://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/
+# https://developers.redhat.com/blog/2014/05/05/running-systemd-within-docker-container/
+# https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container/
+
+ARG BASE_IMAGE="ubuntu:18.04"
+FROM ${BASE_IMAGE}
+
+# setting DEBIAN_FRONTEND=noninteractive stops some apt warnings, this is not
+# a real argument, we're (ab)using ARG to get a temporary ENV again.
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY clean-install /usr/local/bin/clean-install
+RUN chmod +x /usr/local/bin/clean-install
+
+# Get dependencies
+# The base image already has: ssh, apt, snapd
+# This is broken down into (each on a line):
+# - packages necessary for installing docker
+# - packages needed to run services (systemd)
+# - packages needed for docker / hyperkube / kubernetes components
+# - misc packages (utilities we use in our own tooling)
+# Then we cleanup (removing unwanted systemd services)
+# Finally we disable kmsg in journald
+# https://developers.redhat.com/blog/2014/05/05/running-systemd-within-docker-container/
+RUN clean-install \
+      apt-transport-https ca-certificates curl software-properties-common gnupg2 lsb-release \
+      systemd systemd-sysv libsystemd0 \
+      conntrack iptables iproute2 ethtool socat util-linux mount ebtables udev kmod aufs-tools \
+      bash rsync \
+    && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-tmpfiles-setup.service" -delete \
+    && rm -f /lib/systemd/system/multi-user.target.wants/* \
+    && rm -f /etc/systemd/system/*.wants/* \
+    && rm -f /lib/systemd/system/local-fs.target.wants/* \
+    && rm -f /lib/systemd/system/sockets.target.wants/*udev* \
+    && rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
+    && rm -f /lib/systemd/system/basic.target.wants/* \
+    && echo "ReadKMsg=no" >> /etc/systemd/journald.conf
+
+# Install docker, which needs to happen after we install some of the packages above
+# based on https://docs.docker.com/install/linux/docker-ce/ubuntu/#set-up-the-repository
+# and https://kubernetes.io/docs/setup/independent/install-kubeadm/#installing-docker
+# - get docker's GPG key
+# - add the fingerprint
+# - add the repository
+# - update apt, install docker, cleanup
+# NOTE: 18.06 is officially supported by Kubernetes currently, so we pin to that.
+# https://kubernetes.io/docs/tasks/tools/install-kubeadm/
+ARG DOCKER_VERSION="18.06.*"
+# another temporary env, not a real argument. setting this to a non-zero value
+# silences this warning from apt-key:
+# "Warning: apt-key output should not be parsed (stdout is not a terminal)"
+ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE="false"
+RUN curl -fsSL "https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg" | apt-key add - \
+    && apt-key fingerprint 0EBFCD88 \
+    && add-apt-repository \
+        "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" \
+    && clean-install "docker-ce=${DOCKER_VERSION}"
+
+# tell systemd that it is in docker (it will check for the container env)
+# https://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/
+ENV container docker
+# systemd exits on SIGRTMIN+3, not SIGTERM (which re-executes it)
+# https://bugzilla.redhat.com/show_bug.cgi?id=1201657
+STOPSIGNAL SIGRTMIN+3
+
+# wrap systemd with our special entrypoint, see pkg/build for how this is built
+# basically this just lets us set up some things before continuing on to systemd
+# while preserving that systemd is PID1
+# for how we leverage this, see pkg/cluster
+COPY [ "entrypoint/entrypoint", "/usr/local/bin/" ]
+# We need systemd to be PID1 to run the various services (docker, kubelet, etc.)
+# NOTE: this is *only* for documentation, the entrypoint is overridden at runtime
+ENTRYPOINT [ "/usr/local/bin/entrypoint", "/sbin/init" ]
+
+# the docker graph must be a volume to avoid overlay on overlay
+# NOTE: we do this last because changing a volume with a Dockerfile must
+# occur before defining it.
+# See: https://docs.docker.com/engine/reference/builder/#volume
+VOLUME [ "/var/lib/docker" ]

--- a/kinder/images/base/docker/README.md
+++ b/kinder/images/base/docker/README.md
@@ -1,0 +1,4 @@
+Docker support was dropped in kind 0.3.0 in favour of containerd.
+
+This package is based on kind 0.2.1, but then the code evolved in order to keep up with kind evolution and to adapt
+to the kinder specific needs/code organization (e.g. no usage of kindnet).

--- a/kinder/images/base/docker/clean-install
+++ b/kinder/images/base/docker/clean-install
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script encapsulating a common Dockerimage pattern for installing packages
+# and then cleaning up the unnecessary install artifacts.
+# e.g. clean-install iptables ebtables conntrack
+
+set -o errexit
+
+if [ $# = 0 ]; then
+  echo >&2 "No packages specified"
+  exit 1
+fi
+
+apt-get update
+apt-get install -y --no-install-recommends $@
+apt-get clean -y
+rm -rf \
+   /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /var/log/* \
+   /tmp/* \
+   /var/tmp/*

--- a/kinder/images/base/docker/entrypoint/main.go
+++ b/kinder/images/base/docker/entrypoint/main.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This implements our image entrypoint. It:
+- waits for SIGUSR1
+- then execs (argv[1], argv[1:], env[:])
+This allows us to perform other actions in the "node" container via `docker exec`
+_before_ we have actually "booted" the init and everything else along with it.
+We can then send SIGUSR1 to this process to trigger starting the "actual"
+entrypoint when we are done preforming any provisioning on the "node".
+NOTE: this is implemented as a single go1.X file, using only the stdlib.
+This makes it easier to build portably, and is all we need for what it does.
+*/
+
+// Entrypoint implements a small docker image entrypoint that waits for SIGUSR1
+// before execing os.Args[1:]
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"log"
+)
+
+// yes this should be the c macro, but on linux in docker you're going to get this anyhow
+// http://man7.org/linux/man-pages/man7/signal.7.html
+// https://github.com/moby/moby/blob/562df8c2d6f48601c8d1df7256389569d25c0bf1/pkg/signal/signal_linux.go#L10
+const sigrtmin = 34
+
+func main() {
+	// prevent zombie processes since we will be PID1 for a while
+	// https://linux.die.net/man/2/waitpid
+	signal.Ignore(syscall.SIGCHLD)
+
+	// grab the "real" entrypoint command and args from our args
+	if len(os.Args) < 2 {
+		log.Fatal("Not enough arguments to entrypoint!")
+	}
+	cmd, argv := os.Args[1], os.Args[1:]
+
+	// wait for SIGUSR1 (or exit on SIGRTMIN+3 to match systemd)
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGUSR1, syscall.Signal(sigrtmin+3))
+	log.Println("Waiting for SIGUSR1 ...")
+	sig := <-c
+	if sig != syscall.SIGUSR1 {
+		log.Printf("Exiting after signal: %v != SIGUSR1", sig)
+		return
+	}
+
+	// then exec to the "real" entrypoint, keeping the env
+	log.Printf("Received SIGUSR1, execing to: %v %v\n", cmd, argv)
+	syscall.Exec(cmd, argv, os.Environ())
+}

--- a/kinder/pkg/build/base/README.md
+++ b/kinder/pkg/build/base/README.md
@@ -1,0 +1,4 @@
+Docker support was dropped in kind 0.3.0 in favour of containerd.
+
+This package is based on kind 0.2.1, but then the code evolved in order to keep up with kind evolution and to adapt
+to the kinder specific needs/code organization (e.g. no usage of kindnet).

--- a/kinder/pkg/build/base/base.go
+++ b/kinder/pkg/build/base/base.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package base implements functionality to build the kind base image
+package base
+
+import (
+	"go/build"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/kind/pkg/exec"
+	"sigs.k8s.io/kind/pkg/fs"
+	"sigs.k8s.io/kind/pkg/util"
+)
+
+// DefaultImage is the default name:tag of the built base image
+const DefaultImage = "kindest/base:latest"
+
+// BuildContext is used to build the kind node base image, and contains
+// build configuration
+type BuildContext struct {
+	// option fields
+	sourceDir string
+	image     string
+	// non option fields
+	goCmd string // TODO: should be an option possibly
+	arch  string // TODO: should be an option
+}
+
+// Option is BuildContext configuration option supplied to NewBuildContext
+type Option func(*BuildContext)
+
+// WithSourceDir configures a NewBuildContext to use the source dir `sourceDir`
+func WithSourceDir(sourceDir string) Option {
+	return func(b *BuildContext) {
+		b.sourceDir = sourceDir
+	}
+}
+
+// WithImage configures a NewBuildContext to tag the built image with `name`
+func WithImage(image string) Option {
+	return func(b *BuildContext) {
+		b.image = image
+	}
+}
+
+// NewBuildContext creates a new BuildContext with
+// default configuration
+func NewBuildContext(options ...Option) *BuildContext {
+	ctx := &BuildContext{
+		image: DefaultImage,
+		goCmd: "go",
+		arch:  util.GetArch(),
+	}
+	for _, option := range options {
+		option(ctx)
+	}
+	return ctx
+}
+
+// Build builds the cluster node image, the sourcedir must be set on
+// the NodeImageBuildContext
+func (c *BuildContext) Build() (err error) {
+	// create tempdir to build in
+	tmpDir, err := fs.TempDir("", "kind-base-image")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// populate with image sources
+	// if SourceDir is unset then try to autodetect source dir
+	buildDir := tmpDir
+	if c.sourceDir == "" {
+		pkg, err := build.Default.Import("k8s.io/kubeadm/kinder", build.Default.GOPATH, build.FindOnly)
+		if err != nil {
+			return errors.Wrap(err, "failed to locate sources")
+		}
+		c.sourceDir = filepath.Join(pkg.Dir, "images", "base", "docker")
+	}
+
+	err = fs.Copy(c.sourceDir, buildDir)
+	if err != nil {
+		log.Errorf("failed to copy sources to build dir %v", err)
+		return err
+	}
+
+	log.Infof("Building base image in: %s", buildDir)
+
+	// build the entrypoint binary first
+	if err := c.buildEntrypoint(buildDir); err != nil {
+		return err
+	}
+
+	// then the actual docker image
+	return c.buildImage(buildDir)
+}
+
+// builds the entrypoint binary
+func (c *BuildContext) buildEntrypoint(dir string) error {
+	// NOTE: this binary only uses the go1 stdlib, and is a single file
+	entrypointSrc := filepath.Join(dir, "entrypoint", "main.go")
+	entrypointDest := filepath.Join(dir, "entrypoint", "entrypoint")
+
+	cmd := exec.Command(c.goCmd, "build", "-o", entrypointDest, entrypointSrc)
+	cmd.SetEnv(append(os.Environ(), "GOOS=linux", "GOARCH="+c.arch)...)
+
+	// actually build
+	log.Info("Building entrypoint binary ...")
+	exec.InheritOutput(cmd)
+	if err := cmd.Run(); err != nil {
+		log.Errorf("Entrypoint build Failed! %v", err)
+		return err
+	}
+	log.Info("Entrypoint build completed.")
+	return nil
+}
+
+func (c *BuildContext) buildImage(dir string) error {
+	// build the image, tagged as tagImageAs, using the our tempdir as the context
+	cmd := exec.Command("docker", "build", "-t", c.image, dir)
+	log.Info("Starting Docker build ...")
+	exec.InheritOutput(cmd)
+	err := cmd.Run()
+	if err != nil {
+		log.Errorf("Docker build Failed! %v", err)
+		return err
+	}
+	log.Info("Docker build completed.")
+	return nil
+}


### PR DESCRIPTION
This PR adds in kinder support for building docker base-image
xref: https://github.com/kubernetes/kubeadm/issues/1759