### PR TITLE
kinder: fix issue in kubeadm-periodic.tests.md

### DIFF
--- a/kinder/ci/kubeadm-periodic.tests.md
+++ b/kinder/ci/kubeadm-periodic.tests.md
@@ -100,6 +100,6 @@ Kubernetes 1.16 is the minimal supported version that is tested for kustomize.
 
 Kubeadm join and upgrade tests that ensure that kubeadm tolerates missing addon "kube-proxy" and "coredns" ConfigMaps.
 
-| from                            | e.g.              | to                       | e.g.             |
-| ------------------------------- | ----------------- | -------------------------| ---------------- |
-| current<br />(ci/latest-1.18)   | v1.18.1-alpha...  | master<br />(ci/latest)  | v1.19.0-alpha... |
+| from                     | e.g.              | to                       | e.g.             |
+| -------------------------| ----------------- | -------------------------| ---------------- |
+| master<br />(ci/latest)  | v1.19.0-alpha..   | master<br />(ci/latest)  | v1.19.0-alpha... |


### PR DESCRIPTION
"Tests without addon ConfigMaps" was recently updated
incorrectly to include a latest-1.18 -> master upgrade.

The upgrade is actually master->master for this test.
https://github.com/kubernetes/kubeadm/blob/master/kinder/ci/workflows/upgrade-master-no-addon-config-maps.yaml

/assign @fabriziopandini 