### PR TITLE
kinder: remove the docs about 'kinder build node-image'

### DIFF
--- a/kinder/README.md
+++ b/kinder/README.md
@@ -119,8 +119,8 @@ It allows to execute actions (repetitive tasks/sequence of commands) on one or m
 | kubeadm-init    | Executes the kubeadm-init workflow, installs the CNI plugin and then copies the kubeconfig file on the host machine.|
 | manual-copy-certs      | Implement the manual copy of certificates to be shared across control-plane nodes (n.b. manual means not managed by kubeadm).|
 | kubeadm-join    | Executes the kubeadm-join workflow both on secondary control plane nodes and on worker nodes.|
-| kubeadm-upgrade |Executes the kubeadm upgrade workflow and upgrading K8s.|
-| Kubeadm-reset   | Executes the kubeadm-reset workflow on all the nodes.|
+| kubeadm-upgrade | Executes the kubeadm-upgrade workflow and upgrading K8s.|
+| kubeadm-reset   | Executes the kubeadm-reset workflow on all the nodes.|
 | cluster-info    | Returns a summary of cluster info|
 | smoke-test      | Implements a non-exhaustive set of tests|
 

--- a/kinder/cmd/kinder/build/build.go
+++ b/kinder/cmd/kinder/build/build.go
@@ -29,8 +29,8 @@ func NewCommand() *cobra.Command {
 		Args: cobra.NoArgs,
 		// TODO(bentheelder): more detailed usage
 		Use:   "build",
-		Short: "Build one of [base-image, node-image, node-variant]",
-		Long:  "Build the base node image (base-image) or the node image (node-image) or node image variants (node-variant)",
+		Short: "Build one of [base-image, node-image-variant]",
+		Long:  "Build the base node image (base-image) or node image variants (node-image-variant)",
 	}
 	// add subcommands
 	cmd.AddCommand(baseimage.NewCommand())

--- a/kinder/doc/prepare-for-tests.md
+++ b/kinder/doc/prepare-for-tests.md
@@ -8,8 +8,7 @@ pack whatever you need during your test in the node-images.
 kind gives already you what you need in most cases (kubeadm, Kubernetes binaries, pre-pulled images); kinder
 on top of that allows to build node variants for addressing following use cases:
 
-- Adding a Kubernetes version to be used for initializing the cluster (as an alternative to `build node-image
-  --type`(s) already supported by kind)
+- Adding a Kubernetes version to be used for initializing the cluster (as an alternative to `build node-image` already supported by kind)
 - Adding new pre-loaded images that will be made available on all nodes at cluster creation time
 - Replacing the kubeadm binary installed in the cluster, e.g. with a locally build version of kubeadm
 - Replacing the kubelet binary installed in the cluster, e.g. with a locally build version of kubelet
@@ -26,26 +25,18 @@ docker pull kindest/node:vX
 
 ## Build a node-image
 
-For building a node image you can refer to kind documentation; below a short recap of necessary steps:
-
 Build a base-image (or download one from docker hub)
 
 ```bash
 kinder build base-image --image kindest/base:latest
 ```
 
-Build a node-image starting from the above base image using `build node-image --type`(s) supported by kind
+Build a node-image starting from the above base image:
 
 ```bash
-# To build a node-image using latest Kubernetes apt packages available
-kinder build node-image --base-image kindest/base:latest --image kindest/node:vX --type apt
-
-# To build a node-image using local Kubernetes repository
-kinder build node-image --base-image kindest/base:latest --image kindest/node:vX --type bazel
+kind build node-image --base-image kindest/base:latest --image kindest/node:vX
 ```
-
-> NB see <https://github.com/kubernetes/kubeadm/blob/master/docs/testing-pre-releases.md#change-the-target-version-number-when-building-a-local-release> for overriding
-the build version in case of `--type bazel`
+> NB see [kind documentation](https://kind.sigs.k8s.io/docs/user/quick-start/#building-images) for more information about `kind build node-image` usage.
 
 As an alternative, it is possible to pick an existing base image and customize it by adding a Kubernetes
 version with:

--- a/kinder/doc/reference.md
+++ b/kinder/doc/reference.md
@@ -149,8 +149,7 @@ Kind can be extremely efficient when the node image contains all the necessary a
 
 kinder allows kubeadm contributor to exploit this feature by implementing the `kinder build node-image-variant` command, that takes a node-image (or a bare base image) and allows to build variants by:
 
-- Adding a Kubernetes version to be used for initializing the cluster (as an alternative to `build node-image
-  --type`(s) already supported by kind)
+- Adding a Kubernetes version to be used for initializing the cluster (as an alternative to `build node-image` already supported by kind)
 - Adding new pre-loaded images that will be made available on all nodes at cluster creation time
 - Replacing the kubeadm binary installed in the cluster, e.g. with a locally build version of kubeadm
 - Replacing the kubelet binary installed in the cluster, e.g. with a locally build version of kubelet


### PR DESCRIPTION
The command `kinder build node-image` has been removed by #1875, users should use `kind` directly.
And the `apt` build type has been removed by kind with kubernetes-sigs/kind#585.