### PR TITLE
kinder: add a test job family for running regular tests

### DIFF
--- a/kinder/ci/kubeadm-periodic.tests.md
+++ b/kinder/ci/kubeadm-periodic.tests.md
@@ -28,7 +28,7 @@ might be eventually repeated across all/a subset of the Kubernetes versions in s
 ### Regular tests
 
 Kubeadm regular test are meant to create a cluster with `kubeadm init`, `kubeadm join` and then verify cluster
-conformance. Following regular tests are verified using kind (no need of kinder customization so far):
+conformance.
 
 | Version          | e.g.   |                                                              |
 | ---------------- | ------ | ------------------------------------------------------------ |
@@ -36,9 +36,6 @@ conformance. Following regular tests are verified using kind (no need of kinder 
 | current<br />(release-1.16 branch) | v1.16.2-alpha...  | Current GA release              |
 | current -1/minor<br />(release-1.15 branch)  | V1.15.6-alpha...   | Former GA release, still officially supported |
 | current -2/minor<br />(release-1.14 branch)  | V1.14.10-alpha...  | Former GA release, still officially supported for one more cycle |
-
-NB. currently kind tests are build Kubernetes from the selected branch. This is slightly different from what
-kinder is doing, that is to use an existing CI/Release build.
 
 ### Upgrade tests
 

--- a/kinder/ci/workflows/regular-1.14.yaml
+++ b/kinder/ci/workflows/regular-1.14.yaml
@@ -1,0 +1,9 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of the latest 1.14 version of both kubeadm and Kubernetes
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1.14
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.14` }}"
+tasks:
+- import: regular-tasks.yaml

--- a/kinder/ci/workflows/regular-1.15.yaml
+++ b/kinder/ci/workflows/regular-1.15.yaml
@@ -1,0 +1,9 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of the latest 1.15 version of both kubeadm and Kubernetes
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1.15
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.15` }}"
+tasks:
+- import: regular-tasks.yaml

--- a/kinder/ci/workflows/regular-1.16.yaml
+++ b/kinder/ci/workflows/regular-1.16.yaml
@@ -1,0 +1,9 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of the latest 1.16 version of both kubeadm and Kubernetes
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1.16
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.16` }}"
+tasks:
+- import: regular-tasks.yaml

--- a/kinder/ci/workflows/regular-1.17.yaml
+++ b/kinder/ci/workflows/regular-1.17.yaml
@@ -1,0 +1,9 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of the latest 1.17 version of both kubeadm and Kubernetes
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1.17
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.17` }}"
+tasks:
+- import: regular-tasks.yaml

--- a/kinder/ci/workflows/regular-master.yaml
+++ b/kinder/ci/workflows/regular-master.yaml
@@ -1,0 +1,9 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of the latest master version of both kubeadm and Kubernetes
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-master
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest` }}"
+tasks:
+- import: regular-tasks.yaml

--- a/kinder/ci/workflows/regular-tasks.yaml
+++ b/kinder/ci/workflows/regular-tasks.yaml
@@ -1,0 +1,135 @@
+# IMPORTANT! this workflow is imported by regular-* workflows.
+version: 1
+summary: |
+  This workflow implements a sequence of tasks used test the proper functioning
+  of kubeadm version X with Kubernetes version X.
+vars:
+  # vars defines default values for variable used by tasks in this workflow;
+  # those values might be overridden when importing this files.
+  kubernetesVersion: v1.13.5
+  controlPlaneNodes: 3
+  workerNodes: 2
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  image: kindest/node:test
+  clusterName: kinder-regular
+tasks:
+- name: pull-base-image
+  description: |
+    pulls kindest/base image with docker in docker and all the prerequisites necessary for running kind(er)
+  cmd: docker
+  args:
+    - pull
+    - "{{ .vars.baseImage }}"
+- name: add-kubernetes-versions
+  description: |
+    creates a node-image-variant by adding a Kubernetes version
+  cmd: kinder
+  args:
+    - build
+    - node-image-variant
+    - --base-image={{ .vars.baseImage }}
+    - --image={{ .vars.image }}
+    - --with-init-artifacts={{ .vars.kubernetesVersion }}
+    - --loglevel=debug
+  timeout: 10m
+- name: create-cluster
+  description: |
+    create a set of nodes ready for hosting the Kubernetes cluster
+  cmd: kinder
+  args:
+    - create
+    - cluster
+    - --name={{ .vars.clusterName }}
+    - --image={{ .vars.image }}
+    - --control-plane-nodes={{ .vars.controlPlaneNodes }}
+    - --worker-nodes={{ .vars.workerNodes }}
+    - --loglevel=debug
+  timeout: 5m
+- name: init
+  description: |
+    Initializes the Kubernetes cluster with version "initVersion"
+    by starting the boostrap control-plane nodes
+  cmd: kinder
+  args:
+    - do
+    - kubeadm-init
+    - --name={{ .vars.clusterName }}
+    - --loglevel=debug
+  timeout: 5m
+- name: join
+  description: |
+    Join the other nodes to the Kubernetes cluster
+  cmd: kinder
+  args:
+    - do
+    - kubeadm-join
+    - --name={{ .vars.clusterName }}
+    - --loglevel=debug
+  timeout: 10m
+- name: cluster-info
+  description: |
+    Runs cluster-info
+  cmd: kinder
+  args:
+    - do
+    - cluster-info
+    - --name={{ .vars.clusterName }}
+    - --loglevel=debug
+- name: e2e-kubeadm
+  description: |
+    Runs kubeadm e2e tests
+  cmd: kinder
+  args:
+    - test
+    - e2e-kubeadm
+    - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=06-e2e-kubeadm
+    - --name={{ .vars.clusterName }}
+    - --loglevel=debug
+- name: e2e
+  description: |
+    Runs Kubernetes e2e test (conformance)
+  cmd: kinder
+  args:
+    - test
+    - e2e
+    - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=07-e2e
+    - --parallel
+    - --name={{ .vars.clusterName }}
+    - --loglevel=debug
+  timeout: 25m
+- name: get-logs
+  description: |
+    Collects all the test logs
+  cmd: kinder
+  args:
+    - export
+    - logs
+    - --loglevel=debug
+    - --name={{ .vars.clusterName }}
+    - "{{ .env.ARTIFACTS }}"
+  force: true
+  timeout: 5m
+  # kind export log is know to be flaky, so we are temporary ignoring errors in order
+  # to make the test pass in case everything else passed
+  # see https://github.com/kubernetes-sigs/kind/issues/456
+  ignoreError: true
+- name: reset
+  description: |
+    Exec kubeadm reset
+  cmd: kinder
+  args:
+    - do
+    - kubeadm-reset
+    - --name={{ .vars.clusterName }}
+    - --loglevel=debug
+  force: true
+- name: delete
+  description: |
+    Deletes the cluster
+  cmd: kinder
+  args:
+    - delete
+    - cluster
+    - --name={{ .vars.clusterName }}
+    - --loglevel=debug
+  force: true


### PR DESCRIPTION
Currently these are done using kind and the kind kubetest deployer.
We are switching these test jobs to kinder for consistency
and better control.

The workflows do the following:
- pull a base image
- add artifacts for the target version
- create a 3CP2W cluster
- run cluster-info, e2e-kubeadm and e2e
- export logs, reset, delete the cluster

xref https://github.com/kubernetes/kubernetes/issues/84676
test-infra PR: https://github.com/kubernetes/test-infra/pull/15130

