### PR TITLE
tests/e2e/manifests: fix missing module name

### DIFF
--- a/tests/e2e/manifests/verify_manifest_lists.sh
+++ b/tests/e2e/manifests/verify_manifest_lists.sh
@@ -31,7 +31,7 @@ cd "$LPATH"
 
 # use go modules. this forces using the latest k8s.io/apimachinery package.
 export GO111MODULE=on
-go mod init
+go mod init verify-manifest-lists
 
 # run unit tests
 go test -v ./verify_manifest_lists.go ./verify_manifest_lists_test.go


### PR DESCRIPTION
Given the test folder is outside of GOPATH this can cause
a problem if the module name is missing:

```
go: cannot determine module path for source directory
/workspace/k8s.io/kubeadm/tests/e2e/  manifests (outside GOPATH,
no import comments)
```

fixes https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-all#periodic-manifest-lists