### PR TITLE
operator: organize imports

### DIFF
--- a/operator/api/v1alpha1/operation_types.go
+++ b/operator/api/v1alpha1/operation_types.go
@@ -18,8 +18,9 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	operatorerrors "k8s.io/kubeadm/operator/errors"
 	"k8s.io/utils/pointer"
+
+	operatorerrors "k8s.io/kubeadm/operator/errors"
 )
 
 // OperationSpec defines the spec of an Operation to be performed by the kubeadm-operator.

--- a/operator/api/v1alpha1/runtimetask_types.go
+++ b/operator/api/v1alpha1/runtimetask_types.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	operatorerrors "k8s.io/kubeadm/operator/errors"
 	"k8s.io/utils/pointer"
+
+	operatorerrors "k8s.io/kubeadm/operator/errors"
 )
 
 // RuntimeTaskSpec defines the desired state of RuntimeTask

--- a/operator/api/v1alpha1/runtimetaskgroup_types.go
+++ b/operator/api/v1alpha1/runtimetaskgroup_types.go
@@ -18,8 +18,9 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	operatorerrors "k8s.io/kubeadm/operator/errors"
 	"k8s.io/utils/pointer"
+
+	operatorerrors "k8s.io/kubeadm/operator/errors"
 )
 
 // RuntimeTaskGroupSpec defines the RuntimeTask template that applies to a group of nodes that should

--- a/operator/controllers/operation_controller.go
+++ b/operator/controllers/operation_controller.go
@@ -24,13 +24,14 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/tools/record"
-	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
-	operatorerrors "k8s.io/kubeadm/operator/errors"
-	"k8s.io/kubeadm/operator/operations"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
+	operatorerrors "k8s.io/kubeadm/operator/errors"
+	"k8s.io/kubeadm/operator/operations"
 )
 
 // OperationReconciler reconciles a Operation object

--- a/operator/controllers/runtimetask_reconcile.go
+++ b/operator/controllers/runtimetask_reconcile.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
+
 	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
 )
 

--- a/operator/controllers/runtimetaskgroup_controller.go
+++ b/operator/controllers/runtimetaskgroup_controller.go
@@ -25,8 +25,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
-	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
-	operatorerrors "k8s.io/kubeadm/operator/errors"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -34,6 +32,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
+	operatorerrors "k8s.io/kubeadm/operator/errors"
 )
 
 // RuntimeTaskGroupReconciler reconciles a RuntimeTaskGroup object

--- a/operator/controllers/suite_test.go
+++ b/operator/controllers/suite_test.go
@@ -25,11 +25,12 @@ import (
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/operator/controllers/util.go
+++ b/operator/controllers/util.go
@@ -31,12 +31,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
-	"k8s.io/kubeadm/operator/operations"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
+	"k8s.io/kubeadm/operator/operations"
 )
 
 func getImage(c client.Client, namespace, name string) (string, error) {

--- a/operator/hack/update-goimports.sh
+++ b/operator/hack/update-goimports.sh
@@ -23,5 +23,5 @@ source "$(dirname "$0")/utils.sh"
 # cd to the root path
 cd_root_path
 
-# update go imports
-goimports -w ./
+# update go imports, skipping generated files
+git ls-files | grep "\.go$" | grep -v -e "zz_generated" | xargs goimports -local k8s.io/kubeadm/operator -w

--- a/operator/hack/verify-goimports.sh
+++ b/operator/hack/verify-goimports.sh
@@ -47,7 +47,7 @@ go build > /dev/null
 popd > /dev/null
 
 # check for goimports diffs
-diff=$(git ls-files | grep "\.go$" | xargs "${BIN_PATH}/goimports" -d  2>&1)
+diff=$(git ls-files | grep "\.go$" | grep -v -e "zz_generated" | xargs "${BIN_PATH}/goimports" -local k8s.io/kubeadm/operator -d  2>&1)
 if [[ -n "${diff}" ]]; then
   echo "${diff}"
   echo

--- a/operator/main.go
+++ b/operator/main.go
@@ -25,9 +25,10 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog"
 	"k8s.io/klog/klogr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
 	"k8s.io/kubeadm/operator/controllers"
-	ctrl "sigs.k8s.io/controller-runtime"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/operator/operations/factory.go
+++ b/operator/operations/factory.go
@@ -18,6 +18,7 @@ package operations
 
 import (
 	"github.com/pkg/errors"
+
 	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
 )
 

--- a/operator/operations/util.go
+++ b/operator/operations/util.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
 )
 


### PR DESCRIPTION
This changeset makes operator imports sorted as described in #1867.

I also added `-local k8s.io/kubeadm/operator` to **goimports** command, so it will enforce making the 3rd group of imports belonging to "kubeadm/operator". I don't know if this flag is appreciated across kubernetes org; if it's not, I can remove that.