### PR TITLE
kinder: fix wrong patch format in patches-tasks.yaml

### DIFF
--- a/kinder/ci/workflows/patches-tasks.yaml
+++ b/kinder/ci/workflows/patches-tasks.yaml
@@ -69,7 +69,7 @@ tasks:
         EOF
 
         cat <<EOF >/tmp/kubeadm-patches/etcd+json.json
-        {"metadata":{"annotations":{"patched":"true"}}}
+        [{"op":"add","path":"/metadata/annotations/patched","value":"true"}]
         EOF
   - name: prepare verify-patches.sh script
     cmd: /bin/sh


### PR DESCRIPTION
The +json patch file should include a patch that follows RFC6902.

otherwise kubeadm complains that it cannot parse the given patch file for the explicitly specified format.
(expected)