### PR TITLE
fix wrong kinder shellcheck url

### DIFF
--- a/kinder/hack/verify-shellcheck.sh
+++ b/kinder/hack/verify-shellcheck.sh
@@ -34,9 +34,9 @@ trap cleanup EXIT
 
 # install shellcheck (Linux-x64 only!)
 cd "${TMP_DIR}" || exit
-VERSION="shellcheck-v0.6.0"
+VERSION="shellcheck-stable"
 DOWNLOAD_FILE="${VERSION}.linux.x86_64.tar.xz"
-wget https://storage.googleapis.com/shellcheck/"${DOWNLOAD_FILE}"
+wget https://github.com/koalaman/shellcheck/releases/download/stable/"${DOWNLOAD_FILE}"
 tar xf "${DOWNLOAD_FILE}"
 cd "${VERSION}" || exit
 


### PR DESCRIPTION
  1. change to use stable version
  2. change shellcheck url since old url is unavailable now

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>