### PR TITLE
update shellcheck url

### DIFF
--- a/operator/hack/verify-shellcheck.sh
+++ b/operator/hack/verify-shellcheck.sh
@@ -36,7 +36,7 @@ trap cleanup EXIT
 cd "${TMP_DIR}" || exit
 VERSION="shellcheck-stable"
 DOWNLOAD_FILE="${VERSION}.${os}.x86_64.tar.xz"
-wget https://storage.googleapis.com/shellcheck/"${DOWNLOAD_FILE}"
+wget https://github.com/koalaman/shellcheck/releases/download/stable/"${DOWNLOAD_FILE}"
 tar xf "${DOWNLOAD_FILE}"
 cd "${VERSION}" || exit
 


### PR DESCRIPTION
shellcheck url has been changed and its breaking the build with the following error:

  You are downloading ShellCheck from an outdated URL!

  Please update to the new URL:
  https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz

  For more information, see:
  https://github.com/koalaman/shellcheck/issues/1871

  PS: Sorry for breaking your build :(

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>