### PR TITLE
kinder: remove "sigs.k8s.io/kind/pkg/build/node" dependency

### DIFF
--- a/kinder/cmd/kinder/build/baseimage/baseimage.go
+++ b/kinder/cmd/kinder/build/baseimage/baseimage.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/kubeadm/kinder/pkg/build/base"
+	"k8s.io/kubeadm/kinder/pkg/constants"
 	kindbase "sigs.k8s.io/kind/pkg/build/base"
 )
 
@@ -51,7 +52,7 @@ func NewCommand() *cobra.Command {
 	)
 	cmd.Flags().StringVar(
 		&flags.Image, "image",
-		kindbase.DefaultImage,
+		constants.DefaultBaseImage,
 		"name:tag of the resulting image to be built",
 	)
 	cmd.Flags().StringVar(

--- a/kinder/cmd/kinder/build/nodevariant/nodevariant.go
+++ b/kinder/cmd/kinder/build/nodevariant/nodevariant.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubeadm/kinder/pkg/build/alter"
-	kindebuildnode "sigs.k8s.io/kind/pkg/build/node"
+	"k8s.io/kubeadm/kinder/pkg/constants"
 )
 
 type flagpole struct {
@@ -50,12 +50,12 @@ func NewCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(
 		&flags.Image, "image",
-		kindebuildnode.DefaultImage,
+		constants.DefaultNodeImage,
 		"name:tag of the resulting image to be built",
 	)
 	cmd.Flags().StringVar(
 		&flags.BaseImage, "base-image",
-		kindebuildnode.DefaultImage,
+		constants.DefaultBaseImage,
 		"name:tag of the source image; this can be a kindest/base image or kindest/node image",
 	)
 	cmd.Flags().StringVar(

--- a/kinder/cmd/kinder/create/cluster/createcluster.go
+++ b/kinder/cmd/kinder/create/cluster/createcluster.go
@@ -81,7 +81,7 @@ func NewCommand() *cobra.Command {
 	)
 	cmd.Flags().StringVar(
 		&flags.ImageName,
-		"image", "",
+		"image", constants.DefaultNodeImage,
 		"node docker image to use for booting the cluster",
 	)
 	cmd.Flags().BoolVar(

--- a/kinder/doc/kind-kinder.md
+++ b/kinder/doc/kind-kinder.md
@@ -80,8 +80,6 @@ back new features.
     - providing access to kind commands from a single UX
 - "sigs.k8s.io/kind/pkg/build/base" for
     - building a containerd base image
-- "sigs.k8s.io/kind/pkg/build/node" for
-    - `DefaultImage` constant (*)
 - "sigs.k8s.io/kind/pkg/cluster/constants" for
     - constants
 - "sigs.k8s.io/kind/pkg/cluster/config/*" for

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -26,6 +26,12 @@ import (
 // constants inherited from kind.
 // those values are replicated here with the goal to keep under strict control kind dependencies
 const (
+	// DefaultNodeImage is the default name:tag for a base image
+	DefaultBaseImage = "kindest/base:latest"
+
+	// DefaultNodeImage is the default name:tag for a node image
+	DefaultNodeImage = "kindest/node:latest"
+
 	// ControlPlaneNodeRoleValue identifies a node that hosts a Kubernetes
 	// control-plane.
 	//


### PR DESCRIPTION
Little cleanup trying to make easier future upgrades of the kind release