### PR TITLE
kinder: remove unused kind cmd

### DIFF
--- a/kinder/cmd/kinder/build/build.go
+++ b/kinder/cmd/kinder/build/build.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/kubeadm/kinder/cmd/kinder/build/baseimage"
 	"k8s.io/kubeadm/kinder/cmd/kinder/build/nodevariant"
-	kindnodeimage "sigs.k8s.io/kind/cmd/kind/build/nodeimage"
 )
 
 // NewCommand returns a new cobra.Command for building
@@ -35,7 +34,6 @@ func NewCommand() *cobra.Command {
 	}
 	// add subcommands
 	cmd.AddCommand(baseimage.NewCommand())
-	cmd.AddCommand(kindnodeimage.NewCommand())
 	cmd.AddCommand(nodevariant.NewCommand())
 	return cmd
 }

--- a/kinder/cmd/kinder/kinder.go
+++ b/kinder/cmd/kinder/kinder.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/kubeadm/kinder/pkg/constants"
 	kinddelete "sigs.k8s.io/kind/cmd/kind/delete"
 	kindexport "sigs.k8s.io/kind/cmd/kind/export"
-	kindload "sigs.k8s.io/kind/cmd/kind/load"
 	kindlog "sigs.k8s.io/kind/pkg/log"
 )
 
@@ -76,7 +75,6 @@ func NewCommand() *cobra.Command {
 	// add kind top level subcommands re-used without changes
 	cmd.AddCommand(kinddelete.NewCommand())
 	cmd.AddCommand(kindexport.NewCommand())
-	cmd.AddCommand(kindload.NewCommand())
 
 	// add kind commands commands customized in kind
 	cmd.AddCommand(build.NewCommand())

--- a/kinder/doc/kind-kinder.md
+++ b/kinder/doc/kind-kinder.md
@@ -14,8 +14,9 @@ new Kubernetes cluster from "bare" machines running into a container to a workin
 
 ## Differences
 
-All the [kind](https://github.com/kubernetes-sigs/kind) commands will be available in kinder,
-side by side with additional commands designed for helping kubeadm contributors.
+Kinder provider an UX designed for helping kubeadm contributors and for kubeadm E2E tests;
+Only few of the [kind](https://github.com/kubernetes-sigs/kind) commands will be available in kinder,
+because they are useful for the use cases targeted by kinder.
 
 _Building images:_
 - kinder support both containerd and docker as container runtime inside the images
@@ -77,7 +78,7 @@ new use cases, share lesson learned, issues and solutions, and ultimately contri
 back new features.
 
 - "sigs.k8s.io/kind/cmd/*" for
-    - providing access to kind commands from a single UX
+    - providing access to few kind commands useful for the use cases targeted by kinder
 - "sigs.k8s.io/kind/pkg/build/base" for
     - building a containerd base image
 - "sigs.k8s.io/kind/pkg/build/node" for


### PR DESCRIPTION
Little cleanup trying to make easier future upgrades of the kind release

Please note that both` kind build node-image` and `kind load` command does not work with kinder images based on docker

Also, kinder offers a `kinder build node-variants` that replaces the above command in all the kubeadm E2E tests and makes it easier to load locally build artifacts for developers.
