### PR TITLE
kinder: use the etcd tag version for defining etcdctl flags

### DIFF
--- a/kinder/hack/verify-spelling.sh
+++ b/kinder/hack/verify-spelling.sh
@@ -38,7 +38,7 @@ URL="https://github.com/client9/misspell"
 echo "Cloning ${URL} in ${TMP_DIR}..."
 git clone --quiet --depth=1 "${URL}" "${TMP_DIR}"
 pushd "${TMP_DIR}" > /dev/null
-go mod init
+go mod init misspell
 popd > /dev/null
 
 # build misspell

--- a/kinder/pkg/cluster/manager/actions/cluster-info_test.go
+++ b/kinder/pkg/cluster/manager/actions/cluster-info_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actions
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAppendEtcdctlCertArgs(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputImage    string
+		inputArgs     []string
+		expectedArgs  []string
+		expectedError bool
+	}{
+		{
+			name:         "valid: version 3.4",
+			inputImage:   "etcd:3.4.0",
+			expectedArgs: etcdCertArgsNew,
+		},
+		{
+			name:         "valid: version 4.0",
+			inputImage:   "etcd:4.0.0",
+			expectedArgs: etcdCertArgsNew,
+		},
+		{
+			name:         "valid: old version",
+			inputImage:   "etcd:3.3.17",
+			expectedArgs: etcdCertArgsOld,
+		},
+		{
+			name:         "valid: append to existing args",
+			inputImage:   "etcd:3.4.0",
+			inputArgs:    []string{"foo"},
+			expectedArgs: append([]string{"foo"}, etcdCertArgsNew...),
+		},
+		{
+			name:          "invalid: image string missing ':'",
+			inputImage:    "3.4.0",
+			expectedError: true,
+		},
+		{
+			name:          "invalid: image tag is not semver",
+			inputImage:    "etcd:111",
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := test.inputArgs
+			err := appendEtcdctlCertArgs(test.inputImage, &args)
+			if (err != nil) != test.expectedError {
+				t.Fatalf("expected error: %v, found %v, error: %v", test.expectedError, err != nil, err)
+			}
+			if test.expectedError {
+				return
+			}
+			if !reflect.DeepEqual(args, test.expectedArgs) {
+				t.Fatalf("expected args: %v, found %v", test.expectedArgs, args)
+			}
+		})
+	}
+}

--- a/operator/hack/verify-spelling.sh
+++ b/operator/hack/verify-spelling.sh
@@ -38,7 +38,7 @@ URL="https://github.com/client9/misspell"
 echo "Cloning ${URL} in ${TMP_DIR}..."
 git clone --quiet --depth=1 "${URL}" "${TMP_DIR}"
 pushd "${TMP_DIR}" > /dev/null
-go mod init
+go mod init misspell
 popd > /dev/null
 
 # build misspell


### PR DESCRIPTION
etcdctl needs different cert arguments for 3.4+ and older.
Execute EtcdImage() on the bootstrap control plane to obtain the
active etcd image version. This should solve issues where after
upgrade or skew tests the version of etcdctl does not match
the /kind/version version.

The alternative is to add means to update /kind/version for
certain workflows and "do" actions.
