### PR TITLE
Add links to relevant docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Kubeadm's scope is limited to the local node filesystem and the Kubernetes API, 
 
 ## Documentation
 
-- [Installation Instructions](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
+- [Installing kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
 - [Creating a single control-plane cluster](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/)
-- [Command Reference](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/)
-- [Configuration API Reference](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm) - The documentation for each config file version can be found within the [package sub-directories](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#pkg-subdirectories).
+- [Command-line reference](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/)
+- [Configuration API reference](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm) (pick an API version from the [list of packages](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#pkg-subdirectories))
 
 ## Community, discussion, contribution, and support
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Kubeadm's scope is limited to the local node filesystem and the Kubernetes API, 
 1. **kubeadm upgrade** to upgrade a Kubernetes cluster to a newer version.
 1. **kubeadm reset** to revert any changes made to this host by kubeadm init or kubeadm join.
 
+## Documentation
+
+- [Installation Instructions](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
+- [Command Reference](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/)
+- [Config File Reference](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2) (v1beta2)
+
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community page](https://kubernetes.io/community/).

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Kubeadm's scope is limited to the local node filesystem and the Kubernetes API, 
 ## Documentation
 
 - [Installation Instructions](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
+- [Creating a single control-plane cluster](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/)
 - [Command Reference](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/)
-- [Config File Reference](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2) (v1beta2)
+- [Configuration API Reference](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm) - The documentation for each config file version can be found within the [package sub-directories](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#pkg-subdirectories).
 
 ## Community, discussion, contribution, and support
 


### PR DESCRIPTION
The config file documentation can be especially difficult to find. Add a link to that, as well as a couple of helpful sections of the Kubernetes.io website.