### PR TITLE
fix checking of pre-loaded images

### DIFF
--- a/kinder/pkg/cluster/manager/actions/images.go
+++ b/kinder/pkg/cluster/manager/actions/images.go
@@ -31,9 +31,11 @@ import (
 func checkImagesForVersion(n *status.Node, version string) error {
 	n.Infof("Checking pre-loaded images")
 
+	imageListCmd := fmt.Sprintf("kubeadm config images list --kubernetes-version=%s 2>/dev/null", version)
+
 	// gets the list of images kubeadm is going to use
 	expected, err := n.Command(
-		"kubeadm", "config", "images", "list", fmt.Sprintf("--kubernetes-version=%s", version),
+		"bash", "-c", imageListCmd,
 	).Silent().RunAndCapture()
 	if err != nil {
 		return errors.Wrapf(err, "failed to read expected images for version %s from %s", version, n.Name())


### PR DESCRIPTION
`kubeadm config images list --kubernetes-version=%s` emits a warning -
> WARNING: kubeadm cannot validate component configs for API groups [kubelet.config.k8s.io kubeproxy.config.k8s.io]

The `expected` list of images contains this warning and that results in -
>Some of the required images are not pre-loaded into the container runtime

This PR aims to fix that by redirecting the stderr of kubeadm to `/dev/null`