### PR TITLE
update the "manifest lists" test for k8s.gcr.io

### DIFF
--- a/tests/e2e/manifests/verify_manifest_lists.go
+++ b/tests/e2e/manifests/verify_manifest_lists.go
@@ -65,7 +65,7 @@ const (
 	// first release that is known to have full support.
 	firstKnownVersion = "v1.12.0-rc.1"
 
-	gcrBucket = "https://gcr.io/v2/google-containers"
+	gcrBucket = "https://k8s.gcr.io/v2"
 
 	typeManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
 	typeManifest     = "application/vnd.docker.distribution.manifest.v2+json"

--- a/tests/e2e/manifests/verify_manifest_lists.sh
+++ b/tests/e2e/manifests/verify_manifest_lists.sh
@@ -16,21 +16,29 @@ trap "rm go.mod go.sum" EXIT
 
 # install curl if missing
 if ! `curl --version > /dev/null`; then
-	apt-get update || exit 1
-	apt-get install -y curl || exit 1
+	apt-get update
+	apt-get install -y curl
 fi
 
 # install go if missing
 if ! `go version > /dev/null`; then
-	apt-get update || exit 1
-	apt-get install -y golang-go || exit 1
+	curl https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -o /tmp/go.tar.gz
+	tar -C /usr/local -xzf /tmp/go.tar.gz
+	export PATH="$PATH":/usr/local/go/bin
+fi
+
+# api-machinery requires gcc
+#   go: extracting k8s.io/apimachinery v0.17.3
+#   runtime/cgo
+#   exec: "gcc": executable file not found in $PATH
+if ! `gcc -v > /dev/null`; then
+	apt-get install -y gcc
 fi
 
 LPATH=`dirname "$0"`
 cd "$LPATH"
 
 # use go modules. this forces using the latest k8s.io/apimachinery package.
-export GO111MODULE=on
 go mod init verify-manifest-lists
 
 # run unit tests


### PR DESCRIPTION
commits:

> tests/e2e/manifests: use k8s.gcr.io as the GCR bucket

only switches the URL for the bucket

> tests/e2e/manifests: pin the go version and install it using curl

installing go from `debian:stretch` suddenly started returning a version that does not have `go mod`.
download go and install gcc manually.

/assign @SataQiu 
fixes: https://github.com/kubernetes/kubeadm/issues/2051
