### PR TITLE
kinder: increase waitForDocker timeout to 1m

### DIFF
--- a/kinder/pkg/cri/docker/createhelper.go
+++ b/kinder/pkg/cri/docker/createhelper.go
@@ -73,8 +73,9 @@ func CreateNode(cluster, name, image, role string, volumes []string) error {
 	}
 
 	// wait for docker to be ready
-	if !waitForDocker(name, time.Now().Add(time.Second*30)) {
-		return errors.Errorf("timed out waiting for docker to be ready on node %s", name)
+	const dockerTimeout = time.Second * 60
+	if !waitForDocker(name, time.Now().Add(dockerTimeout)) {
+		return errors.Errorf("timed out waiting for docker to be ready on node %s after %v", name, dockerTimeout)
 	}
 
 	// load the docker image artifacts into the docker daemon


### PR DESCRIPTION
Attempt to fix flakes related to slow start of docker in the kinder nodes:
"time="07:37:01" level=error msg="timed out waiting for docker to be ready on node kinder-upgrade-worker-1"
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-18-master/1262284866163052547/artifacts/task-02-create-cluster-log.txt

xref https://github.com/kubernetes/kubernetes/issues/90761
