### PR TITLE
kinder fix issues around containerd base images

### DIFF
--- a/kinder/pkg/build/alter/alter.go
+++ b/kinder/pkg/build/alter/alter.go
@@ -305,15 +305,14 @@ func (c *Context) alterImage(bitsInstallers []bits.Installer, bc *bits.BuildCont
 		}
 	}
 
-	log.Info("Pre pull extra images ...")
+	log.Info("Pre-pull extra images ...")
 	if err := alterHelper.PrePullAdditionalImages(bc, "/kind", "/kinder/upgrade"); err != nil {
 		return errors.Wrapf(err, "image build Failed! Failed to pre-pull additional images into %s", runtime)
 	}
 
-	log.Info("Pre loading images ...")
-	// TODO: preload upgrade images for containerd too?
-	if err := alterHelper.PreLoadInitImages(bc); err != nil {
-		return errors.Wrapf(err, "image build Failed! Failed to load images into %s", runtime)
+	// Make sure the /kind/images folder exists
+	if err := bc.RunInContainer("mkdir", "-p", "/kind/images"); err != nil {
+		return err
 	}
 
 	log.Infof("Commit to %s ...", c.image)

--- a/kinder/pkg/cri/alterhelper.go
+++ b/kinder/pkg/cri/alterhelper.go
@@ -126,21 +126,6 @@ func (h *AlterHelper) pullImagesForKubeadmBinary(bc *bits.BuildContext, binaryPa
 	return errors.Errorf("unknown cri: %s", h.cri)
 }
 
-// PreLoadInitImages preload images required by kubeadm-init into the selected container runtime that exists inside a kind(er) node
-func (h *AlterHelper) PreLoadInitImages(bc *bits.BuildContext) error {
-	if err := bc.RunInContainer("mkdir", "-p", "/kind/images"); err != nil {
-		return err
-	}
-
-	switch h.cri {
-	case status.ContainerdRuntime:
-		return containerd.PreLoadInitImages(bc)
-	case status.DockerRuntime:
-		return docker.PreLoadInitImages(bc)
-	}
-	return errors.Errorf("unknown cri: %s", h.cri)
-}
-
 // Commit a kind(er) node image that uses the selected container runtime internally
 func (h *AlterHelper) Commit(containerID, targetImage string) error {
 	switch h.cri {

--- a/kinder/pkg/cri/containerd/actionhelper.go
+++ b/kinder/pkg/cri/containerd/actionhelper.go
@@ -27,7 +27,7 @@ func PreLoadUpgradeImages(n *status.Node, srcFolder string) error {
 	// NB. this code is an extract from "sigs.k8s.io/kind/pkg/build/node"
 	return n.Command(
 		"bash", "-c",
-		`find `+srcFolder+` -name *.tar -print0 | xargs -0 -n 1 -P $(nproc) ctr --namespace=k8s.io images import --no-unpack && rm -rf `+srcFolder+`/*.tar`,
+		`find `+srcFolder+` -name *.tar -print0 | xargs -0 -n 1 -P $(nproc) ctr --namespace=k8s.io images import --no-unpack`,
 	).Silent().Run()
 }
 

--- a/kinder/pkg/cri/containerd/alterhelper.go
+++ b/kinder/pkg/cri/containerd/alterhelper.go
@@ -28,18 +28,21 @@ import (
 
 // GetAlterContainerArgs returns arguments for the alter container for containerd
 func GetAlterContainerArgs() ([]string, []string) {
+	// NB. using /usr/local/bin/entrypoint or /sbin/init both throw errors
+	// for base image "kindest/base:v20191105-ee880e9b".
+	// Use "sleep infinity" instead, but still make sure containerd can run.
 	runArgs := []string{
 		// privileged is required for "ctr image pull" permissions
 		"--privileged",
 		// the snapshot storage must be a volume.
 		// see the info in Commit()
 		"-v=/var/lib/containerd",
-		// enable the actual entry point in the kind base image
-		"--entrypoint=/usr/local/bin/entrypoint",
+		// override the entrypoint
+		"--entrypoint=/bin/sleep",
 	}
 	runCommands := []string{
-		// pass the init binary to the entrypoint
-		"/sbin/init",
+		// pass this to the entrypoint
+		"infinity",
 	}
 	return runArgs, runCommands
 }

--- a/kinder/pkg/cri/containerd/alterhelper.go
+++ b/kinder/pkg/cri/containerd/alterhelper.go
@@ -71,19 +71,6 @@ func PullImages(bc *bits.BuildContext, images []string, targetPath string) error
 	return nil
 }
 
-// PreLoadInitImages preload images required by kubeadm-init into the containerd runtime installed that exists inside a kind(er) node
-func PreLoadInitImages(bc *bits.BuildContext) error {
-	// NB. this code is an extract from "sigs.k8s.io/kind/pkg/build/node"
-
-	return bc.RunInContainer(
-		// NB. the ctr call bellow used to include "--no-unpack", but his flag is not longer available
-		// TODO: importing the images, deleting the tars, committing the changes to the image and then creating
-		// a container from the image results in no images in the container, so this preload does not work.
-		"bash", "-c",
-		`containerd & find /kind/images -name *.tar -print0 | xargs -r -0 -n 1 -P $(nproc) ctr --namespace=k8s.io images import && kill %1 && rm -rf /kind/images/*`,
-	)
-}
-
 // Commit a kind(er) node image that uses the containerd runtime internally
 func Commit(containerID, targetImage string) error {
 	// NB. this code is an extract from "sigs.k8s.io/kind/pkg/build/node"

--- a/kinder/pkg/cri/containerd/createhelper.go
+++ b/kinder/pkg/cri/containerd/createhelper.go
@@ -17,6 +17,8 @@ limitations under the License.
 package containerd
 
 import (
+	log "github.com/sirupsen/logrus"
+
 	"k8s.io/kubeadm/kinder/pkg/cri/util"
 	"k8s.io/kubeadm/kinder/pkg/exec"
 )
@@ -37,5 +39,25 @@ func CreateNode(cluster, name, image, role string, volumes []string) error {
 	args = append(args, image)
 
 	// creates the container
-	return exec.NewHostCmd("docker", args...).Run()
+	if err := exec.NewHostCmd("docker", args...).Run(); err != nil {
+		return err
+	}
+
+	// load the image artifacts into containerd
+	loadImages(name)
+
+	return nil
+}
+
+// loadImages loads image tarballs stored on the node into containerd on the node
+func loadImages(name string) {
+	// load images cached on the node into containerd
+	if err := exec.NewNodeCmd(name,
+		"/bin/bash", "-c",
+		// use xargs to load images in parallel
+		`find /kind/images -name *.tar -print0 | xargs -r -0 -n 1 -P $(nproc) ctr --namespace=k8s.io images import --no-unpack`,
+	).Silent().Run(); err != nil {
+		log.Warningf("Failed to preload containerd images from /kind/images: %v", err)
+		return
+	}
 }

--- a/kinder/pkg/cri/docker/alterhelper.go
+++ b/kinder/pkg/cri/docker/alterhelper.go
@@ -82,12 +82,6 @@ func PullImages(bc *bits.BuildContext, images []string, targetPath string) error
 	return nil
 }
 
-// PreLoadInitImages preload images required by kubeadm-init into the docker runtime that exists inside a kind(er) node
-func PreLoadInitImages(bc *bits.BuildContext) error {
-	// in docker images are pre-loaded at create time, so this action is a no-op at alter time
-	return nil
-}
-
 // Commit a kind(er) node image that uses the docker runtime internally
 func Commit(containerID, targetImage string) error {
 	// Save the image changes to a new image


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubeadm/issues/2142

tested with two separate images:
```
kinder build node-image-variant --base-image kindest/base:v20190403-1ebf15f --with-init-artifacts=./alter/bits/init --with-upgrade-artifacts=./alter/bits/upgrade --loglevel=debug
kinder build node-image-variant --base-image kindest/base:v20191105-ee880e9b --with-init-artifacts=./alter/bits/init --with-upgrade-artifacts=./alter/bits/upgrade --loglevel=debug
```

then for each image:
```
kinder create cluster ...
kinder do kubeadm-init ...
kinder do kubeadm-upgrade ...
```

commits:

```
    kinder: don't delete upgrade image tars for containerd
    
    Keep the images in the container for Init and Upgrade for both CRs.
-------
    kinder: load init images from tars on cluster creation for containerd
    
    - When pulling images with containerd export them to tars
    - Add loadImages() that uses "ctr images import"
-------
    kinder: don't use /usr/local/bin/entrypoint for alter
    
    - /usr/local/bin/entrypoint throws an error since /kind/product_name
    is missing
    - /sbin/init throws a strage docker related error
    
    Using this for alter is not needed. Use sleep infinity instead.
-------
    kinder: remove PreloadInitImages for alter
    
    Preloading images on containerd using snapshotting / ctr image pull
    does not work. Remove the function PreloadInitImages for
    both docker (was empty) and containerd.
    
    The preloading of init images would now happen for both CR on
    cluster creation.
```
