### PR TITLE
kinder: avoid orphaning child processes on task timeouts

### DIFF
--- a/kinder/pkg/test/workflow/taskCmdRunner.go
+++ b/kinder/pkg/test/workflow/taskCmdRunner.go
@@ -287,18 +287,23 @@ func cleanup(cmd *exec.Cmd) {
 		}
 	}()
 
-	/* temporary disabled to better investigate test-grid failures
+	// obtain the process ground ID
 	pgid, err := syscall.Getpgid(cmd.Process.Pid)
 	if err != nil {
-		cmd.Process.Kill()
+		fmt.Printf("error: failed obtaining the pgid for pid: %v, %v\n", cmd.Process.Pid, err)
+		goto kill_process
 	}
 
-	if err := syscall.Kill(-pgid, syscall.SIGABRT); err == nil {
-		return
+	// kill all processes in the process group
+	if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
+		fmt.Printf("error: failed to kill pgid: %v, %v\n", pgid, err)
+		goto kill_process
 	}
+	return
 
-	syscall.Kill(-pgid, syscall.SIGTERM)
-	*/
-
-	cmd.Process.Kill()
+kill_process:
+	fmt.Println("falling back to killing the parent process only...")
+	if err := cmd.Process.Kill(); err != nil {
+		fmt.Printf("error: failed killing process with pid: %v, %v\n", cmd.Process.Pid, err)
+	}
 }


### PR DESCRIPTION
When a task has timed out, ideally the whole process tree should be
terminated with a SIGKILL.

The e2e suite has some caveats with AfterSuite() functions and
these can only contribute noise to the logs. A SIGKILL to
the parent process (Golang command) and the child processes such
as Ginkgo, ensure that everything is terminated right away.

Otherwise, Ginkgo can continue running while the cluster is
being destroyed and fill the logs with errors.

Originally this code was disabled for debugging, but executing it
is mandatory. Add more debug messages to help find problems around
obtaining a pgid or killing a process tree in case failures in CI
are seen again.

fixes https://github.com/kubernetes/kubeadm/issues/2252
