### PR TITLE
fix-master-on-v1.16

### DIFF
--- a/kinder/pkg/cluster/manager/actions/cluster-info.go
+++ b/kinder/pkg/cluster/manager/actions/cluster-info.go
@@ -59,12 +59,13 @@ func CluterInfo(c *status.Cluster) error {
 			"--",
 			"etcdctl", fmt.Sprintf("--endpoints=https://127.0.0.1:2379"),
 		}
-		if cp1.MustKubeadmVersion().AtLeast(constants.V1_17) {
+
+		// Before v1.17 the etcd version installed by default by kubeadm was using --ca-file, --cert-file, --key-file flags; in newer etcd releases those flags are renamed
+		if cp1.MustKubeVersion().AtLeast(constants.V1_17) {
 			etcdArgs = append(etcdArgs,
 				"--cacert=/etc/kubernetes/pki/etcd/ca.crt", "--cert=/etc/kubernetes/pki/etcd/peer.crt", "--key=/etc/kubernetes/pki/etcd/peer.key",
 			)
 		} else {
-			// before v1.17, etcdctl was using --ca-file, --cert-file, --key-file flags
 			etcdArgs = append(etcdArgs,
 				"--ca-file=/etc/kubernetes/pki/etcd/ca.crt", "--cert-file=/etc/kubernetes/pki/etcd/peer.crt", "--key-file=/etc/kubernetes/pki/etcd/peer.key",
 			)

--- a/kinder/pkg/cluster/status/node.go
+++ b/kinder/pkg/cluster/status/node.go
@@ -359,3 +359,19 @@ func (n *Node) CopyTo(source, dest string) error {
 func (n *Node) KubeVersion() (version string, err error) {
 	return n.kindNode.KubeVersion()
 }
+
+// MustKubeVersion returns the Kubernetes version installed on the node or panics
+// if a valid Kubernetes version can't be identified.
+func (n *Node) MustKubeVersion() *K8sVersion.Version {
+	v, err := n.KubeVersion()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	sv, err := K8sVersion.ParseSemantic(v)
+	if err != nil {
+		panic(err)
+	}
+
+	return sv
+}


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/84690

latest release of etcdctl renamed some flags; this PR makes kinder use the right flags according to the kubernetes version installed in the cluster