### PR TITLE
kinder: remove kind cluster dependencies

### DIFF
--- a/kinder/cmd/kinder/get/get.go
+++ b/kinder/cmd/kinder/get/get.go
@@ -21,8 +21,8 @@ import (
 
 	"k8s.io/kubeadm/kinder/cmd/kinder/get/artifacts"
 	"k8s.io/kubeadm/kinder/cmd/kinder/get/clusters"
-	kindgetkubeconfig "sigs.k8s.io/kind/cmd/kind/get/kubeconfigpath"
-	kindgetnodes "sigs.k8s.io/kind/cmd/kind/get/nodes"
+	"k8s.io/kubeadm/kinder/cmd/kinder/get/kubeconfigpath"
+	"k8s.io/kubeadm/kinder/cmd/kinder/get/nodes"
 )
 
 // NewCommand returns a new cobra.Command for get
@@ -37,8 +37,8 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(clusters.NewCommand())
 
 	// add kind top level subcommands re-used without changes
-	cmd.AddCommand(kindgetnodes.NewCommand())
-	cmd.AddCommand(kindgetkubeconfig.NewCommand())
+	cmd.AddCommand(nodes.NewCommand())
+	cmd.AddCommand(kubeconfigpath.NewCommand())
 
 	// add kinder only commands
 	cmd.AddCommand(artifacts.NewCommand())

--- a/kinder/cmd/kinder/get/kubeconfigpath/kubeconfigpath.go
+++ b/kinder/cmd/kinder/get/kubeconfigpath/kubeconfigpath.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clusters
+package kubeconfigpath
 
 import (
 	"fmt"
@@ -22,29 +22,31 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubeadm/kinder/pkg/cluster/status"
+	"k8s.io/kubeadm/kinder/pkg/constants"
 )
 
-// NewCommand returns a new cobra.Command for getting the list of clusters
-func NewCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Args:  cobra.NoArgs,
-		Use:   "clusters",
-		Short: "Lists existing kind clusters by their name",
-		Long:  "Lists existing kind clusters by their name",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runE(cmd, args)
-		},
-	}
-	return cmd
+type flagpole struct {
+	Name string
 }
 
-func runE(cmd *cobra.Command, args []string) error {
-	clusters, err := status.ListClusters()
-	if err != nil {
-		return err
+// NewCommand returns a new cobra.Command for getting the list of nodes in a cluster
+func NewCommand() *cobra.Command {
+	flags := &flagpole{}
+
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "kubeconfig-path",
+		Short: "Prints the default kubeconfig path for the kind cluster by --name",
+		Long:  "Prints the default kubeconfig path for the kind cluster by --name",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println(status.KubeConfigPath(flags.Name))
+			return nil
+		},
 	}
-	for _, cluster := range clusters {
-		fmt.Println(cluster)
-	}
-	return nil
+
+	cmd.Flags().StringVar(
+		&flags.Name,
+		"name", constants.DefaultClusterName, "cluster name",
+	)
+	return cmd
 }

--- a/kinder/cmd/kinder/get/nodes/nodes.go
+++ b/kinder/cmd/kinder/get/nodes/nodes.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clusters
+package nodes
 
 import (
 	"fmt"
@@ -22,29 +22,42 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubeadm/kinder/pkg/cluster/status"
+	"k8s.io/kubeadm/kinder/pkg/constants"
 )
 
-// NewCommand returns a new cobra.Command for getting the list of clusters
+type flagpole struct {
+	Name string
+}
+
+// NewCommand returns a new cobra.Command for getting the list of nodes in a cluster
 func NewCommand() *cobra.Command {
+	flags := &flagpole{}
+
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
-		Use:   "clusters",
-		Short: "Lists existing kind clusters by their name",
-		Long:  "Lists existing kind clusters by their name",
+		Use:   "nodes",
+		Short: "Lists existing nodes in kind clusters by their name",
+		Long:  "Lists existing nodes in kind clusters by their name",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runE(cmd, args)
+			return runE(flags, cmd, args)
 		},
 	}
+
+	cmd.Flags().StringVar(
+		&flags.Name,
+		"name", constants.DefaultClusterName, "cluster name",
+	)
 	return cmd
 }
 
-func runE(cmd *cobra.Command, args []string) error {
-	clusters, err := status.ListClusters()
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	cluster, err := status.FromDocker(flags.Name)
 	if err != nil {
 		return err
 	}
-	for _, cluster := range clusters {
-		fmt.Println(cluster)
+
+	for _, node := range cluster.AllNodes() {
+		fmt.Println(node.Name())
 	}
 	return nil
 }


### PR DESCRIPTION
This PR removes `kind` dependencies when calling `kinder get nodes` and `kinder get kubeconfig-path`. It addresses issue #1902.