### PR TITLE
kinder: enable "echo mode" for copy commands

### DIFF
--- a/kinder/pkg/cluster/status/node.go
+++ b/kinder/pkg/cluster/status/node.go
@@ -393,7 +393,7 @@ func (n *Node) CopyFrom(source, dest string) error {
 		n.name+":"+source, // from the node, at source
 		dest,              // to the host, at dest
 	)
-	return cmd.Run()
+	return cmd.RunWithEcho()
 }
 
 // CopyTo copies the source file on the host to dest on the node
@@ -403,7 +403,7 @@ func (n *Node) CopyTo(source, dest string) error {
 		source,          // from the host, at source
 		n.name+":"+dest, // to the node, at dest
 	)
-	return cmd.Run()
+	return cmd.RunWithEcho()
 }
 
 // WriteFile writes a temporary file with the given contents and copies the file to the node container


### PR DESCRIPTION
With hope that this will explain the occasional flakes
when copying the cluster settings to a node.

could not reproduce this locally, so maybe it's a RAM issue.

yet we do set 9000Mi and kinder takes around 7GB while creating a 3CP,2W cluster.
https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml#L41

xref https://github.com/kubernetes/kubeadm/issues/1918
https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-master
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-master/1206284863246700545/build-log.txt

```
time="18:51:58" level=error msg="failed to write cluster settings to node kinder-regular-control-plane-2: failed to write /kinder/cluster-settings.yaml: exit status 1"
Error: failed to create cluster: failed to write cluster settings to node kinder-regular-control-plane-2: failed to write /kinder/cluster-settings.yaml: exit status 1
```
