### PR TITLE
kinder: improve workflow verification

### DIFF
--- a/kinder/ci/tools/verify-workflow.go
+++ b/kinder/ci/tools/verify-workflow.go
@@ -17,7 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
+	log "github.com/sirupsen/logrus"
+	"io/ioutil"
 	"os"
 
 	ktestworkflow "k8s.io/kubeadm/kinder/pkg/test/workflow"
@@ -25,16 +26,18 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Println("error: missing file argument")
-		fmt.Println("usage: verify-workflow some-file.yaml")
+		log.Infoln("error: missing file argument")
+		log.Infoln("usage: verify-workflow some-file.yaml")
 		os.Exit(1)
 	}
 	file := os.Args[1]
-	fmt.Printf("Verifying %s...", file)
-	_, err := ktestworkflow.NewWorkflow(file)
+	log.Infof("Verifying %s...", file)
+	w, err := ktestworkflow.NewWorkflow(file)
 	if err != nil {
-		fmt.Printf("FAILED\n%v\n", err)
-		os.Exit(1)
+		log.Fatalf("error: failed to create workflow: %v\n", err)
 	}
-	fmt.Println("OK")
+	if err := w.Run(ioutil.Discard, true, false, true, "ARTIFACTS"); err != nil {
+		log.Fatalf("error: failed to run workflow: %v\n", err)
+	}
+	log.Infof("%s OK", file)
 }

--- a/kinder/cmd/kinder/test/workflow/workflow.go
+++ b/kinder/cmd/kinder/test/workflow/workflow.go
@@ -18,6 +18,7 @@ package workflow
 
 import (
 	"github.com/spf13/cobra"
+	"os"
 
 	"k8s.io/kubeadm/kinder/pkg/test/workflow"
 )
@@ -76,5 +77,5 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return w.Run(flags.DryRun, flags.Verbose, flags.ExitOnError, artifacts)
+	return w.Run(os.Stdout, flags.DryRun, flags.Verbose, flags.ExitOnError, artifacts)
 }

--- a/kinder/hack/verify-workflows.sh
+++ b/kinder/hack/verify-workflows.sh
@@ -46,5 +46,7 @@ while read -r file; do
 done <<< "$FILES"
 
 if [[ "${ERR}" == "1" ]]; then
+    echo ""
+    echo "Found errors in workflow files! See output above..."
     exit 1
 fi

--- a/kinder/pkg/test/workflow/taskCmdBuilder.go
+++ b/kinder/pkg/test/workflow/taskCmdBuilder.go
@@ -92,7 +92,7 @@ var funcMap = template.FuncMap{
 // expand takes a string that might contain a golang template and process it
 // using Vars and Env variables as a context
 func (c *taskCmdBuilder) expand(text string) (string, error) {
-	templ, err := template.New("").Funcs(funcMap).Parse(text)
+	templ, err := template.New("").Option("missingkey=error").Funcs(funcMap).Parse(text)
 	if err != nil {
 		return "", errors.Wrapf(err, "%q is not a valid expression", text)
 	}


### PR DESCRIPTION
- make verify-workflow.go use logrus, to be consistent with the
underlying API functions it's calling.
- dry-run a workflow as part of verification
- allow passing a io.Writer to workflow.Run, when calling from
kinder use os.Stdout, when called from the verify-workflow pass
ioutil.Discard
- print better message in verify-workflows.sh
- handle missing template vars via "missingkey=error"
- use logrus.Debug for shadowed variables
