### PR TITLE
kinder: enable verbose output for two more workflows

### DIFF
--- a/kinder/ci/workflows/kustomize-tasks.yaml
+++ b/kinder/ci/workflows/kustomize-tasks.yaml
@@ -10,6 +10,7 @@ vars:
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-kustomize
+  kubeadmVerbosity: 6
 tasks:
   - name: pull-base-image
     description: |
@@ -138,6 +139,7 @@ tasks:
       - --name={{ .vars.clusterName }}
       - -k=/tmp/kubeadm-patches
       - --loglevel=debug
+      - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
     timeout: 5m
   - name: join
     description: |
@@ -149,6 +151,7 @@ tasks:
       - --name={{ .vars.clusterName }}
       - -k=/tmp/kubeadm-patches
       - --loglevel=debug
+      - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
     timeout: 5m
   - name: run verify-kustomize.sh on controlplane nodes before upgrades
     cmd: kinder
@@ -169,6 +172,7 @@ tasks:
       - -k=/tmp/kubeadm-patches
       - --name={{ .vars.clusterName }}
       - --loglevel=debug
+      - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   - name: run verify-kustomize.sh on controlplane nodes after upgrades
     cmd: kinder
     args:
@@ -202,6 +206,7 @@ tasks:
       - kubeadm-reset
       - --name={{ .vars.clusterName }}
       - --loglevel=debug
+      - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
     force: true
   - name: delete
     description: |

--- a/kinder/ci/workflows/upgrade-tasks-automatic-copy-certs.yaml
+++ b/kinder/ci/workflows/upgrade-tasks-automatic-copy-certs.yaml
@@ -12,6 +12,7 @@ vars:
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-upgrade
+  kubeadmVerbosity: 6
 tasks:
 - name: pull-base-image
   description: |
@@ -59,6 +60,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --automatic-copy-certs
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: join
   description: |
@@ -70,6 +72,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --automatic-copy-certs
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: cluster-info-before
   description: |
@@ -90,6 +93,7 @@ tasks:
     - --upgrade-version={{ .vars.upgradeVersion }}
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 5m
 - name: e2e-kubeadm-after
   description: |
@@ -147,6 +151,7 @@ tasks:
     - kubeadm-reset
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   force: true
 - name: delete
   description: |


### PR DESCRIPTION
The previous commit missed these workflows.

https://github.com/kubernetes/kubeadm/pull/1980

self-applying LGTM again to not bother folks during the h-days.

