### PR TITLE
verify_manifest_lists_test.go: add unit test for minEstimated.Minor = 1

### DIFF
--- a/tests/e2e/manifests/verify_manifest_lists_test.go
+++ b/tests/e2e/manifests/verify_manifest_lists_test.go
@@ -134,6 +134,15 @@ func TestFilterVersions(t *testing.T) {
 			},
 		},
 		{
+			name: "valid: list is filtered correctly [3]",
+			input: VersionList{
+				version.MustParseSemantic("2.1.7"),
+			},
+			output: VersionList{
+				version.MustParseSemantic("2.1.7"),
+			},
+		},
+		{
 			name: "valid: result is an empty list",
 			input: VersionList{
 				version.MustParseSemantic("1.12.0-beta.2"),


### PR DESCRIPTION
Now we haven't test minEstimated.Minor() = 1 situation in func
filterVersions

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>