### PR TITLE
kinder: add higher kubeadm verbosity to all workflow tasks

### DIFF
--- a/kinder/ci/workflows/discovery-tasks.yaml
+++ b/kinder/ci/workflows/discovery-tasks.yaml
@@ -10,6 +10,7 @@ vars:
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-discovery
+  kubeadmVerbosity: 6
 tasks:
 - name: pull-base-image
   description: |
@@ -53,6 +54,7 @@ tasks:
     - kubeadm-init
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: join
   description: |
@@ -65,6 +67,7 @@ tasks:
     - --only-node=kinder-discovery-worker
     - --discovery-mode=file
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: join
   description: |
@@ -77,6 +80,7 @@ tasks:
     - --only-node=kinder-discovery-worker2
     - --discovery-mode=file-with-token
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: join
   description: |
@@ -89,6 +93,7 @@ tasks:
     - --only-node=kinder-discovery-worker3
     - --discovery-mode=file-with-embedded-client-certificates
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: join
   description: |
@@ -101,6 +106,7 @@ tasks:
     - --only-node=kinder-discovery-worker4
     - --discovery-mode=file-with-external-client-certificates
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: e2e-kubeadm
   description: |
@@ -137,6 +143,7 @@ tasks:
     - kubeadm-reset
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   force: true
 - name: delete
   description: |

--- a/kinder/ci/workflows/external-etcd.yaml
+++ b/kinder/ci/workflows/external-etcd.yaml
@@ -7,6 +7,7 @@ vars:
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-external-etcd
+  kubeadmVerbosity: 6
 tasks:
 - name: pull-base-image
   description: |
@@ -53,6 +54,7 @@ tasks:
     - --automatic-copy-certs
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: join
   description: |
@@ -64,6 +66,7 @@ tasks:
     - --automatic-copy-certs
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: e2e-kubeadm
   description: |
@@ -112,6 +115,7 @@ tasks:
     - kubeadm-reset
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   force: true
 - name: delete
   description: |

--- a/kinder/ci/workflows/presubmit-upgrade-master.yaml
+++ b/kinder/ci/workflows/presubmit-upgrade-master.yaml
@@ -11,6 +11,7 @@ vars:
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-pull
+  kubeadmVerbosity: 6
 tasks:
 - name: pull-base-image
   description: |
@@ -57,6 +58,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --automatic-copy-certs
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: join
   description: |
@@ -68,6 +70,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --automatic-copy-certs
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: upgrade
   description: |
@@ -79,6 +82,7 @@ tasks:
     - --upgrade-version={{ .vars.upgradeVersion }}
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
 - name: cluster-info
   description: |
     Runs cluster-info
@@ -132,6 +136,7 @@ tasks:
     - kubeadm-reset
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   force: true
 - name: delete
   description: |

--- a/kinder/ci/workflows/regular-tasks.yaml
+++ b/kinder/ci/workflows/regular-tasks.yaml
@@ -12,6 +12,7 @@ vars:
   baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-regular
+  kubeadmVerbosity: 6
 tasks:
 - name: pull-base-image
   description: |
@@ -55,6 +56,7 @@ tasks:
     - kubeadm-init
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: join
   description: |
@@ -65,6 +67,7 @@ tasks:
     - kubeadm-join
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 10m
 - name: cluster-info
   description: |
@@ -122,6 +125,7 @@ tasks:
     - kubeadm-reset
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   force: true
 - name: delete
   description: |

--- a/kinder/ci/workflows/skew-x-on-y-tasks-automatic-copy-certs.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks-automatic-copy-certs.yaml
@@ -13,6 +13,7 @@ vars:
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-xony
+  kubeadmVerbosity: 6
 tasks:
 - name: pull-base-image
   description: |
@@ -59,6 +60,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --automatic-copy-certs
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: join
   description: |
@@ -70,6 +72,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --automatic-copy-certs
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: cluster-info
   description: |
@@ -127,6 +130,7 @@ tasks:
     - kubeadm-reset
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   force: true
 - name: delete
   description: |

--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -13,6 +13,7 @@ vars:
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-xony
+  kubeadmVerbosity: 6
 tasks:
 # Important! this workflow differs from skew-x-on-y-tasks-automatic-copy-certs.yaml
 # - e2e-kubeadm is not run (nb. e2e-kubeadm was heavily refactored in v1.15 cycle)
@@ -63,6 +64,8 @@ tasks:
     - do
     - kubeadm-init
     - --name={{ .vars.clusterName }}
+    - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: join
   description: |
@@ -73,6 +76,7 @@ tasks:
     - kubeadm-join
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: cluster-info
   description: |
@@ -120,6 +124,7 @@ tasks:
     - kubeadm-reset
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   force: true
 - name: delete
   description: |

--- a/kinder/ci/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-tasks.yaml
@@ -13,6 +13,7 @@ vars:
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-upgrade
+  kubeadmVerbosity: 6
 tasks:
 # Important! this workflow differs from upgrade-tasks-automatic-copy-certs.yaml
 # - e2e-kubeadm is not run (nb. e2e-kubeadm was heavily refactored in v1.15 cycle)
@@ -66,6 +67,7 @@ tasks:
     - kubeadm-init
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: join
   description: |
@@ -76,6 +78,7 @@ tasks:
     - kubeadm-join
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: cluster-info-before
   description: |
@@ -96,6 +99,7 @@ tasks:
     - --upgrade-version={{ .vars.upgradeVersion }}
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: cluster-info-after
   description: |
@@ -143,6 +147,7 @@ tasks:
     - kubeadm-reset
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   force: true
 - name: delete
   description: |


### PR DESCRIPTION
was adding higher verbosity for the upgrade jobs to debug https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-upgrade-1-17-master

but instead added it to all workflows.

will probably self-LGTM due to no folks being around during the holidays.
