### PR TITLE
Replacing 'HTTP' by 'HTTPS' for securing links

### DIFF
--- a/kinder/hack/verify-golint.sh
+++ b/kinder/hack/verify-golint.sh
@@ -36,7 +36,7 @@ trap exitHandler EXIT
 
 # pull the source code and build the binary
 cd "${TMP_DIR}"
-URL="http://github.com/golang/lint"
+URL="https://github.com/golang/lint"
 echo "Cloning ${URL} in ${TMP_DIR}..."
 git clone --quiet --depth=1 "${URL}" .
 echo "Building golint..."

--- a/kinder/hack/verify-staticcheck.sh
+++ b/kinder/hack/verify-staticcheck.sh
@@ -36,7 +36,7 @@ trap exitHandler EXIT
 
 # pull the source code and build the binary
 cd "${TMP_DIR}"
-URL="http://github.com/dominikh/go-tools"
+URL="https://github.com/dominikh/go-tools"
 echo "Cloning ${URL} in ${TMP_DIR}..."
 git clone --quiet --depth=1 "${URL}" .
 echo "Building staticcheck..."

--- a/operator/hack/verify-golint.sh
+++ b/operator/hack/verify-golint.sh
@@ -36,7 +36,7 @@ trap exitHandler EXIT
 
 # pull the source code and build the binary
 cd "${TMP_DIR}"
-URL="http://github.com/golang/lint"
+URL="https://github.com/golang/lint"
 echo "Cloning ${URL} in ${TMP_DIR}..."
 git clone --quiet --depth=1 "${URL}" .
 echo "Building golint..."


### PR DESCRIPTION
Currently, when we access github.com with HTTP, it is redirected to HTTPS automatically. So this commit aims to replace http://github.com by https://github.com for security.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>