### PR TITLE
kinder: increase timeout for building node images to 15m

### DIFF
--- a/kinder/ci/workflows/discovery-tasks.yaml
+++ b/kinder/ci/workflows/discovery-tasks.yaml
@@ -31,7 +31,7 @@ tasks:
     - --image={{ .vars.image }}
     - --with-init-artifacts={{ .vars.kubernetesVersion }}
     - --loglevel=debug
-  timeout: 10m
+  timeout: 15m
 - name: create-cluster
   description: |
     create a set of nodes ready for hosting the Kubernetes cluster

--- a/kinder/ci/workflows/external-etcd.yaml
+++ b/kinder/ci/workflows/external-etcd.yaml
@@ -28,7 +28,7 @@ tasks:
     - --image={{ .vars.image }}
     - --with-init-artifacts={{ .vars.kubernetesVersion }}
     - --loglevel=debug
-  timeout: 10m
+  timeout: 15m
 - name: create-cluster
   description: |
     create a set of nodes ready for hosting the Kubernetes cluster

--- a/kinder/ci/workflows/kustomize-tasks.yaml
+++ b/kinder/ci/workflows/kustomize-tasks.yaml
@@ -32,7 +32,7 @@ tasks:
       - --with-init-artifacts={{ .vars.kubernetesVersion }}
       - --with-upgrade-artifacts={{ .vars.kubernetesVersion }}
       - --loglevel=debug
-    timeout: 10m
+    timeout: 15m
   - name: create-cluster
     description: |
       create a set of nodes ready for hosting the Kubernetes cluster

--- a/kinder/ci/workflows/regular-tasks.yaml
+++ b/kinder/ci/workflows/regular-tasks.yaml
@@ -32,7 +32,7 @@ tasks:
     - --image={{ .vars.image }}
     - --with-init-artifacts={{ .vars.kubernetesVersion }}
     - --loglevel=debug
-  timeout: 10m
+  timeout: 15m
 - name: create-cluster
   description: |
     create a set of nodes ready for hosting the Kubernetes cluster

--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -35,7 +35,7 @@ tasks:
     - --with-init-artifacts={{ .vars.kubernetesVersion }}
     - --with-kubeadm={{ .vars.kubeadmVersion }}
     - --loglevel=debug
-  timeout: 10m
+  timeout: 15m
 - name: create-cluster
   description: |
     create a set of nodes ready for hosting the Kubernetes cluster

--- a/kinder/ci/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-tasks.yaml
@@ -35,7 +35,7 @@ tasks:
     - --with-init-artifacts={{ .vars.initVersion }}
     - --with-upgrade-artifacts={{ .vars.upgradeVersion }}
     - --loglevel=debug
-  timeout: 10m
+  timeout: 15m
 - name: create-cluster
   description: |
     create a set of nodes ready for hosting the Kubernetes cluster
@@ -94,7 +94,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
-  timeout: 10m
+  timeout: 15m
 - name: e2e-kubeadm-after
   description: |
     Runs kubeadm e2e test on the cluster with Kubernetes "upgradeVersion"


### PR DESCRIPTION
Attempt to resolve potential flakes where building the node image
takes more than 10 minutes.
Also increase the timeout for the upgrade task in upgrade-tasks.yaml.

xref https://github.com/kubernetes/kubernetes/issues/90761#issuecomment-647673633