### PR TITLE
fix small shellcheck issue

### DIFF
--- a/kinder/hack/verify-whitespace.sh
+++ b/kinder/hack/verify-whitespace.sh
@@ -25,7 +25,7 @@ echo "Verifying trailing whitespace..."
 TRAILING="$(grep -rnI '[[:blank:]]$' .)"
 
 ERR="0"
-if [[ ! -z "$TRAILING" ]]; then
+if [[ -n "$TRAILING" ]]; then
     echo "Found trailing whitespace in the follow files:"
     echo "${TRAILING}"
     ERR="1"


### PR DESCRIPTION
  fix the following issue:
    In ./hack/verify-whitespace.sh line 28:
    if [[ ! -z "$TRAILING" ]]; then
          ^-- SC2236: Use -n instead of ! -z.

    For more information:
      https://www.shellcheck.net/wiki/SC2236 -- Use -n instead of ! -z.

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>