### PR TITLE
[kinder] remove dependency kind util

### DIFF
--- a/kinder/doc/kind-kinder.md
+++ b/kinder/doc/kind-kinder.md
@@ -28,6 +28,7 @@ _Building images:_
      - Replace the kubectl, kubelet, kubeadm binary to be used for `kubeadm init` (from release, CI/CD or locally
        build artifacts)
      - Add a Kubernetes version to be used for `kubeadm upgrade` (from release, CI/CD or locally build artifacts)
+- kinder can build images only on top of linux/amd64 base images (currently ubuntu:18.04)
 
 _Creating the cluster:_
 - kinder support both containerd and as container runtime inside the images

--- a/kinder/pkg/build/base/base.go
+++ b/kinder/pkg/build/base/base.go
@@ -24,10 +24,8 @@ import (
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-
 	"k8s.io/kubeadm/kinder/pkg/exec"
 	"sigs.k8s.io/kind/pkg/fs"
-	"sigs.k8s.io/kind/pkg/util"
 )
 
 // DefaultImage is the default name:tag of the built base image
@@ -39,9 +37,6 @@ type BuildContext struct {
 	// option fields
 	sourceDir string
 	image     string
-	// non option fields
-	goCmd string // TODO: should be an option possibly
-	arch  string // TODO: should be an option
 }
 
 // Option is BuildContext configuration option supplied to NewBuildContext
@@ -66,8 +61,6 @@ func WithImage(image string) Option {
 func NewBuildContext(options ...Option) *BuildContext {
 	ctx := &BuildContext{
 		image: DefaultImage,
-		goCmd: "go",
-		arch:  util.GetArch(),
 	}
 	for _, option := range options {
 		option(ctx)
@@ -119,8 +112,8 @@ func (c *BuildContext) buildEntrypoint(dir string) error {
 	entrypointSrc := filepath.Join(dir, "entrypoint", "main.go")
 	entrypointDest := filepath.Join(dir, "entrypoint", "entrypoint")
 
-	cmd := exec.NewHostCmd(c.goCmd, "build", "-o", entrypointDest, entrypointSrc)
-	cmd.SetEnv(append(os.Environ(), "GOOS=linux", "GOARCH="+c.arch)...)
+	cmd := exec.NewHostCmd("go", "build", "-o", entrypointDest, entrypointSrc)
+	cmd.SetEnv(append(os.Environ(), "GOOS=linux", "GOARCH=amd64")...)
 
 	// actually build
 	log.Info("Building entrypoint binary ...")


### PR DESCRIPTION
This PR remove dependency from sigs.k8s.io/kind/pkg/util.
Important. after this change, kinder can build images only on top of linux/amd64 os, but this should not be a problem because we never tested/aimed to support other os as a base image.
FYI  currently we are using ubuntu:18.04

/assign @neolit123 