### PR TITLE
kinder: support and test the --experimental-patches flag for kubeadm

### DIFF
--- a/kinder/ci/workflows/patches-1.19.yaml
+++ b/kinder/ci/workflows/patches-1.19.yaml
@@ -1,0 +1,9 @@
+version: 1
+summary: |
+  This workflow implements a sequence of tasks for testing the patches functionality.
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-patches-1-19
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
+tasks:
+- import: patches-tasks.yaml

--- a/kinder/ci/workflows/patches-master.yaml
+++ b/kinder/ci/workflows/patches-master.yaml
@@ -1,0 +1,9 @@
+version: 1
+summary: |
+  This workflow implements a sequence of tasks for testing the patches functionality.
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-patches-master
+  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest` }}"
+tasks:
+- import: patches-tasks.yaml

--- a/kinder/ci/workflows/patches-tasks.yaml
+++ b/kinder/ci/workflows/patches-tasks.yaml
@@ -1,0 +1,200 @@
+# IMPORTANT! this workflow is imported by patches-* workflows.
+version: 1
+summary: |
+  This workflow implements a sequence of tasks for testing the patches functionality.
+vars:
+  # vars defines default values for variable used by tasks in this workflow;
+  # those values might be overridden when importing this files.
+  kubernetesVersion: v1.16.0
+  baseImage: kindest/base:v20190403-1ebf15f
+  image: kindest/node:test
+  clusterName: kinder-patches
+  kubeadmVerbosity: 6
+tasks:
+  - name: pull-base-image
+    description: |
+      pulls kindest/base image with docker in docker and all the prerequisites necessary for running kind(er)
+    cmd: docker
+    args:
+      - pull
+      - "{{ .vars.baseImage }}"
+  - name: add-kubernetes-versions
+    description: |
+      creates a node-image-variant by adding Kubernetes version "kubernetesVersion"
+      to be used when executing "kinder do kubeadm-init"
+    cmd: kinder
+    args:
+      - build
+      - node-image-variant
+      - --base-image={{ .vars.baseImage }}
+      - --image={{ .vars.image }}
+      - --with-init-artifacts={{ .vars.kubernetesVersion }}
+      - --with-upgrade-artifacts={{ .vars.kubernetesVersion }}
+      - --loglevel=debug
+    timeout: 15m
+  - name: create-cluster
+    description: |
+      create a set of nodes ready for hosting the Kubernetes cluster
+    cmd: kinder
+    args:
+      - create
+      - cluster
+      - --name={{ .vars.clusterName }}
+      - --image={{ .vars.image }}
+      - --control-plane-nodes=2
+      - --worker-nodes=1
+      - --loglevel=debug
+    timeout: 5m
+  - name: prepare patches
+    cmd: /bin/sh
+    args:
+      - -c
+      - |
+        mkdir -p /tmp/kubeadm-patches
+
+        cat <<EOF >/tmp/kubeadm-patches/kube-apiserver.yaml
+        {"metadata":{"annotations":{"patched":"true"}}}
+        EOF
+
+        cat <<EOF >/tmp/kubeadm-patches/kube-controller-manager+merge.yaml
+        metadata:
+          annotations:
+            patched: "true"
+        EOF
+
+        cat <<EOF >/tmp/kubeadm-patches/kube-scheduler0+strategic.yaml
+        metadata:
+          annotations:
+            patched: "true"
+        EOF
+
+        cat <<EOF >/tmp/kubeadm-patches/etcd+json.json
+        {"metadata":{"annotations":{"patched":"true"}}}
+        EOF
+  - name: prepare verify-patches.sh script
+    cmd: /bin/sh
+    args:
+      - -c
+      - |
+        cat <<EOF >/tmp/verify-patches.sh
+        #!/usr/bin/env bash
+        res=0
+        for d in /etc/kubernetes/manifests/*.yaml; do
+          if grep -q "patched: \"true\"" \$d ; then
+              echo "\$d is patched!"
+          else
+              echo "ERROR: \$d is not patched"
+              res=1
+          fi
+        done
+
+        if [[ "\${res}" = 0 ]]; then
+          echo "All verify checks passed, congrats!"
+          echo ""
+        else
+          echo "One or more verify checks failed! See output above..."
+          echo ""
+          exit 1
+        fi
+        EOF
+
+        chmod +x /tmp/verify-patches.sh
+  - name: copy verify-patches.sh on controlplane nodes
+    cmd: kinder
+    args:
+      - cp
+      - --name={{ .vars.clusterName }}
+      - /tmp/verify-patches.sh
+      - "@cp*:/kinder/verify-patches.sh"
+      - --loglevel=debug
+  - name: init
+    description: |
+      Initializes the Kubernetes cluster with version "kubernetesVersion"
+      by starting the bootstrap control-plane node
+    cmd: kinder
+    args:
+      - do
+      - kubeadm-init
+      - --name={{ .vars.clusterName }}
+      - --patches=/tmp/kubeadm-patches
+      - --loglevel=debug
+      - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    timeout: 5m
+  - name: join
+    description: |
+      Join a node using file discovery (without authentication credentials)
+    cmd: kinder
+    args:
+      - do
+      - kubeadm-join
+      - --name={{ .vars.clusterName }}
+      - --patches=/tmp/kubeadm-patches
+      - --loglevel=debug
+      - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    timeout: 10m
+  - name: run verify-patches.sh on controlplane nodes before upgrades
+    cmd: kinder
+    args:
+      - exec
+      - --name={{ .vars.clusterName }}
+      - "@cp*"
+      - /kinder/verify-patches.sh
+      - --loglevel=debug
+  - name: upgrade
+    description: |
+      upgrades the cluster to Kubernetes "upgradeVersion"
+    cmd: kinder
+    args:
+      - do
+      - kubeadm-upgrade
+      - --upgrade-version={{ .vars.kubernetesVersion }}
+      - --patches=/tmp/kubeadm-patches
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+      - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    timeout: 15m
+  - name: run verify-patches.sh on controlplane nodes after upgrades
+    cmd: kinder
+    args:
+      - exec
+      - --name={{ .vars.clusterName }}
+      - "@cp*"
+      - /kinder/verify-patches.sh
+      - --loglevel=debug
+  - name: get-logs
+    description: |
+      Collects all the test logs
+    cmd: kinder
+    args:
+      - export
+      - logs
+      - --loglevel=debug
+      - --name={{ .vars.clusterName }}
+      - "{{ .env.ARTIFACTS }}"
+    force: true
+    timeout: 5m
+    # kind export log is know to be flaky, so we are temporary ignoring errors in order
+    # to make the test pass in case everything else passed
+    # see https://github.com/kubernetes-sigs/kind/issues/456
+    ignoreError: true
+  - name: reset
+    description: |
+      Exec kubeadm reset
+    cmd: kinder
+    args:
+      - do
+      - kubeadm-reset
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+      - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    force: true
+  - name: delete
+    description: |
+      Deletes the cluster
+    cmd: kinder
+    args:
+      - delete
+      - cluster
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+    force: true

--- a/kinder/cmd/kinder/do/do.go
+++ b/kinder/cmd/kinder/do/do.go
@@ -41,6 +41,7 @@ type flagpole struct {
 	DryRun             bool
 	VLevel             int
 	KustomizeDir       string
+	PatchesDir         string
 	Wait               time.Duration
 }
 
@@ -114,6 +115,11 @@ func NewCommand() *cobra.Command {
 		"kustomize-dir", "k", flags.KustomizeDir,
 		"the kustomize folder to be used for init,join and upgrade",
 	)
+	cmd.Flags().StringVar(
+		&flags.PatchesDir,
+		"patches", flags.PatchesDir,
+		"the patches directory to be used for init, join and upgrade",
+	)
 	return cmd
 }
 
@@ -161,6 +167,7 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) (err error) {
 		actions.UpgradeVersion(upgradeVersion),
 		actions.VLevel(flags.VLevel),
 		actions.KustomizeDir(flags.KustomizeDir),
+		actions.PatchesDir(flags.PatchesDir),
 	)
 	if err != nil {
 		return errors.Wrapf(err, "failed to exec action %s", action)

--- a/kinder/pkg/cluster/manager/actions/actions.go
+++ b/kinder/pkg/cluster/manager/actions/actions.go
@@ -42,13 +42,13 @@ var actionRegistry = map[string]func(*status.Cluster, *RunOptions) error{
 		return KubeadmConfig(c, flags.kubeDNS, flags.automaticCopyCerts, flags.discoveryMode, c.K8sNodes().EligibleForActions()...)
 	},
 	"kubeadm-init": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmInit(c, flags.usePhases, flags.kubeDNS, flags.automaticCopyCerts, flags.kustomizeDir, flags.wait, flags.vLevel)
+		return KubeadmInit(c, flags.usePhases, flags.kubeDNS, flags.automaticCopyCerts, flags.kustomizeDir, flags.patchesDir, flags.wait, flags.vLevel)
 	},
 	"kubeadm-join": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmJoin(c, flags.usePhases, flags.automaticCopyCerts, flags.discoveryMode, flags.kustomizeDir, flags.wait, flags.vLevel)
+		return KubeadmJoin(c, flags.usePhases, flags.automaticCopyCerts, flags.discoveryMode, flags.kustomizeDir, flags.patchesDir, flags.wait, flags.vLevel)
 	},
 	"kubeadm-upgrade": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmUpgrade(c, flags.upgradeVersion, flags.kustomizeDir, flags.wait, flags.vLevel)
+		return KubeadmUpgrade(c, flags.upgradeVersion, flags.kustomizeDir, flags.patchesDir, flags.wait, flags.vLevel)
 	},
 	"kubeadm-reset": func(c *status.Cluster, flags *RunOptions) error {
 		return KubeadmReset(c, flags.vLevel)
@@ -135,6 +135,13 @@ func KustomizeDir(kustomizeDir string) Option {
 	}
 }
 
+// PatchesDir option sets the patches dir for the kubeadm commands
+func PatchesDir(patchesDir string) Option {
+	return func(r *RunOptions) {
+		r.patchesDir = patchesDir
+	}
+}
+
 // RunOptions holds options supplied to actions.Run
 type RunOptions struct {
 	kubeDNS            bool
@@ -145,6 +152,7 @@ type RunOptions struct {
 	upgradeVersion     *K8sVersion.Version
 	vLevel             int
 	kustomizeDir       string
+	patchesDir         string
 }
 
 // DiscoveryMode defines discovery mode supported by kubeadm join

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -101,8 +101,8 @@ const (
 	// DiscoveryFile defines the path to a discovery file stored on nodes
 	DiscoveryFile = "/kinder/discovery.conf"
 
-	// KustomizeDir defines the path to patches stored on node
-	KustomizeDir = "/kinder/kustomize"
+	// PatchesDir defines the path to patches stored on node
+	PatchesDir = "/kinder/patches"
 )
 
 // kubernetes releases, used for branching code according to K8s release or kubeadm release version
@@ -121,6 +121,9 @@ var (
 
 	// V1.18 minor version
 	V1_18 = K8sVersion.MustParseSemantic("v1.18.0-0")
+
+	// V1.19 minor version
+	V1_19 = K8sVersion.MustParseSemantic("v1.19.0-0")
 )
 
 // other constants


### PR DESCRIPTION
- Add test workflows
- Add the flag "--patches" for "kinder do"
- Bind the flag to init, join, upgrade.
- Support only Nodes that are >= 1.19.
- Use the same directory constant for kustomize / patches "PatchesDir".

xref https://github.com/kubernetes/kubeadm/issues/2046

/kind feature
/area kinder test
/priority important-soon