### PR TITLE
make kinder refer to "kinder get kubeconfig-path"

### DIFF
--- a/kinder/pkg/cluster/manager/actions/kubeadm-init.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-init.go
@@ -293,7 +293,7 @@ func postInit(c *status.Cluster, wait time.Duration) error {
 	fmt.Printf(
 		"Cluster creation complete. You can now use the cluster with:\n\n"+
 
-			"export KUBECONFIG=\"$(kind get kubeconfig-path --name=%q)\"\n"+
+			"export KUBECONFIG=\"$(kinder get kubeconfig-path --name=%q)\"\n"+
 			"kubectl cluster-info\n",
 		c.Name(),
 	)


### PR DESCRIPTION
It referred to `kind`, which might have been a small typo or mistake.

In any case it's one tool less to install and you can just copy and paste what's on the screen.