### PR TITLE
kinder: make the task runner perform cleanup only on existing processes

### DIFF
--- a/kinder/pkg/test/workflow/taskCmdRunner.go
+++ b/kinder/pkg/test/workflow/taskCmdRunner.go
@@ -287,6 +287,12 @@ func cleanup(cmd *exec.Cmd) {
 		}
 	}()
 
+	// if the process doesn't exist we can skip the cleanup
+	// https://man7.org/linux/man-pages/man2/kill.2.html
+	if err := syscall.Kill(cmd.Process.Pid, syscall.Signal(0)); err != nil {
+		return
+	}
+
 	// obtain the process ground ID
 	pgid, err := syscall.Getpgid(cmd.Process.Pid)
 	if err != nil {


### PR DESCRIPTION
If the process PID no longer exists we can omit killing the process
tree in cleanup(). Passing 0 as the signal to syscall.Kill() is used
to determine if the process is still running.

https://man7.org/linux/man-pages/man2/kill.2.html

"If sig is 0, then no signal is sent, but existence and permission
checks are still performed; this can be used to check for the
existence of a process ID or process group ID that the caller is
permitted to signal."

This avoids errors if the command process already terminated, - e.g:
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-17-1-18/1306307188003704834
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-17-1-18/1306307188003704834/build-log.txt

> error: failed obtaining the pgid for pid: 2405, no such process
falling back to killing the parent process only...
error: failed killing process with pid: 2405, os: process already finished

fixes: https://github.com/kubernetes/kubeadm/issues/2252
