### PR TITLE
kinder prepull images during build

### DIFF
--- a/kinder/pkg/cri/docker/createhelper.go
+++ b/kinder/pkg/cri/docker/createhelper.go
@@ -182,7 +182,7 @@ func loadImages(name string) {
 		// use xargs to load images in parallel
 		`find /kind/images -name *.tar -print0 | xargs -0 -n 1 -P $(nproc) docker load -i`,
 	).Silent().Run(); err != nil {
-		log.Warningf("Failed to preload docker images: %v", err)
+		log.Warningf("Failed to preload docker images from /kind/images: %v", err)
 		return
 	}
 }

--- a/kinder/pkg/test/workflow/taskCmdRunner.go
+++ b/kinder/pkg/test/workflow/taskCmdRunner.go
@@ -182,7 +182,7 @@ func (c *taskCmdRunner) Run(t *taskCmd, artifacts string, verbose bool) error {
 
 		// record test case timeout and exits with error
 		return c.registerTestCase(t.Name,
-			withFailure(fmt.Sprintf("timeout. task did not completed in less than %s as expected", t.Timeout.Duration)),
+			withFailure(fmt.Sprintf("timeout. The task did not complete in less than %s as expected", t.Timeout.Duration)),
 			withDuration(time.Since(start)),
 		)
 	}


### PR DESCRIPTION
xref https://github.com/kubernetes/kubernetes/issues/90761


first commit is just a typo fix.
second commit:
```
The idea of this change is to reduce the amount of network traffic
kinder e2e test workflows have to do with the attempt to fix flakes.

For 3CP setup etcd has to be pulled 3x~200MB (6x~200MB for upgrade).
After this change it has to be pulled 1x~200MB (2x~200MB for upgrade).

- pre-pull non-kube images for docker and containerd based on the output
of the kubeadm binary for init/join and binary for upgrade.
- pre-load these images for docker during cluster create and upgrade
- for containerd the images are not pre-loaded due to issues related
to the containerd "snapshoter" functionality. add TODOs to resolve
that in the future. one potential fix is to import them on runtime
the same way it is done for docker.
NOTE: currently we don't have e2e tests for containerd.

CNI images (Calico) are not pre-pulled.
```

/area kinder
/kind feature
