### PR TITLE
kinder: add e2e workflow for testing join and upgrade without addon ConfigMap

### DIFF
--- a/kinder/ci/kubeadm-periodic.tests.md
+++ b/kinder/ci/kubeadm-periodic.tests.md
@@ -95,3 +95,11 @@ Kubernetes 1.16 is the minimal supported version that is tested for kustomize.
 | -------------------------------------- | ------            |
 | master<br />(ci/latest)                | v1.17.0-alpha...  |
 | master<br />(ci/latest-1.16)           | v1.16.2-alpha...  |
+
+### Tests without addon ConfigMaps
+
+Kubeadm join and upgrade tests that ensure that kubeadm tolerates missing addon "kube-proxy" and "coredns" ConfigMaps.
+
+| from                            | e.g.              | to                       | e.g.             |
+| ------------------------------- | ----------------- | -------------------------| ---------------- |
+| current<br />(ci/latest-1.18)   | v1.18.1-alpha...  | master<br />(ci/latest)  | v1.19.0-alpha... |

--- a/kinder/ci/workflows/upgrade-master-no-addon-config-maps.yaml
+++ b/kinder/ci/workflows/upgrade-master-no-addon-config-maps.yaml
@@ -1,0 +1,101 @@
+version: 1
+summary: |
+  This workflow implements a sequence of tasks for testing kubeadm join
+  and upgrade when the "kube-proxy" and "coredns" ConfigMaps are missing.
+vars:
+  initVersion: "{{ resolve `ci/latest` }}"
+  controlPlaneNodes: 1
+  workerNodes: 1
+  baseImage: kindest/base:v20190403-1ebf15f
+  image: kindest/node:test
+  clusterName: kinder-upgrade
+  kubeadmVerbosity: 6
+tasks:
+- name: pull-base-image
+  description: |
+    Pulls kindest/base image with docker in docker and all the prerequisites necessary for running kind(er)
+  cmd: docker
+  args:
+    - pull
+    - "{{ .vars.baseImage }}"
+- name: add-kubernetes-versions
+  description: |
+    Creates a node-image-variant by adding Kubernetes version "initVersion"
+    to be used when executing "kinder do kubeadm-init" and Kubernetes
+    version "upgradeVersion" to be used afterwards when executing "kinder do kubeadm-upgrade"
+  cmd: kinder
+  args:
+    - build
+    - node-image-variant
+    - --base-image={{ .vars.baseImage }}
+    - --image={{ .vars.image }}
+    - --with-init-artifacts={{ .vars.initVersion }}
+    - --loglevel=debug
+  timeout: 10m
+- name: create-cluster
+  description: |
+    Create a set of nodes ready for hosting the Kubernetes cluster
+  cmd: kinder
+  args:
+    - create
+    - cluster
+    - --name={{ .vars.clusterName }}
+    - --image={{ .vars.image }}
+    - --control-plane-nodes={{ .vars.controlPlaneNodes }}
+    - --worker-nodes={{ .vars.workerNodes }}
+    - --loglevel=debug
+  timeout: 5m
+- name: init
+  description: |
+    Initializes the Kubernetes cluster with version "initVersion"
+    by starting the boostrap control-plane nodes
+  cmd: kinder
+  args:
+    - do
+    - kubeadm-init
+    - --name={{ .vars.clusterName }}
+    - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+  timeout: 5m
+- name: delete-addon-config-maps
+  description: |
+    Deletes the "coredns" and "kube-proxy" ConfigMaps under "kube-system"
+  cmd: /bin/sh
+  args:
+    - -c
+    - |
+      docker exec {{ .vars.clusterName }}-control-plane-1 kubectl delete cm -n kube-system --kubeconfig=/etc/kubernetes/admin.conf kube-proxy
+      docker exec {{ .vars.clusterName }}-control-plane-1 kubectl delete cm -n kube-system --kubeconfig=/etc/kubernetes/admin.conf coredns
+  timeout: 5m
+- name: join
+  description: |
+    Joins a worker node and verifies that it tolerates missing addon ConfigMaps
+  cmd: kinder
+  args:
+    - do
+    - kubeadm-join
+    - --name={{ .vars.clusterName }}
+    - --loglevel=debug
+    - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+  timeout: 5m
+- name: upgrade-control-plane
+  description: |
+    Upgrades the control-plane node to the same version of the existing control-plane. This verifies
+    that "kubeadm upgrade apply" tolerates missing addon ConfigMaps. Ignoring preflight errors
+    is still required due to CoreDNS checks.
+  cmd: /bin/sh
+  args:
+    - -c
+    - |
+      docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm upgrade apply -f --ignore-preflight-errors=all --v={{ .vars.kubeadmVerbosity }} {{ .vars.initVersion }}
+  timeout: 5m
+- name: delete
+  description: |
+    Deletes the cluster
+  cmd: kinder
+  args:
+    - delete
+    - cluster
+    - --name={{ .vars.clusterName }}
+    - --loglevel=debug
+  force: true


### PR DESCRIPTION
Add a workflow that:
 - creates 1CP1W cluster
 - inits the CP node
 - deletes the kube-proxy and coredns config maps
 - joins the worker
 - upgrades the CP node (to the same version as init)

This ensures that kubeadm tolerates missing addon config maps.
"upgrade apply" still requires skipping the CoreDNS preflight checks,
but this is controllable by the user.

Skipping the "addon" phase from "init" completely results in a cluster
that does not work, as a proxy / CNI solution has to be deployed for the
"upgrade-prepull*" DS to complete. Potentially replacement addons
can provide a better e2e test for this (in the future).
