### PR TITLE
kinder: fix more etcd image related issues

### DIFF
--- a/kinder/pkg/cluster/manager/actions/cluster-info.go
+++ b/kinder/pkg/cluster/manager/actions/cluster-info.go
@@ -64,18 +64,27 @@ func CluterInfo(c *status.Cluster) error {
 		etcdArgs := []string{
 			"--kubeconfig=/etc/kubernetes/admin.conf", "exec", "-n=kube-system", fmt.Sprintf("etcd-%s", c.BootstrapControlPlane().Name()),
 			"--",
-			"etcdctl", fmt.Sprintf("--endpoints=https://127.0.0.1:2379"),
+			"etcdctl",
 		}
 
-		etcdImage, err := cp1.EtcdImage()
+		// Get the version of etcdctl
+		versionArgs := append(etcdArgs, "version")
+		lines, err := cp1.Command("kubectl", versionArgs...).RunAndCapture()
 		if err != nil {
 			return err
 		}
-		if err := appendEtcdctlCertArgs(etcdImage, &etcdArgs); err != nil {
+		etcdctlVersion, err := parseEtcdctlVersion(lines)
+		if err != nil {
 			return err
 		}
 
-		etcdArgs = append(etcdArgs, "member", "list")
+		// Append version specific etcdctl certificate flags
+		if err := appendEtcdctlCertArgs(etcdctlVersion, &etcdArgs); err != nil {
+			return err
+		}
+
+		fmt.Printf("Using etcdctl version: %s\n", etcdctlVersion)
+		etcdArgs = append(etcdArgs, "--endpoints=https://127.0.0.1:2379", "member", "list")
 
 		if err := cp1.Command(
 			"kubectl", etcdArgs...,
@@ -89,21 +98,28 @@ func CluterInfo(c *status.Cluster) error {
 	return nil
 }
 
-// appendEtcdctlCertArgs takes an etcd "image:tag" and appends etcdctl certificate arguments
-// to a existing list of arguments based on the version in "tag"
-func appendEtcdctlCertArgs(etcdImage string, etcdArgs *[]string) error {
-	// Obtain the etcd version from the etcd image
-	etcdImageElements := strings.Split(etcdImage, ":")
-	if len(etcdImageElements) < 2 {
-		return errors.Errorf("cannot parse etcd version from image %q", etcdImage)
+// parseEtcdctlVersion takes the output lines of 'etcdctl version' and returns the version
+func parseEtcdctlVersion(lines []string) (string, error) {
+	if len(lines) < 1 {
+		return "", errors.New("expected at least one line from the output of 'etcdctl version'")
 	}
-	etcdVersion, err := versionutils.ParseGeneric(etcdImageElements[1])
+	elements := strings.Split(lines[0], ":")
+	if len(elements) != 2 {
+		return "", errors.New("expected ':' on the first line of 'etcdctl version'")
+	}
+	return strings.TrimSpace(elements[1]), nil
+}
+
+// appendEtcdctlCertArgs takes an etcd version and appends etcdctl certificate arguments
+// to a existing list of arguments based on the version
+func appendEtcdctlCertArgs(etcdVersion string, etcdArgs *[]string) error {
+	version, err := versionutils.ParseGeneric(etcdVersion)
 	if err != nil {
 		return errors.Wrap(err, "cannot parse etcd version")
 	}
 
 	// Before 3.4.0, etcdctl was using --ca-file, --cert-file, --key-file flags; in newer etcdctl releases those flags are renamed
-	if etcdVersion.AtLeast(versionutils.MustParseGeneric("v3.4.0")) {
+	if version.AtLeast(versionutils.MustParseGeneric("v3.4.0")) {
 		*etcdArgs = append(*etcdArgs, etcdCertArgsNew...)
 	} else {
 		*etcdArgs = append(*etcdArgs, etcdCertArgsOld...)

--- a/kinder/pkg/cluster/status/node.go
+++ b/kinder/pkg/cluster/status/node.go
@@ -47,6 +47,7 @@ type Node struct {
 	ipv6            string
 	cri             ContainerRuntime
 	kubeadmVersion  *K8sVersion.Version
+	etcdImage       string
 	skip            bool
 	commandMutators []commandMutator
 }

--- a/kinder/pkg/cluster/status/node.go
+++ b/kinder/pkg/cluster/status/node.go
@@ -40,17 +40,15 @@ type commandMutator = func(*cmd.ProxyCmd) *cmd.ProxyCmd
 // Node defines a K8s node running in a kinde(er) docker container or a container hosting
 // one external dependency of the cluster, like etcd or the load balancer.
 type Node struct {
-	name              string
-	role              string
-	ports             map[int32]int32
-	ipv4              string
-	ipv6              string
-	kubernetesVersion string
-	cri               ContainerRuntime
-	kubeadmVersion    *K8sVersion.Version
-	etcdImage         string
-	skip              bool
-	commandMutators   []commandMutator
+	name            string
+	role            string
+	ports           map[int32]int32
+	ipv4            string
+	ipv6            string
+	cri             ContainerRuntime
+	kubeadmVersion  *K8sVersion.Version
+	skip            bool
+	commandMutators []commandMutator
 }
 
 // NodeSettings defines a set of settings that will be stored in the node and re-used
@@ -425,10 +423,6 @@ func (n *Node) CopyTo(source, dest string) error {
 
 // KubeVersion returns the Kubernetes version installed on the node
 func (n *Node) KubeVersion() (version string, err error) {
-	// use the cached version first
-	if n.kubernetesVersion != "" {
-		return n.kubernetesVersion, nil
-	}
 	// grab kubernetes version from the node image
 	lines, err := n.Command("cat", "/kind/version").RunAndCapture()
 	if err != nil {
@@ -437,10 +431,7 @@ func (n *Node) KubeVersion() (version string, err error) {
 	if len(lines) != 1 {
 		return "", errors.Errorf("file should only be one line, got %d lines", len(lines))
 	}
-	version = lines[0]
-	n.kubernetesVersion = version
-
-	return version, nil
+	return lines[0], nil
 }
 
 // MustKubeVersion returns the Kubernetes version installed on the node or panics


### PR DESCRIPTION
xref https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-upgrade-1-16-1-17

```
kinder: do not cache the kubernetesVersion  …
The call is cheap and caching can present issues when the version
is changed in the container.
 
kinder: call etcdctl flags based on the etcdctl version  …
- call etcdctl from the etcd container and get its version
- append the version specific etcdctl cert flags based on the version
```
