### PR TITLE
kinder: a couple of fixes for external-ca

### DIFF
--- a/kinder/ci/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/workflows/external-ca-tasks.yaml
@@ -82,6 +82,7 @@ tasks:
       - --ignore-preflight-errors=FileAvailable--etc-kubernetes-kubelet.conf,FileAvailable--etc-kubernetes-pki-ca.crt,Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    timeout: 10m
   - name: e2e-kubeadm
     description: |
       Runs kubeadm e2e tests

--- a/kinder/pkg/cluster/manager/actions/setup-external-ca.go
+++ b/kinder/pkg/cluster/manager/actions/setup-external-ca.go
@@ -35,9 +35,11 @@ func SetupExternalCA(c *status.Cluster, vLevel int) error {
 	}
 
 	// generate certs on the primary node
+	// ensure that "localhost" is included for the SANs for the kube-apiserver serving certificate,
+	// so that the server is accessible from the kubeconfig on the host
 	if err := c.BootstrapControlPlane().Command(
 		"/bin/sh", "-c",
-		fmt.Sprintf("kubeadm init phase certs all --control-plane-endpoint=%s --v=%d",
+		fmt.Sprintf("kubeadm init phase certs all --control-plane-endpoint=%s --apiserver-cert-extra-sans=localhost --v=%d",
 			loadBalancerIP,
 			vLevel),
 	).RunWithEcho(); err != nil {
@@ -85,7 +87,7 @@ func SetupExternalCA(c *status.Cluster, vLevel int) error {
 		// generate remaining certificates
 		if err := n.Command(
 			"/bin/sh", "-c",
-			fmt.Sprintf("kubeadm init phase certs all --control-plane-endpoint=%s --v=%d",
+			fmt.Sprintf("kubeadm init phase certs all --control-plane-endpoint=%s --apiserver-cert-extra-sans=localhost --v=%d",
 				loadBalancerIP,
 				vLevel),
 		).RunWithEcho(); err != nil {


### PR DESCRIPTION
the tests are failing as can be seen here:
https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-ca-latest

----
problem 1:

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-external-ca-latest/1311057566834364416

join seems flaky and needs more time: 
```
kinder.test.workflow: task-05-join expand_less | 5m0s
-- | --
timeout. The task did not complete in less than 5m0s as expected
```

----
problem 2:

the kubeadm e2e test suite is also failing because the kubeconfig on the host tries to connect the api-server on "localhost" but the serving cert on all CP nodes does not have "localhost" in the SANs:
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-external-ca-latest/1311027115340075008
