### PR TITLE
[kinder] remove dependency yaml.v2

### DIFF
--- a/kinder/go.mod
+++ b/kinder/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/spf13/pflag v1.0.3
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
-	gopkg.in/yaml.v2 v2.2.1
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/utils v0.0.0-20190712204705-3dccf664f023 // indirect

--- a/kinder/pkg/test/workflow/workflow.go
+++ b/kinder/pkg/test/workflow/workflow.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // Workflow represents a list of tasks to be executed during test workflow and related context


### PR DESCRIPTION
this PR remove dependency from `gopkg.in/yaml.v2` since we are already using `sigs.k8s.io/yaml` in other places

/area clusterctl
/assign @neolit123 