### PR TITLE
verify_manifest_lists.go: fix "panic: could not parse "v1.18.6\n" as version [recovered]" issue

### DIFF
--- a/tests/e2e/manifests/verify_manifest_lists.go
+++ b/tests/e2e/manifests/verify_manifest_lists.go
@@ -631,6 +631,7 @@ func filterVersions(versions VersionList) (VersionList, error) {
 		if err != nil {
 			return versions, err
 		}
+		verFromURL = strings.TrimSpace(verFromURL)
 		minEstimated := version.MustParseGeneric(verFromURL)
 		minor := minEstimated.Minor() - (2 - minEstimated.Minor())
 		semVersion := fmt.Sprintf("%d.%d.%d", minEstimated.Major(), minor, minEstimated.Patch())


### PR DESCRIPTION
verFromURL we get at first is v1.18.6\n, however version.MustParseGeneric can only parse
something like 1.18.6. so we should remove the first and last character

$ curl -s https://storage.googleapis.com/kubernetes-release/release/stable-1.txt
v1.18.6

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>