### PR TITLE
kinder: add --volume option to configure mount volumes on containers

### DIFF
--- a/kinder/pkg/cluster/manager/create.go
+++ b/kinder/pkg/cluster/manager/create.go
@@ -39,6 +39,7 @@ type CreateOptions struct {
 	externalLoadBalancer bool
 	externalEtcd         bool
 	retain               bool
+	volumes              []string
 }
 
 // CreateOption is a configuration option supplied to Create
@@ -81,10 +82,17 @@ func ExternalLoadBalancer(externalLoadBalancer bool) CreateOption {
 	}
 }
 
-// Retain option instructs create cluster to preserve node in case of errors for debuggin pouposes
+// Retain option instructs create cluster to preserve node in case of errors for debugging purposes
 func Retain(retain bool) CreateOption {
 	return func(c *CreateOptions) {
 		c.retain = retain
+	}
+}
+
+// Volumes option instructs create cluster to add volumes to the node containers
+func Volumes(volumes []string) CreateOption {
+	return func(c *CreateOptions) {
+		c.volumes = volumes
 	}
 }
 
@@ -180,7 +188,7 @@ func createNodes(clusterName string, flags *CreateOptions) error {
 			case constants.ExternalLoadBalancerNodeRoleValue:
 				return createHelper.CreateExternalLoadBalancer(clusterName, desiredNode.Name)
 			case constants.ControlPlaneNodeRoleValue, constants.WorkerNodeRoleValue:
-				return createHelper.CreateNode(clusterName, desiredNode.Name, flags.image, desiredNode.Role)
+				return createHelper.CreateNode(clusterName, desiredNode.Name, flags.image, desiredNode.Role, flags.volumes)
 			default:
 				return nil
 			}

--- a/kinder/pkg/cri/containerd/createhelper.go
+++ b/kinder/pkg/cri/containerd/createhelper.go
@@ -22,13 +22,13 @@ import (
 )
 
 // CreateNode creates a container that internally hosts the containerd cri runtime
-func CreateNode(cluster, name, image, role string) error {
+func CreateNode(cluster, name, image, role string, volumes []string) error {
 	args, err := util.CommonArgs(cluster, name, role)
 	if err != nil {
 		return err
 	}
 
-	args, err = util.RunArgsForNode(role, args)
+	args, err = util.RunArgsForNode(role, volumes, args)
 	if err != nil {
 		return err
 	}

--- a/kinder/pkg/cri/createhelper.go
+++ b/kinder/pkg/cri/createhelper.go
@@ -41,12 +41,12 @@ func NewCreateHelper(cri status.ContainerRuntime) (*CreateHelper, error) {
 }
 
 // CreateNode creates a container that internally hosts the selected cri runtime
-func (h *CreateHelper) CreateNode(cluster, name, image, role string) error {
+func (h *CreateHelper) CreateNode(cluster, name, image, role string, volumes []string) error {
 	switch h.cri {
 	case status.ContainerdRuntime:
-		return containerd.CreateNode(cluster, name, image, role)
+		return containerd.CreateNode(cluster, name, image, role, volumes)
 	case status.DockerRuntime:
-		return docker.CreateNode(cluster, name, image, role)
+		return docker.CreateNode(cluster, name, image, role, volumes)
 	}
 	return errors.Errorf("unknown cri: %s", h.cri)
 }

--- a/kinder/pkg/cri/docker/createhelper.go
+++ b/kinder/pkg/cri/docker/createhelper.go
@@ -29,13 +29,13 @@ import (
 )
 
 // CreateNode creates a container that internally hosts the docker cri runtime
-func CreateNode(cluster, name, image, role string) error {
+func CreateNode(cluster, name, image, role string, volumes []string) error {
 	args, err := util.CommonArgs(cluster, name, role)
 	if err != nil {
 		return err
 	}
 
-	args, err = util.RunArgsForNode(role, args)
+	args, err = util.RunArgsForNode(role, volumes, args)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,6 @@ func fixMachineID(name string) error {
 
 func runArgsForDocker(args []string) []string {
 	args = append(args,
-		// define a minimal etcd (insecure, single node, not exposed to the host machine)
 		"--entrypoint=/usr/local/bin/entrypoint",
 	)
 

--- a/kinder/pkg/cri/util/util.go
+++ b/kinder/pkg/cri/util/util.go
@@ -134,7 +134,7 @@ func usernsRemap() bool {
 }
 
 // RunArgsForNode computes docker run arguments that apply to containers that should host K8s nodes
-func RunArgsForNode(role string, args []string) ([]string, error) {
+func RunArgsForNode(role string, volumes []string, args []string) ([]string, error) {
 	args = append(args,
 		// running containers in a container requires privileged
 		// NOTE: we could try to replicate this with --cap-add, and use less
@@ -155,6 +155,10 @@ func RunArgsForNode(role string, args []string) ([]string, error) {
 		// some k8s things want to read /lib/modules
 		"--volume", "/lib/modules:/lib/modules:ro",
 	)
+
+	for _, v := range volumes {
+		args = append(args, "--volume", v)
+	}
 
 	if role == constants.ControlPlaneNodeRoleValue {
 		// API server port mapping


### PR DESCRIPTION
After removing support for the kind config, kinder lost some features.
Some users showed interest in mount volumes (e.g. for mounting sources folders inside containers) and this PR is an MVP for restoring mount volumes.

/assign @neolit123
/area kinder
/kind cleanup
/priority backlog
/milestone next

/hold
until release cut