### PR TITLE
fix a bug in kinder related to 'docker cp'

### DIFF
--- a/kinder/pkg/cluster/manager/manage.go
+++ b/kinder/pkg/cluster/manager/manage.go
@@ -154,12 +154,16 @@ func (c *ClusterManager) CopyFile(source, target string) error {
 
 	if teargetNodes == nil {
 		fmt.Printf("Copying from %s ...\n", sourceNodes[0].Name())
-		sourceNodes[0].CopyFrom(sourcePath, targetPath)
+		if err := sourceNodes[0].CopyFrom(sourcePath, targetPath); err != nil {
+			return err
+		}
 	}
 
 	for _, n := range teargetNodes {
 		fmt.Printf("Copying to %s ...\n", n.Name())
-		n.CopyTo(sourcePath, targetPath)
+		if err := n.CopyTo(sourcePath, targetPath); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/kinder/pkg/cluster/manager/manage.go
+++ b/kinder/pkg/cluster/manager/manage.go
@@ -122,12 +122,12 @@ func (c *ClusterManager) CopyFile(source, target string) error {
 		return err
 	}
 
-	teargetNodes, targetPath, err := c.ResolveNodesPath(target)
+	targetNodes, targetPath, err := c.ResolveNodesPath(target)
 	if err != nil {
 		return err
 	}
 
-	if sourceNodes == nil && teargetNodes == nil {
+	if sourceNodes == nil && targetNodes == nil {
 		return errors.Errorf("at least one between source and target must be a node/nodes in the cluster")
 	}
 
@@ -142,24 +142,24 @@ func (c *ClusterManager) CopyFile(source, target string) error {
 		}
 	}
 
-	if teargetNodes != nil && len(teargetNodes) == 0 {
+	if targetNodes != nil && len(targetNodes) == 0 {
 		return errors.Errorf("no target node matches given criteria")
 	}
 
-	if sourceNodes != nil && teargetNodes != nil {
+	if sourceNodes != nil && targetNodes != nil {
 		// create tmp folder
 		// cp locally
 		return errors.Errorf("copy between nodes not implemented yet!")
 	}
 
-	if teargetNodes == nil {
+	if targetNodes == nil {
 		fmt.Printf("Copying from %s ...\n", sourceNodes[0].Name())
 		if err := sourceNodes[0].CopyFrom(sourcePath, targetPath); err != nil {
 			return err
 		}
 	}
 
-	for _, n := range teargetNodes {
+	for _, n := range targetNodes {
 		fmt.Printf("Copying to %s ...\n", n.Name())
 		if err := n.CopyTo(sourcePath, targetPath); err != nil {
 			return err

--- a/kinder/pkg/cluster/status/node.go
+++ b/kinder/pkg/cluster/status/node.go
@@ -407,8 +407,8 @@ func (n *Node) IP() (ipv4 string, ipv6 string, err error) {
 func (n *Node) CopyFrom(source, dest string) error {
 	cmd := kindexec.Command(
 		"docker", "cp",
-		source,          // from the source file
-		n.name+":"+dest, // to the node, at dest
+		n.name+":"+source, // from the node, at source
+		dest,              // to the host, at dest
 	)
 	return cmd.Run()
 }
@@ -417,8 +417,8 @@ func (n *Node) CopyFrom(source, dest string) error {
 func (n *Node) CopyTo(source, dest string) error {
 	cmd := kindexec.Command(
 		"docker", "cp",
-		n.name+":"+source, // from the node, at src
-		dest,              // to the host
+		source,          // from the host, at source
+		n.name+":"+dest, // to the node, at dest
 	)
 	return cmd.Run()
 }


### PR DESCRIPTION
commits:
```
kinder: fix a bug when coping files from or to a container 
kinder: handle errors from Node#CopyTo() and Node#CopyFrom()
kinder: fix typo in manager/manage.go
```

https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kustomize-master
