### PR TITLE
kinder: adjust timeouts to attempt to fix flakes

### DIFF
--- a/kinder/ci/workflows/discovery-tasks.yaml
+++ b/kinder/ci/workflows/discovery-tasks.yaml
@@ -118,6 +118,7 @@ tasks:
     - --test-flags=--report-dir={{ .env.ARTIFACTS }}
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+  timeout: 10m
 - name: get-logs
   description: |
     Collects all the test logs

--- a/kinder/ci/workflows/external-etcd.yaml
+++ b/kinder/ci/workflows/external-etcd.yaml
@@ -67,7 +67,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
-  timeout: 5m
+  timeout: 10m
 - name: e2e-kubeadm
   description: |
     Runs kubeadm e2e tests
@@ -78,6 +78,7 @@ tasks:
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-kubeadm
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+  timeout: 10m
 - name: e2e
   description: |
     Runs Kubernetes e2e test (conformance)

--- a/kinder/ci/workflows/kustomize-tasks.yaml
+++ b/kinder/ci/workflows/kustomize-tasks.yaml
@@ -173,6 +173,7 @@ tasks:
       - --name={{ .vars.clusterName }}
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    timeout: 10m
   - name: run verify-kustomize.sh on controlplane nodes after upgrades
     cmd: kinder
     args:

--- a/kinder/ci/workflows/presubmit-upgrade-master.yaml
+++ b/kinder/ci/workflows/presubmit-upgrade-master.yaml
@@ -71,7 +71,7 @@ tasks:
     - --automatic-copy-certs
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
-  timeout: 5m
+  timeout: 10m
 - name: upgrade
   description: |
     upgrades the cluster to Kubernetes "upgradeVersion"
@@ -83,6 +83,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+  timeout: 10m
 - name: cluster-info
   description: |
     Runs cluster-info

--- a/kinder/ci/workflows/regular-tasks.yaml
+++ b/kinder/ci/workflows/regular-tasks.yaml
@@ -88,6 +88,7 @@ tasks:
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-kubeadm
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+  timeout: 10m
 - name: e2e
   description: |
     Runs Kubernetes e2e test (conformance)

--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -73,7 +73,7 @@ tasks:
     - --automatic-copy-certs
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
-  timeout: 5m
+  timeout: 10m
 - name: cluster-info
   description: |
     Runs cluster-info
@@ -93,6 +93,7 @@ tasks:
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-kubeadm
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+  timeout: 10m
 - name: e2e
   description: |
     Runs Kubernetes e2e test (conformance)

--- a/kinder/ci/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-tasks.yaml
@@ -73,7 +73,7 @@ tasks:
     - --automatic-copy-certs
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
-  timeout: 5m
+  timeout: 10m
 - name: cluster-info-before
   description: |
     Runs cluster-info on the cluster before upgrade
@@ -94,7 +94,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
-  timeout: 5m
+  timeout: 10m
 - name: e2e-kubeadm-after
   description: |
     Runs kubeadm e2e test on the cluster with Kubernetes "upgradeVersion"
@@ -105,6 +105,7 @@ tasks:
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-kubeadm
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+  timeout: 10m
 - name: cluster-info-after
   description: |
     Runs cluster-info on the cluster after upgrade


### PR DESCRIPTION
xref https://github.com/kubernetes/kubernetes/issues/90761

5 minutes has become more and more flaky for some tasks.

This could be caused by a couple of factors:

1) A scheduling / node regression in core of sort. I think I started
seeing this in my local kubeadm clusters (without kind/kinder)
around 1.16-1.17.

2) Slower infra: GCE VMs / Prow Pods / CR could be involved. Maybe
our jobs have less resources compared to before or maybe it only
happens sometimes.

Increase the timeout for the following tasks to 10m:
- "kubeadm-join": The nodes just don't get ready in time for 3CP2W workflows.
- "e2e-kubeadm": It seems building the suite times-out a lot now.
Maybe the suite just got a little bigger and we were borderline
flaky without catching it before.
- "kubeadm-upgrade": it just timeouts waiting on the nodes to become
Ready. Happens for 2CP1W workflows too. This case in particular
tells me that we maybe have a case of 2) as well, somehow, occasionally.