### PR TITLE
fix typos comment and indentation in tests/e2e

### DIFF
--- a/tests/e2e/manifests/README.md
+++ b/tests/e2e/manifests/README.md
@@ -8,7 +8,7 @@ It is run periodically and results are available at https://k8s-testgrid.appspot
 
 ### Running
 
-If you have `go` and `curl` installed you can run the script like so:
+If you have `go`, `curl` and `gcc` installed you can run the script like so:
 
 ```
 ./verify_manifest_lists.sh

--- a/tests/e2e/packages/verify_packages_install_deb.sh
+++ b/tests/e2e/packages/verify_packages_install_deb.sh
@@ -17,7 +17,7 @@ PACKAGES_TO_TEST_EXT=("cri-tools" "kubernetes-cni")
 
 PACKAGES_TO_TEST=("${PACKAGES_TO_TEST_EXT[@]}" "${PACKAGES_TO_TEST_K8S[@]}")
 
-# harcode the LSB release to "xenial" instead of calling "lsb_release -c -s"
+# hardcode the LSB release to "xenial" instead of calling "lsb_release -c -s"
 LSB_RELEASE="xenial"
 
 # install prerequisites

--- a/tests/e2e/packages/verify_packages_published.sh
+++ b/tests/e2e/packages/verify_packages_published.sh
@@ -75,9 +75,9 @@ if [[ ! -z "$available" ]]; then
 fi
 
 if [[ ! -z "$missing" ]]; then
-    echo "ERROR: These versions do not have matching packages:"
-    echo "$missing"
-    exit 1
+	echo "ERROR: These versions do not have matching packages:"
+	echo "$missing"
+	exit 1
 else
 	echo ""
 	echo "TESTS PASSED!! All necessary packages are pushed!"


### PR DESCRIPTION
1. change harcode to hardcode
2. unify indentation with tab
3. gcc is also needed when ./verify_manifest_lists.sh

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>