### PR TITLE
[kinder] remove dependency kind kustomize

### DIFF
--- a/kinder/doc/kind-kinder.md
+++ b/kinder/doc/kind-kinder.md
@@ -40,6 +40,7 @@ _Creating the cluster:_
   config init, join (eventually, only the last two operations can be skipped)
 - kinder allows adding an external etcd to the cluster
 - kinder allows adding an external loadbalancer to the cluster even if less than two control-plane nodes
+- kinder still uses kustomize for bulding the kubeadm config file, while kind dropped this dependency for a lighther solution
 
 _Actions on a running cluster:_
 - kinder support running actions on a running cluster (after `kinder create`)
@@ -96,8 +97,5 @@ back new features.
 - "sigs.k8s.io/kind/pkg/fs" (*) for
     - `TempDir`
     - `Copy`
-- "sigs.k8s.io/kind/pkg/kustomize" for
-    - `PatchJSON6902` struct
-    - `Build`
 
 (*) to be evaluated if removing dependency in future kinder versions

--- a/kinder/go.mod
+++ b/kinder/go.mod
@@ -16,5 +16,6 @@ require (
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/utils v0.0.0-20190712204705-3dccf664f023 // indirect
 	sigs.k8s.io/kind v0.4.0
+	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/kinder/pkg/cluster/manager/actions/kubeadm-config.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-config.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/kubeadm/kinder/pkg/constants"
 	"k8s.io/kubeadm/kinder/pkg/cri"
 	"k8s.io/kubeadm/kinder/pkg/kubeadm"
-	kindkustomize "sigs.k8s.io/kind/pkg/kustomize"
 )
 
 // kubeadmConfigOptionsall stores all the kinder flags that impact on the kubeadm config generation
@@ -192,7 +191,7 @@ func getKubeadmConfig(c *status.Cluster, n *status.Node, data kubeadm.ConfigData
 
 	// apply all the kinder specific settings using patches
 	var patches = []string{}
-	var jsonPatches = []kindkustomize.PatchJSON6902{}
+	var jsonPatches = []kubeadm.PatchJSON6902{}
 
 	// add patches for instructing kubeadm to use the CRI runtime engine  installed on a node
 	// NB. this is a no-op in case of containerd, because it is already the default in the raw config
@@ -295,7 +294,7 @@ func getKubeadmConfig(c *status.Cluster, n *status.Node, data kubeadm.ConfigData
 	patches, jsonPatches = setPatchNames(patches, jsonPatches)
 
 	// apply patches
-	patched, err := kindkustomize.Build([]string{rawconfig}, patches, jsonPatches)
+	patched, err := kubeadm.Build([]string{rawconfig}, patches, jsonPatches)
 	if err != nil {
 		return "", err
 	}
@@ -397,9 +396,9 @@ const objectName = "config"
 // setPatchNames sets the targeted object name on every patch to be the fixed
 // name we use when generating config objects (we have one of each type, all of
 // which have the same fixed name)
-func setPatchNames(patches []string, jsonPatches []kindkustomize.PatchJSON6902) ([]string, []kindkustomize.PatchJSON6902) {
+func setPatchNames(patches []string, jsonPatches []kubeadm.PatchJSON6902) ([]string, []kubeadm.PatchJSON6902) {
 	fixedPatches := make([]string, len(patches))
-	fixedJSONPatches := make([]kindkustomize.PatchJSON6902, len(jsonPatches))
+	fixedJSONPatches := make([]kubeadm.PatchJSON6902, len(jsonPatches))
 	for i, patch := range patches {
 		// insert the generated name metadata
 		fixedPatches[i] = fmt.Sprintf("metadata:\nname: %s\n%s", objectName, patch)

--- a/kinder/pkg/kubeadm/discovery.go
+++ b/kinder/pkg/kubeadm/discovery.go
@@ -20,20 +20,19 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 
+	log "github.com/sirupsen/logrus"
 	K8sVersion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/kubeadm/kinder/pkg/constants"
-	kindkustomize "sigs.k8s.io/kind/pkg/kustomize"
 )
 
 // GetRemoveTokenPatch returns the kubeadm config patch that will instruct kubeadm
 // to not uses token discovery.
-func GetRemoveTokenPatch(kubeadmVersion *K8sVersion.Version) (kindkustomize.PatchJSON6902, error) {
+func GetRemoveTokenPatch(kubeadmVersion *K8sVersion.Version) (PatchJSON6902, error) {
 	// gets the config version corresponding to a kubeadm version
 	kubeadmConfigVersion, err := getKubeadmConfigVersion(kubeadmVersion)
 	if err != nil {
-		return kindkustomize.PatchJSON6902{}, err
+		return PatchJSON6902{}, err
 	}
 
 	// select the patches for the kubeadm config version
@@ -49,10 +48,10 @@ func GetRemoveTokenPatch(kubeadmVersion *K8sVersion.Version) (kindkustomize.Patc
 	case "v1alpha3":
 		patch = removeTokenPatchv1alpha3
 	default:
-		return kindkustomize.PatchJSON6902{}, errors.Errorf("unknown kubeadm config version: %s", kubeadmConfigVersion)
+		return PatchJSON6902{}, errors.Errorf("unknown kubeadm config version: %s", kubeadmConfigVersion)
 	}
 
-	return kindkustomize.PatchJSON6902{
+	return PatchJSON6902{
 		Group:   "kubeadm.k8s.io",
 		Version: kubeadmConfigVersion,
 		Kind:    kind,

--- a/kinder/pkg/kubeadm/kustomize.go
+++ b/kinder/pkg/kubeadm/kustomize.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"runtime"
+
+	"sigs.k8s.io/kustomize/k8sdeps"
+	"sigs.k8s.io/kustomize/pkg/commands/build"
+	"sigs.k8s.io/kustomize/pkg/fs"
+)
+
+// kustomize.go contains helpers for working with embedded kustomize commands
+// This file was originally implemented in "sigs.k8s.io/kind/pkg/kustomize", but then kind dropped
+// support for kustomize patches, so we forked this code in kind.
+
+// PatchJSON6902 represents an inline kustomize json 6902 patch
+// https://tools.ietf.org/html/rfc6902
+type PatchJSON6902 struct {
+	// these fields specify the patch target resource
+	Group   string `json:"group"`
+	Version string `json:"version"`
+	Kind    string `json:"kind"`
+	// Name and Namespace are optional
+	// NOTE: technically name is required now, but we default it elsewhere
+	// Third party users of this type / library would need to set it.
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	// Patch should contain the contents of the json patch as a string
+	Patch string `json:"patch"`
+}
+
+// Build takes a set of resource blobs (yaml), patches (strategic merge patch)
+// https://github.com/kubernetes/community/blob/master/contributors/devel/strategic-merge-patch.md
+// and returns the `kustomize build` result as a yaml blob
+// It does this in-memory using the build cobra command
+func Build(resources, patches []string, patchesJSON6902 []PatchJSON6902) (string, error) {
+	// write the resources and patches to an in memory fs with a generated
+	// kustomization.yaml
+	memFS := fs.MakeFakeFS()
+	var kustomization bytes.Buffer
+	fakeDir := "/"
+	// for Windows we need this to be a drive because kustomize uses filepath.Abs()
+	// which will add a drive letter if there is none. which drive letter is
+	// unimportant as the path is on the fake filesystem anyhow
+	if runtime.GOOS == "windows" {
+		fakeDir = `C:\`
+	}
+
+	// NOTE: we always write this header as you cannot build without any resources
+	kustomization.WriteString("resources:\n")
+	for i, resource := range resources {
+		// this cannot error per docs
+		name := fmt.Sprintf("resource-%d.yaml", i)
+		_ = memFS.WriteFile(filepath.Join(fakeDir, name), []byte(resource))
+		fmt.Fprintf(&kustomization, " - %s\n", name)
+	}
+
+	if len(patches) > 0 {
+		kustomization.WriteString("patches:\n")
+	}
+	for i, patch := range patches {
+		// this cannot error per docs
+		name := fmt.Sprintf("patch-%d.yaml", i)
+		_ = memFS.WriteFile(filepath.Join(fakeDir, name), []byte(patch))
+		fmt.Fprintf(&kustomization, " - %s\n", name)
+	}
+
+	if len(patchesJSON6902) > 0 {
+		kustomization.WriteString("patchesJson6902:\n")
+	}
+	for i, patch := range patchesJSON6902 {
+		// this cannot error per docs
+		name := fmt.Sprintf("patch-json6902-%d.yaml", i)
+		_ = memFS.WriteFile(filepath.Join(fakeDir, name), []byte(patch.Patch))
+		fmt.Fprintf(&kustomization, " - path: %s\n", name)
+		fmt.Fprintf(&kustomization, "   target:\n")
+		fmt.Fprintf(&kustomization, "     group: %s\n", patch.Group)
+		fmt.Fprintf(&kustomization, "     version: %s\n", patch.Version)
+		fmt.Fprintf(&kustomization, "     kind: %s\n", patch.Kind)
+		if patch.Name != "" {
+			fmt.Fprintf(&kustomization, "     name: %s\n", patch.Name)
+		}
+		if patch.Namespace != "" {
+			fmt.Fprintf(&kustomization, "     namespace: %s\n", patch.Namespace)
+		}
+	}
+
+	memFS.WriteFile(filepath.Join(fakeDir, "kustomization.yaml"), kustomization.Bytes())
+
+	// now we can build the kustomization
+	var out bytes.Buffer
+	f := k8sdeps.NewFactory()
+	cmd := build.NewCmdBuild(&out, memFS, f.ResmapF, f.TransformerF)
+	cmd.SetArgs([]string{fakeDir})
+	// we want to silence usage, error output, and any future output from cobra
+	// we will get error output as a golang error from execute
+	cmd.SetOutput(ioutil.Discard)
+	_, err := cmd.ExecuteC()
+	if err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}


### PR DESCRIPTION
This PR remove dependency from "sigs.k8s.io/kind/pkg/kustomize" by forking some code from older versions of kind.

Please note that kind moved away from kustomize in favor or lighter solutions. In kinder, we are not taking this step yet because the size of the binary is not a major concern at this stage.

/area kinder
/assign @neolit123 