### PR TITLE
fix wrong dir

### DIFF
--- a/operator/hack/verify-shellcheck.sh
+++ b/operator/hack/verify-shellcheck.sh
@@ -41,7 +41,7 @@ tar xf "${DOWNLOAD_FILE}"
 cd "${VERSION}" || exit
 
 echo "Running shellcheck..."
-cd "${ROOT_PATH}/operator" || exit
+cd "${ROOT_PATH}" || exit
 OUT="${TMP_DIR}/out.log"
 FILES=$(find . -name "*.sh")
 while read -r file; do


### PR DESCRIPTION
fix the following issue:
  operator/hack/verify-shellcheck.sh: line 44: cd: /root/go/src/github.com/kubernetes/kubeadm/operator/operator: No such file or directory

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>