### PR TITLE
kinder: don't use "docker cp /dev/stdin"

### DIFF
--- a/kinder/pkg/cluster/manager/actions/copy-certs.go
+++ b/kinder/pkg/cluster/manager/actions/copy-certs.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 
 	"k8s.io/kubeadm/kinder/pkg/cluster/status"
-	"k8s.io/kubeadm/kinder/pkg/constants"
 )
 
 // CopyCertificates actions automate the manual copy of
@@ -73,12 +72,8 @@ func copyCertificatesToNode(c *status.Cluster, n *status.Node) error {
 			return errors.Wrapf(err, "failed to read certificate %s from %s", fileName, c.BootstrapControlPlane().Name())
 		}
 		// copies from tmp area to joining node
-		if err := n.Command(
-			"cp", "/dev/stdin", containerPath,
-		).Stdin(
-			strings.NewReader(strings.Join(lines, "\n")),
-		).Silent().Run(); err != nil {
-			return errors.Wrapf(err, "failed to write %s", constants.KubeadmConfigPath)
+		if err := n.WriteFile(containerPath, []byte(strings.Join(lines, "\n"))); err != nil {
+			return err
 		}
 	}
 

--- a/kinder/pkg/cluster/manager/actions/kubeadm-init.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-init.go
@@ -392,17 +392,9 @@ func copyPatchesToNode(n *status.Node, dir string) error {
 		hostPath := filepath.Join(dir, file.Name())
 		nodePath := filepath.Join(constants.KustomizeDir, file.Name())
 
-		content, err := ioutil.ReadFile(hostPath)
-		if err != nil {
-			return errors.Wrapf(err, "failed to read %s", hostPath)
-		}
-
-		if err := n.Command(
-			"cp", "/dev/stdin", nodePath,
-		).Stdin(
-			bytes.NewReader(content),
-		).Silent().Run(); err != nil {
-			return errors.Wrapf(err, "failed to write %s", nodePath)
+		if err := n.CopyTo(hostPath, nodePath); err != nil {
+			errors.Wrapf(err, "failed to copy from host path %q to node path %q for node %q",
+				hostPath, nodePath, n.Name())
 		}
 	}
 

--- a/kinder/pkg/cluster/manager/actions/loadbalancer.go
+++ b/kinder/pkg/cluster/manager/actions/loadbalancer.go
@@ -18,7 +18,6 @@ package actions
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -73,10 +72,7 @@ func LoadBalancer(c *status.Cluster, nodes ...*status.Node) error {
 	// create loadbalancer config on the node
 	log.Debugf("Writing loadbalancer config on %s...", lb.Name())
 
-	if err = lb.Command("cp", "/dev/stdin", constants.LoadBalancerConfigPath).
-		Stdin(strings.NewReader(loadbalancerConfig)).
-		Silent().
-		Run(); err != nil {
+	if err := lb.WriteFile(constants.LoadBalancerConfigPath, []byte(loadbalancerConfig)); err != nil {
 		return errors.Wrap(err, "failed to copy loadbalancer config to node")
 	}
 


### PR DESCRIPTION
potential fix for https://github.com/kubernetes/kubeadm/issues/1918

Similar flakes were seen in kind when the command "export logs"
is used. The command also uses "/dev/stdin" for copying between
host and container. As much as being a speculation the "/dev/stdin"
flakes could be a Docker bug.

Create a utility function Node#WriteFile that instead of
using /dev/stdin uses a temporary file on the host and copies
the contents of the file to the node.

Use this function in a number of locations instead of using
"docker cp /dev/stdin ...".