### PR TITLE
Create E2E jobs for 1.17

### DIFF
--- a/kinder/ci/workflows/discovery-1.17.yaml
+++ b/kinder/ci/workflows/discovery-1.17.yaml
@@ -1,0 +1,10 @@
+version: 1
+summary: |
+  This workflow implements a sequence of tasks used for testing alternative
+  discovery methods for kubeadm join.
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-discovery-1-17
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.17` }}"
+tasks:
+- import: discovery-tasks.yaml

--- a/kinder/ci/workflows/external-etcd-1.17.yaml
+++ b/kinder/ci/workflows/external-etcd-1.17.yaml
@@ -1,0 +1,11 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of deploying an HA
+  cluster with secret copy using an external etcd cluster
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-etcd-1.17
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.17` }}"
+tasks:
+- import: external-etcd.yaml

--- a/kinder/ci/workflows/kustomize-1.17.yaml
+++ b/kinder/ci/workflows/kustomize-1.17.yaml
@@ -1,0 +1,10 @@
+version: 1
+summary: |
+  This workflow implements a sequence of tasks used for testing alternative
+  discovery methods for kubeadm join.
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kustomize-1-17
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kustomize.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.17` }}"
+tasks:
+- import: kustomize-tasks.yaml

--- a/kinder/ci/workflows/skew-1.17-on-1.16.yaml
+++ b/kinder/ci/workflows/skew-1.17-on-1.16.yaml
@@ -1,11 +1,11 @@
 version: 1
 summary: |
-  This workflow tests the proper functioning of kubeadm version from master with Kubernetes v1.16
-  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-master-on-1.16
+  This workflow tests the proper functioning of kubeadm version v1.17 with Kubernetes v1.16
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1-17-on-1-16
   config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
   config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
 vars:
-  kubeadmVersion: "{{ resolve `ci/latest` }}"
+  kubeadmVersion: "{{ resolve `ci/latest-1.17` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.16` }}"
   controlPlaneNodes: 3
 tasks:

--- a/kinder/ci/workflows/skew-master-on-1.17.yaml
+++ b/kinder/ci/workflows/skew-master-on-1.17.yaml
@@ -1,0 +1,12 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of kubeadm version from master with Kubernetes v1.17
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-master-on-1.17
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
+  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+vars:
+  kubeadmVersion: "{{ resolve `ci/latest` }}"
+  kubernetesVersion: "{{ resolve `ci/latest-1.17` }}"
+  controlPlaneNodes: 3
+tasks:
+- import: skew-x-on-y-tasks-automatic-copy-certs.yaml

--- a/kinder/ci/workflows/upgrade-1.16-1.17.yaml
+++ b/kinder/ci/workflows/upgrade-1.16-1.17.yaml
@@ -1,12 +1,12 @@
 version: 1
 summary: |
-  this workflow test kubeadm upgrades from Kubernetes ci/latest-1.16 version to Kubernetes ci/latest version
-  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-upgrade-1-16-master
+  this workflow test kubeadm upgrades from Kubernetes ci/latest-1.16 version to Kubernetes ci/latest-1.17 version
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-upgrade-1-16-1-17
   config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
   config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
 vars:
   initVersion: "{{ resolve `ci/latest-1.16` }}"
-  upgradeVersion: "{{ resolve `ci/latest` }}"
+  upgradeVersion: "{{ resolve `ci/latest-1.17` }}"
   controlPlaneNodes: 3
 tasks:
 - import: upgrade-tasks-automatic-copy-certs.yaml

--- a/kinder/ci/workflows/upgrade-1.17-master.yaml
+++ b/kinder/ci/workflows/upgrade-1.17-master.yaml
@@ -1,0 +1,12 @@
+version: 1
+summary: |
+  this workflow test kubeadm upgrades from Kubernetes ci/latest-1.17 version to Kubernetes ci/latest version
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-upgrade-1-17-master
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+vars:
+  initVersion: "{{ resolve `ci/latest-1.17` }}"
+  upgradeVersion: "{{ resolve `ci/latest` }}"
+  controlPlaneNodes: 3
+tasks:
+- import: upgrade-tasks-automatic-copy-certs.yaml


### PR DESCRIPTION
This PR:

- Creates E2E jobs for kubernetes 1.17
- Changes master jobs to use 1.17 instead of 1.16

As proposed in #1871

test-infra PR: https://github.com/kubernetes/test-infra/pull/15077