### PR TITLE
[Kinder] Dropping support for v1.16

### DIFF
--- a/kinder/pkg/cluster/manager/actions/kubeadm-init.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-init.go
@@ -40,9 +40,9 @@ import (
 func KubeadmInit(c *status.Cluster, usePhases, kubeDNS, automaticCopyCerts bool, kustomizeDir, patchesDir string, wait time.Duration, vLevel int) (err error) {
 	cp1 := c.BootstrapControlPlane()
 
-	// fail fast if required to use kustomize and kubeadm less than v1.16
-	if kustomizeDir != "" && cp1.MustKubeadmVersion().LessThan(constants.V1_16) {
-		return errors.New("--kustomize-dir can't be used with kubeadm older than v1.16")
+	// fail fast if required to use kustomize and kubeadm less than v1.17
+	if kustomizeDir != "" && cp1.MustKubeadmVersion().LessThan(constants.V1_17) {
+		return errors.New("--kustomize-dir can't be used with kubeadm older than v1.17")
 	}
 
 	// if kustomize copy patches to the node

--- a/kinder/pkg/cluster/manager/actions/kubeadm-join.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-join.go
@@ -43,9 +43,9 @@ func joinControlPlanes(c *status.Cluster, usePhases, automaticCopyCerts bool, di
 	cpX := []*status.Node{c.BootstrapControlPlane()}
 
 	for _, cp2 := range c.SecondaryControlPlanes().EligibleForActions() {
-		// fail fast if required to use kustomize and kubeadm less than v1.16
-		if kustomizeDir != "" && cp2.MustKubeadmVersion().LessThan(constants.V1_16) {
-			return errors.New("--kustomize-dir can't be used with kubeadm older than v1.16")
+		// fail fast if required to use kustomize and kubeadm less than v1.17
+		if kustomizeDir != "" && cp2.MustKubeadmVersion().LessThan(constants.V1_17) {
+			return errors.New("--kustomize-dir can't be used with kubeadm older than v1.17")
 		}
 
 		// if kustomize copy patches to the node

--- a/kinder/pkg/cluster/manager/actions/kubeadm-upgrade.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-upgrade.go
@@ -45,9 +45,9 @@ func KubeadmUpgrade(c *status.Cluster, upgradeVersion *K8sVersion.Version, kusto
 
 	for _, n := range nodeList {
 
-		// fail fast if required to use kustomize and kubeadm less than v1.16
-		if kustomizeDir != "" && n.MustKubeadmVersion().LessThan(constants.V1_16) {
-			return errors.New("--kustomize-dir can't be used with kubeadm older than v1.16")
+		// fail fast if required to use kustomize and kubeadm less than v1.17
+		if kustomizeDir != "" && n.MustKubeadmVersion().LessThan(constants.V1_17) {
+			return errors.New("--kustomize-dir can't be used with kubeadm older than v1.17")
 		}
 
 		// if kustomize copy patches to the node

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -107,9 +107,6 @@ const (
 
 // kubernetes releases, used for branching code according to K8s release or kubeadm release version
 var (
-	// V1.16 minor version
-	V1_16 = K8sVersion.MustParseSemantic("v1.16.0-0")
-
 	// V1.17 minor version
 	V1_17 = K8sVersion.MustParseSemantic("v1.17.0-0")
 


### PR DESCRIPTION
This CL aims to remove kinder support for v1.16 while
init, join and upgrade actions.
This solves task 1 of #2277 
Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>