### PR TITLE
Avoid linking to the "master" branch of repositories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,10 @@ These pages cover topics such as installation steps, troubleshooting and command
 You can help `kubeadm` **a lot** by filling issue reports for inconsistencies and keeping the documentation up-to-date by submitting PRs.
 
 The process for contributing to the website is very straight forward and is outlined here:
-* https://github.com/kubernetes/website/blob/master/CONTRIBUTING.md
+* https://git.k8s.io/website/CONTRIBUTING.md
 
 Here is a document that explains the process of updating the `kubeadm` command line reference:
-* https://github.com/kubernetes/kubeadm/blob/master/docs/updating-command-reference.md
+* https://git.k8s.io/kubeadm/docs/updating-command-reference.md
 
 ### Building
 
@@ -52,7 +52,7 @@ or kubeadm and how to test them.
 
 ### Adding dependencies
 
-If your patch depends on new packages, add that package with [`godep`](https://github.com/tools/godep). Follow the [instructions to add a dependency](https://github.com/kubernetes/community/blob/master/contributors/devel/development.md).
+If your patch depends on new packages, add that package with [`godep`](https://github.com/tools/godep). Follow the [instructions to add a dependency](https://git.k8s.io/community/contributors/devel/development.md).
 
 ### Running unit tests
 
@@ -70,7 +70,7 @@ make test-cmd WHAT=kubeadm
 ```
 
 For more information about running tests in Kubernetes have a look at:
-* https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
+* https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
 
 For more general information about unit tests in Go please have a look at:
 * https://golang.org/pkg/testing/

--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,5 @@
 # See the OWNERS file documentation:
-#  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
+#  https://git.k8s.io/community/contributors/devel/owners.md
 
 approvers:
 - luxas

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubeadm
 
-The purpose of this repo is to aggregate issues filed against the [kubeadm component](https://github.com/kubernetes/kubernetes/tree/master/cmd/kubeadm).
+The purpose of this repo is to aggregate issues filed against the [kubeadm component](https://git.k8s.io/kubernetes/cmd/kubeadm).
 
 ## What is Kubeadm ?
 Kubeadm is a tool built to provide best-practice "fast paths" for creating Kubernetes clusters.
@@ -25,7 +25,7 @@ Kubeadm's scope is limited to the local node filesystem and the Kubernetes API, 
 
 Learn how to engage with the Kubernetes community on the [community page](https://kubernetes.io/community/).
 
-You can reach the maintainers of this project at the [Cluster Lifecycle SIG](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle#cluster-lifecycle-sig).
+You can reach the maintainers of this project at the [Cluster Lifecycle SIG](https://git.k8s.io/community/sig-cluster-lifecycle#cluster-lifecycle-sig).
 
 ## Roadmap
 

--- a/docs/design/design_v1.10.md
+++ b/docs/design/design_v1.10.md
@@ -233,7 +233,7 @@ Other flags that are set unconditionally:
     - [`DefaultTolerationSeconds`](https://kubernetes.io/docs/admin/admission-controllers/#defaulttolerationseconds) .
     - [`NodeRestriction`](https://kubernetes.io/docs/admin/admission-controllers/#noderestriction) to limit what a kubelet can modify (e.g. its own pods).
  - `--kubelet-preferred-address-types` to `InternalIP,ExternalIP,Hostname;` this makes `kubectl logs` and other apiserver -> kubelet communication work in environments where the hostnames of the nodes aren't resolvable.
- - `requestheader-client-ca-file` to`front-proxy-ca.crt`,  `proxy-client-cert-file` to `front-proxy-client.crt`,  `proxy-client-key-file` to `front-proxy-client.key` ,  and`--requestheader-username-headers=X-Remote-User`, `--requestheader-group-headers=X-Remote-Group`, `--requestheader-extra-headers-prefix=X-Remote-Extra-`, `--requestheader-allowed-names=front-proxy-client` so the front proxy ([API Aggregation](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/aggregated-api-servers.md)) communication is secure.
+ - `requestheader-client-ca-file` to`front-proxy-ca.crt`,  `proxy-client-cert-file` to `front-proxy-client.crt`,  `proxy-client-key-file` to `front-proxy-client.key` ,  and`--requestheader-username-headers=X-Remote-User`, `--requestheader-group-headers=X-Remote-Group`, `--requestheader-extra-headers-prefix=X-Remote-Extra-`, `--requestheader-allowed-names=front-proxy-client` so the front proxy ([API Aggregation](https://git.k8s.io/community/contributors/design-proposals/api-machinery/aggregated-api-servers.md)) communication is secure.
 
 #### Controller manager
 
@@ -323,7 +323,7 @@ Please note that
 
 ### Configure TLS-Bootstrapping for node joining
 
-Kubeadm uses [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) for joining new nodes to an existing cluster; for more details see also [design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
+Kubeadm uses [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) for joining new nodes to an existing cluster; for more details see also [design proposal](https://git.k8s.io/community/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
 
 `kubeadm init`  ensures that everything is properly configured for this process, and this includes following steps as well as setting API server and controller flags as already described in previous paragraphs.
 
@@ -434,7 +434,7 @@ Similarly to `kubeadm init`, also `kubeadm join` internal workflow consists of a
 
 This is split into discovery (having the Node trust the Kubernetes Master) and TLS bootstrap (having the Kubernetes Master trust the Node).
 
-see [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) , [design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
+see [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) , [design proposal](https://git.k8s.io/community/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
 
 ### Preflight checks
 

--- a/docs/design/design_v1.7.md
+++ b/docs/design/design_v1.7.md
@@ -185,11 +185,11 @@ kubectl label node ${master_name} node-role.kubernetes.io/master=""
 
 #### cluster-info
 
-This phase creates the `cluster-info` ConfigMap in the `kube-public` namespace as defined in [the Bootstrap Tokens proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md)
+This phase creates the `cluster-info` ConfigMap in the `kube-public` namespace as defined in [the Bootstrap Tokens proposal](https://git.k8s.io/community/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md)
  - The `ca.crt` and the address/port of the apiserver is added to the `cluster-info` ConfigMap in the `kubeconfig` key
  - Exposes the `cluster-info` ConfigMap to unauthenticated users (i.e. users in RBAC group `system:unauthenticated`)
 
-**Note:** The access to the `cluster-info` ConfigMap _is not_ rate-limited. 
+**Note:** The access to the `cluster-info` ConfigMap _is not_ rate-limited.
 This may or may not be a problem if you expose your master to the internet.
 Worst-case scenario here is a DoS attack where an attacker uses all the in-flight requests the kube-apiserver can handle to serving the `cluster-info` ConfigMap.
 TBD for v1.8
@@ -224,7 +224,7 @@ The `system:bootstrappers` Group is granted auto-approving status by it being ab
  - The auto-approving certificate controller in the controller-manager checks whether the poster of the CSR (in this case the Bootstrap Token) can POST to
    `/apis/certificates.k8s.io/certificatesigningrequests/nodeclient`. If the poster can, the controller approves the CSR.
  - This makes it possible to easily revoke the auto-approving functionality by removing the `ClusterRoleBinding` that grants Bootstrap Tokens that, or you can
-   revoke access for all Bootstrap Tokens and instead make the auto-approving more granular by granting just a few users or tokens access to auto-approved credentials. 
+   revoke access for all Bootstrap Tokens and instead make the auto-approving more granular by granting just a few users or tokens access to auto-approved credentials.
 
 ## `kubeadm join` phases
 

--- a/docs/design/design_v1.8.md
+++ b/docs/design/design_v1.8.md
@@ -67,16 +67,16 @@ This means we aim to standardize:
 
 `kubeadm init` internal workflow consists of a sequence of atomic work tasks to perform.
 
-The `kubeadm phase` command, (in v1.8 staged under `kubeadm alpha phase`), allows users to invoke individually each task, and ultimately offers a reusable and composable API/toolbox that can be used by other kubernetes bootstrap tools / by any IT automation tool / by advanced user for creating custom clusters. 
+The `kubeadm phase` command, (in v1.8 staged under `kubeadm alpha phase`), allows users to invoke individually each task, and ultimately offers a reusable and composable API/toolbox that can be used by other kubernetes bootstrap tools / by any IT automation tool / by advanced user for creating custom clusters.
 
 ### Preflight checks
 
-`kubeadm` executes a set of preflight checks before starting the init, with the aim to verify preconditions and avoid common cluster startup problems. 
+`kubeadm` executes a set of preflight checks before starting the init, with the aim to verify preconditions and avoid common cluster startup problems.
 In any case the user can skip preflight checks with the `--skip-preflight-checks` option.
 
 - [warning] If the Kubernetes version to use (passed with the `--kubernetes-version` flag) is one minor version higher than the kubeadm CLI version.
-- Kubernetes system requirements, 
-  - [error] if not linux, 
+- Kubernetes system requirements,
+  - [error] if not linux,
   - [error] if not Kernel 3.10+ or 4+ with specific KernelSpec,
   - [error] if required cgroups subsystem aren't in set up,
   - [error/warning] if Docker endpoint does not exist or does not work, if docker version v1.11.2 <= x <= v1.13.1,
@@ -169,7 +169,7 @@ Please note that:
 
 Common properties for the control plane components:
 
-- `hostNetwork: true` is present on all static pods since there is no network configured yet; accordingly 
+- `hostNetwork: true` is present on all static pods since there is no network configured yet; accordingly
   -  the `address` of the API server for controller-manager and the scheduler will be set to `127.0.0.1`
   -  if using a local etcd server, `etcd-servers` address  will be set to `127.0.0.1:2379`
 - Leader election is enabled for both the controller-manager and the scheduler
@@ -202,8 +202,8 @@ Other flags that are set unconditionally:
  - `--requestheader-client-ca-file` to `front-proxy-ca.crt`
  - `--admission-control` to `Initializers, NamespaceLifecycle, LimitRanger, ServiceAccount, PersistentVolumeLabel, DefaultStorageClass, DefaultTolerationSeconds, NodeRestriction, ResourceQuota`...or whatever the recommended set of admission controllers is at a given version
  - `--kubelet-preferred-address-types` to `InternalIP,ExternalIP,Hostname;` this makes `kubectl logs` and other apiserver -> kubelet communication work in environments where the hostnames of the nodes aren't resolvable
- - `requestheader-client-ca-file` to`front-proxy-ca.crt`,  `proxy-client-cert-file` to `front-proxy-client.crt`,  `proxy-client-key-file` to `front-proxy-client.key` ,  and`--requestheader-username-headers=X-Remote-User`, `--requestheader-group-headers=X-Remote-Group`, `--requestheader-extra-headers-prefix=X-Remote-Extra-`, `--requestheader-allowed-names=front-proxy-client` so the front proxy ([API Aggregation](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/aggregated-api-servers.md)) communication is secure.
- - `--allow-privileged` to `true` 
+ - `requestheader-client-ca-file` to`front-proxy-ca.crt`,  `proxy-client-cert-file` to `front-proxy-client.crt`,  `proxy-client-key-file` to `front-proxy-client.key` ,  and`--requestheader-username-headers=X-Remote-User`, `--requestheader-group-headers=X-Remote-Group`, `--requestheader-extra-headers-prefix=X-Remote-Extra-`, `--requestheader-allowed-names=front-proxy-client` so the front proxy ([API Aggregation](https://git.k8s.io/community/contributors/design-proposals/api-machinery/aggregated-api-servers.md)) communication is secure.
+ - `--allow-privileged` to `true`
 
 
 #### Controller Manager
@@ -215,7 +215,7 @@ Other flags that are set unconditionally:
  - The `BootstrapSigner` and `TokenCleaner` controllers are enabled
  - `--root-ca-file` to `ca.crt`
  - `--cluster-signing-cert-file` to `ca.crt`, if External CA mode is disabled, otherwise to `""`.
- - `--cluster-signing-key-file` to `ca.key`, if External CA mode is disabled, otherwise to `""`. 
+ - `--cluster-signing-key-file` to `ca.key`, if External CA mode is disabled, otherwise to `""`.
  - `--service-account-private-key-file` to `sa.key`
  - `--use-service-account-credentials` to `true`
 
@@ -253,25 +253,25 @@ kubeadm saves the configuration passed to `kubeadm init`, either via flags or th
 
 This will ensure that kubeadm actions executed in future (e.g `kubeadm upgrade`) will be able to determine the actual/current cluster state and make new decisions based on that data.
 
-Please note that 
+Please note that
 
 1. Upload of master configuration can be invoked individually with the `kubeadm phase upload-config` command.
 2. If you initialized your cluster using kubeadm v1.7.x or lower, you must create manually the master configuration ConfigMap before `kubeadm upgrade` to v1.8 . In order to facilitate this task, the ` kubeadm config upload (from-flags|from-file)` was implemented.
 
 ### Mark master
 
-As soon as the control plane is available, kubeadm executes following actions: 
+As soon as the control plane is available, kubeadm executes following actions:
 
-- Label  the master with `node-role.kubernetes.io/master=""` 
+- Label  the master with `node-role.kubernetes.io/master=""`
 - Taints  the master with `node-role.kubernetes.io/master:NoSchedule`
 
-Please note that 
+Please note that
 
 1. Mark master phase can be invoked individually with the `kubeadm phase mark-master` command.
 
 ### Configure TLS-Bootstrapping for node joining
 
-Kubeadm uses [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) for joining new nodes to an existing cluster; for more details see also [design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
+Kubeadm uses [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) for joining new nodes to an existing cluster; for more details see also [design proposal](https://git.k8s.io/community/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
 
 `kubeadm init`  ensures that everything is properly configured for this process, and this includes following steps as well as setting API Server and controller flags as already described in previous paragraphs.
 
@@ -279,7 +279,7 @@ Kubeadm uses [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/a
 
 `kubeadm init`  create a first bootstrap token, either generated automatically or provided by the user with the `--token` flag; as documented in bootstrap token specification, token should be saved as secrets with name `bootstrap-token-<token-id>` under `kube-system` namespace.
 
-Please note that 
+Please note that
 
 1. The token will be used to validate temporary user during TLS bootstrap process; those users will be member of  `system:bootstrappers:kubeadm:default-node-token` group (nb. formerly `system:bootstrappers` in v1.7)
 2. Starting from 1.8 token has a limited validity, default 24Hours (that can be changed with `—token-ttl` flag)
@@ -291,7 +291,7 @@ kubeadm ensure that users in  `system:bootstrappers:kubeadm:default-node-token` 
 
 This is implemented by creating a ClusterRoleBinding named `kubeadm:kubelet-bootstrap` between the  group above and the default RBAC role `system:node-bootstrapper`.
 
-Please note that 
+Please note that
 
 1. This phase can be invoked individually with the `kubeadm phase bootstrap-token node allow-post-csrs` command.
 
@@ -303,7 +303,7 @@ This is implemented by creating ClusterRoleBinding named `kubeadm:node-autoappro
 
 The role `system:certificates.k8s.io:certificatesigningrequests:nodeclient` should be created as well, granting POST permission to `/apis/certificates.k8s.io/certificatesigningrequests/nodeclient` (in v1.8  role will be automatically created by default).
 
-Please note that 
+Please note that
 
 1. This phase can be invoked individually with the `kubeadm phase bootstrap-token node allow-auto-approve` command.
 
@@ -313,7 +313,7 @@ This phase creates the `cluster-info` ConfigMap in the `kube-public` namespace.
 
 Additionally it is created a role and a RoleBinding granting access for to the ConfigMap for unauthenticated users (i.e. users in RBAC group `system:unauthenticated`)
 
-Please note that 
+Please note that
 
 1. The access to the `cluster-info` ConfigMap _is not_ rate-limited. This may or may not be a problem if you expose your master to the internet; worst-case scenario here is a DoS attack where an attacker uses all the in-flight requests the kube-apiserver can handle to serving the `cluster-info` ConfigMap.
 2. This phase can be invoked individually with the `kubeadm phase bootstrap-token node allow-auto-approve` command.
@@ -326,7 +326,7 @@ A ServiceAccount for `kube-proxy` is created in the `kube-system` namespace; the
 - the location of the master comes from a ConfigMap
 - the `kube-proxy` ServiceAccount is bound to the privileges in the `system:node-proxier` ClusterRole
 
-Please note that 
+Please note that
 
 1. This phase can be invoked individually with the `kubeadm phase addon kube-proxy`  command.
 
@@ -339,7 +339,7 @@ Deploy the kube-dns Deployment and Service:
 - it's the upstream kube-dns deployment relatively unmodified
 - the `kube-dns` ServiceAccount is bound to the privileges in the `system:kube-dns` ClusterRole
 
-Please note that 
+Please note that
 
 1. This phase can be invoked individually with the `kubeadm phase addon kube-dns`  command.
 
@@ -349,10 +349,10 @@ This phase is performed only if `kubeadm init` is invoked with `—features-gate
 
 The self hosting phase basically replaces static pods for control plane components with DaemonSets; this is achieved by executing following procedure for API Server, scheduler and controller manager static pods:
 
-- Load the Static Pod specification from disk 
+- Load the Static Pod specification from disk
 - Extract the PodSpec from that Static Pod specification
 - Mutate the PodSpec to be compatible with self-hosting, and more in detail:
-  - add node selector attribute targeting nodes with`node-role.kubernetes.io/master=""`  label, 
+  - add node selector attribute targeting nodes with`node-role.kubernetes.io/master=""`  label,
   - add a toleration for `node-role.kubernetes.io/master:NoSchedule` taint,
   - set `spec.DNSPolicy` to `ClusterFirstWithHostNet`
 - Build a new DaemonSet object for the self-hosted component in question. Use the above mentioned PodSpec
@@ -380,11 +380,11 @@ Similarly to `kubeadm init`, also `kubeadm join` internal workflow consists of a
 
 This is split into discovery (having the Node trust the Kubernetes Master) and TLS bootstrap (having the Kubernetes Master trust the Node).
 
-see [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) , [design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
+see [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) , [design proposal](https://git.k8s.io/community/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
 
 ### Discovery cluster-info
 
-There are 2 main schemes for discovery. The first is to use a shared token along with the IP address of the API server. The second is to provide a file (a subset of the standard kubeconfig file). 
+There are 2 main schemes for discovery. The first is to use a shared token along with the IP address of the API server. The second is to provide a file (a subset of the standard kubeconfig file).
 
 #### Shared token discovery
 
@@ -393,7 +393,7 @@ If `kubeadm join` is invoked with `--discovery-token`, token discovery is used; 
 In order to prevent "man in the middle" attacks, several steps are taken:
 
 - First, the CA certificate is retrieved via insecure connection (NB. this is possible because `kubeadm init` granted access to  `cluster-info` users for `system:unauthenticated` )
-- Then the CA certificate goes through following validation steps: 
+- Then the CA certificate goes through following validation steps:
   - "Basic validation", using the token ID against a JWT signature
   - "Pub key validation", using provided `--discovery-token-ca-cert-hash`. This value is available in the output of "kubeadm init" or can be calculated using standard tools (the hash is calculated over the bytes of the Subject Public Key Info (SPKI) object as in RFC7469). The `--discovery-token-ca-cert-hash flag` may be repeated multiple times to allow more than one public key.
   - as a additional validation, the CA certificate is retrieved via secure connection and then compared with the CA retrieved initially
@@ -428,13 +428,13 @@ Finally, when the connection with the cluster is established, kubeadm try to acc
 
 Once the cluster info are known, the file `bootstrap-kubelet.conf` is written, allowing kubelet to do TLS Bootstrapping (conversely in v.1.7 TLS were managed by kubeadm).
 
-The TLS bootstrap mechanism uses the shared token to temporarily authenticate with the Kubernetes Master to submit a certificate signing request (CSR) for a locally created key pair. 
+The TLS bootstrap mechanism uses the shared token to temporarily authenticate with the Kubernetes Master to submit a certificate signing request (CSR) for a locally created key pair.
 
 The request is then automatically approved and the operation completes saving `ca.crt` file and `kubelet.conf` file to be used by kubelet for joining the cluster, while`bootstrap-kubelet.conf` is deleted.
 
 Please note that:
 
-- The temporary authentication is validated against the token saved during the `kubeadm init` process (or with additional tokens created with `kubeadm token`) 
+- The temporary authentication is validated against the token saved during the `kubeadm init` process (or with additional tokens created with `kubeadm token`)
 - The temporary authentication resolve to a user member of  `system:bootstrappers:kubeadm:default-node-token` group which was granted access to CSR api during the `kubeadm init` process
 - The automatic CSR approval is managed by the csrapprover controller, according with configuration done the `kubeadm init` process
 

--- a/docs/design/design_v1.9.md
+++ b/docs/design/design_v1.9.md
@@ -67,11 +67,11 @@ This means we aim to standardize:
 
 `kubeadm init` internal workflow consists of a sequence of atomic work tasks to perform.
 
-The `kubeadm alpha phase` command allows users to invoke individually each task, and ultimately offers a reusable and composable API/toolbox that can be used by other Kubernetes bootstrap tools / by any IT automation tool / by advanced user for creating custom clusters. 
+The `kubeadm alpha phase` command allows users to invoke individually each task, and ultimately offers a reusable and composable API/toolbox that can be used by other Kubernetes bootstrap tools / by any IT automation tool / by advanced user for creating custom clusters.
 
 ### Preflight checks
 
-`kubeadm` executes a set of preflight checks before starting the init, with the aim to verify preconditions and avoid common cluster startup problems. 
+`kubeadm` executes a set of preflight checks before starting the init, with the aim to verify preconditions and avoid common cluster startup problems.
 In any case the user can skip specific preflight checks (or eventually all preflight checks) with the `--ignore-preflight-errors` option.
 
 - [warning] If the Kubernetes version to use (passed with the `--kubernetes-version` flag) is at least one minor version higher than the kubeadm CLI version.
@@ -102,11 +102,11 @@ In any case the user can skip specific preflight checks (or eventually all prefl
   - [warning/error] if Docker service does not exist, if it is disabled, if it is not active.
 - If using other cri engine:
   - [error] if crictl socket does not answer.
-- If external etcd is provided: 
+- If external etcd is provided:
   - [Error] if etcd version less than 3.0.14.
-  - [Error] if certificates or keys are specified, but not provided. 
-- If external etcd is NOT provided: 
-  - [Error] if ports 2379 is used. 
+  - [Error] if certificates or keys are specified, but not provided.
+- If external etcd is NOT provided:
+  - [Error] if ports 2379 is used.
   - [Error] if Etcd.DataDir folder already exists and it is not empty.
 - If authorization mode is ABAC, [Error] if abac_policy.json does not exist.
 - If authorization mode is WebHook, [Error] if webhook_authz.conf does not exist.
@@ -136,7 +136,7 @@ There should be:
    - Be in the `system:masters` organization.
  - A private key for signing ServiceAccount Tokens (`sa.key`) along with its public key (`sa.pub`).
  - A CA for the front proxy (`front-proxy-ca.crt`) with its key (`front-proxy-ca.key`).
- - A client cert for the front proxy client with its key  (`front-proxy-client.crt` and `front-proxy-client.key`) generate using `front-proxy-ca.crt` as the CA. 
+ - A client cert for the front proxy client with its key  (`front-proxy-client.crt` and `front-proxy-client.key`) generate using `front-proxy-ca.crt` as the CA.
 
 
 Please note that:
@@ -187,7 +187,7 @@ Common properties for the control plane components:
 - All static Pods are deployed on `kube-system` namespace.
 - All static Pods get `tier:control-plane` and `component:{component-name}` labels.
 - All static Pods get `scheduler.alpha.kubernetes.io/critical-pod` annotation. Note. this will be moved over to the proper solution of using Pod Priority and Preemption when ready.
-- `hostNetwork: true` is set on all static Pods to allow control plane startup before a network is configured; accordingly: 
+- `hostNetwork: true` is set on all static Pods to allow control plane startup before a network is configured; accordingly:
   * The `address` that the controller-manager and the scheduler use to refer the API server is `127.0.0.1`.
   * If using a local etcd server, `etcd-servers` address  will be set to `127.0.0.1:2379`.
 - Leader election is enabled for both the controller-manager and the scheduler.
@@ -214,7 +214,7 @@ The API server needs to know this in particular:
 Other flags that are set unconditionally:
 
  - `--insecure-port=0` to avoid insecure connections to the API server.
- - `--enable-bootstrap-token-auth=true` to enable the `BootstrapTokenAuthenticator` authentication module. 
+ - `--enable-bootstrap-token-auth=true` to enable the `BootstrapTokenAuthenticator` authentication module.
  - `--allow-privileged` to `true` (used e.g. by kube proxy).
  - `--client-ca-file` to `ca.crt`.
  - `--tls-cert-file` to `apiserver.crt`.
@@ -233,12 +233,12 @@ Other flags that are set unconditionally:
     - [`DefaultTolerationSeconds`](https://kubernetes.io/docs/admin/admission-controllers/#defaulttolerationseconds) .
     - [`NodeRestriction`](https://kubernetes.io/docs/admin/admission-controllers/#noderestriction) to limit what a kubelet can modify (e.g. its own pods).
  - `--kubelet-preferred-address-types` to `InternalIP,ExternalIP,Hostname;` this makes `kubectl logs` and other apiserver -> kubelet communication work in environments where the hostnames of the nodes aren't resolvable.
- - `requestheader-client-ca-file` to`front-proxy-ca.crt`,  `proxy-client-cert-file` to `front-proxy-client.crt`,  `proxy-client-key-file` to `front-proxy-client.key` ,  and`--requestheader-username-headers=X-Remote-User`, `--requestheader-group-headers=X-Remote-Group`, `--requestheader-extra-headers-prefix=X-Remote-Extra-`, `--requestheader-allowed-names=front-proxy-client` so the front proxy ([API Aggregation](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/aggregated-api-servers.md)) communication is secure.
+ - `requestheader-client-ca-file` to`front-proxy-ca.crt`,  `proxy-client-cert-file` to `front-proxy-client.crt`,  `proxy-client-key-file` to `front-proxy-client.key` ,  and`--requestheader-username-headers=X-Remote-User`, `--requestheader-group-headers=X-Remote-Group`, `--requestheader-extra-headers-prefix=X-Remote-Extra-`, `--requestheader-allowed-names=front-proxy-client` so the front proxy ([API Aggregation](https://git.k8s.io/community/contributors/design-proposals/api-machinery/aggregated-api-servers.md)) communication is secure.
 
 #### Controller manager
 
 The controller-manager needs to know this in particular:
-- If kubeadm is invoked specifying a `--pod-network-cidr`, the Subnet manager feature required for some CNI network plugins is enabled by 
+- If kubeadm is invoked specifying a `--pod-network-cidr`, the Subnet manager feature required for some CNI network plugins is enabled by
    setting `--allocate-node-cidrs=true`,  `--cluster-cidr` and `--node-cidr-mask-size` flags are set.
  - If a cloud provider is specified, the corresponding `--cloud-provider` is specified, together with  the  `--cloud-config` path if such configuration file exists. Note: this is experimental, alpha and will be removed in a future version
 
@@ -246,7 +246,7 @@ Other flags that are set unconditionally:
  - Enables all the default controllers plus `BootstrapSigner` and `TokenCleaner` controllers for TLS bootstrap.
  - `--root-ca-file` to `ca.crt`.
  - `--cluster-signing-cert-file` to `ca.crt`, if External CA mode is disabled, otherwise to `""`.
- - `--cluster-signing-key-file` to `ca.key`, if External CA mode is disabled, otherwise to `""`. 
+ - `--cluster-signing-key-file` to `ca.key`, if External CA mode is disabled, otherwise to `""`.
  - `--service-account-private-key-file` to `sa.key`.
  - `--use-service-account-credentials` to `true`.
 
@@ -272,7 +272,7 @@ Please note that:
 
 If kubeadm is invoked with `--feature-gates=DynamicKubeletConfig`, it writes the kubelet init configuration into `/var/lib/kubelet/config/init/kubelet` file.
 
-The init configuration is used for starting the kubelet on this specific node, providing an alternative for the kubelet drop-in file; such configuration will be replaced by the kubelet base configuration as described in following steps. 
+The init configuration is used for starting the kubelet on this specific node, providing an alternative for the kubelet drop-in file; such configuration will be replaced by the kubelet base configuration as described in following steps.
 See [online doc](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/) for additional info.
 
 Please note that:
@@ -292,7 +292,7 @@ After the control plane is up, kubeadm completes a couple of tasks described in 
 
 ### (optional and alpha in v1.9) Write base kubelet configuration
 
-If kubeadm is invoked with `--feature-gates=DynamicKubeletConfig`: 
+If kubeadm is invoked with `--feature-gates=DynamicKubeletConfig`:
 
 1. Write the kubelet base configuration into the `kubelet-base-config-v1.9`  ConfigMap in the `kube-system` namespace.
 2. Creates RBAC rules for granting read access to that ConfigMap to all bootstrap tokens and all kubelets (`system:bootstrappers:kubeadm:default-node-token` and `system:nodes` groups).
@@ -304,30 +304,30 @@ kubeadm saves the configuration passed to `kubeadm init`, either via flags or th
 
 This will ensure that kubeadm actions executed in future (e.g `kubeadm upgrade`) will be able to determine the actual/current cluster state and make new decisions based on that data.
 
-Please note that 
+Please note that
 
-1. Before uploading, sensitive information like e.g. the token are stripped from the configuration. 
+1. Before uploading, sensitive information like e.g. the token are stripped from the configuration.
 2. Upload of master configuration can be invoked individually with the `kubeadm alpha phase upload-config` command.
 3. If you initialized your cluster using kubeadm v1.7.x or lower, you must create manually the master configuration ConfigMap before `kubeadm upgrade` to v1.8 . In order to facilitate this task, the `kubeadm config upload (from-flags|from-file)` was implemented.
 
 ### Mark master
 
-As soon as the control plane is available, kubeadm executes following actions: 
+As soon as the control plane is available, kubeadm executes following actions:
 
-- Label  the master with `node-role.kubernetes.io/master=""` 
+- Label  the master with `node-role.kubernetes.io/master=""`
 - Taints  the master with `node-role.kubernetes.io/master:NoSchedule`
 
-Please note that 
+Please note that
 
 1. Mark master phase can be invoked individually with the `kubeadm alpha phase mark-master` command.
 
 ### Configure TLS-Bootstrapping for node joining
 
-Kubeadm uses [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) for joining new nodes to an existing cluster; for more details see also [design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
+Kubeadm uses [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) for joining new nodes to an existing cluster; for more details see also [design proposal](https://git.k8s.io/community/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
 
 `kubeadm init`  ensures that everything is properly configured for this process, and this includes following steps as well as setting API server and controller flags as already described in previous paragraphs.
 
-Please note that 
+Please note that
 
 1. TLS bootstrapping for nodes can be configured with the `kubeadm alpha phase bootstrap-token all` command, executing configuration steps described in following paragraphs; alternatively, each step can be invoked individually.
 
@@ -335,7 +335,7 @@ Please note that
 
 `kubeadm init`  create a first bootstrap token, either generated automatically or provided by the user with the `--token` flag; as documented in bootstrap token specification, token should be saved as secrets with name `bootstrap-token-<token-id>` under `kube-system` namespace.
 
-Please note that 
+Please note that
 
 1. The default token created by `kubeadm init` will be used to validate temporary user during TLS bootstrap process; those users will be member of  `system:bootstrappers:kubeadm:default-node-token` group.
 2. The token has a limited validity, default 24 hours (the interval may be changed with the `—token-ttl` flag)
@@ -367,7 +367,7 @@ This phase creates the `cluster-info` ConfigMap in the `kube-public` namespace.
 
 Additionally it is created a role and a RoleBinding granting access for to the ConfigMap for unauthenticated users (i.e. users in RBAC group `system:unauthenticated`)
 
-Please note that 
+Please note that
 
 1. The access to the `cluster-info` ConfigMap _is not_ rate-limited. This may or may not be a problem if you expose your master to the internet; worst-case scenario here is a DoS attack where an attacker uses all the in-flight requests the kube-apiserver can handle to serving the `cluster-info` ConfigMap.
 
@@ -379,7 +379,7 @@ A ServiceAccount for `kube-proxy` is created in the `kube-system` namespace; the
 - the location of the master comes from a ConfigMap
 - the `kube-proxy` ServiceAccount is bound to the privileges in the `system:node-proxier` ClusterRole
 
-Please note that 
+Please note that
 
 1. This phase can be invoked individually with the `kubeadm alpha phase addon kube-proxy`  command.
 
@@ -392,7 +392,7 @@ Deploy the kube-dns Deployment and Service:
 - it's the upstream kube-dns deployment relatively unmodified
 - the `kube-dns` ServiceAccount is bound to the privileges in the `system:kube-dns` ClusterRole
 
-Please note that 
+Please note that
 
 1. If kubeadm is invoked with `--feature-gates=CoreDNS`,  CoreDNS is installed instead of `kube-dns`.
 2. This phase can be invoked individually with the `kubeadm alpha phase addon kube-dns`  command.
@@ -403,10 +403,10 @@ This phase is performed only if `kubeadm init` is invoked with `—features-gate
 
 The self hosting phase basically replaces static Pods for control plane components with DaemonSets; this is achieved by executing following procedure for API server, scheduler and controller manager static Pods:
 
-- Load the static Pod specification from disk 
+- Load the static Pod specification from disk
 - Extract the PodSpec from that static Pod specification
 - Mutate the PodSpec to be compatible with self-hosting, and more in detail:
-  - add node selector attribute targeting nodes with`node-role.kubernetes.io/master=""`  label, 
+  - add node selector attribute targeting nodes with`node-role.kubernetes.io/master=""`  label,
   - add a toleration for `node-role.kubernetes.io/master:NoSchedule` taint,
   - set `spec.DNSPolicy` to `ClusterFirstWithHostNet`
 - Build a new DaemonSet object for the self-hosted component in question. Use the above mentioned PodSpec
@@ -434,11 +434,11 @@ Similarly to `kubeadm init`, also `kubeadm join` internal workflow consists of a
 
 This is split into discovery (having the Node trust the Kubernetes Master) and TLS bootstrap (having the Kubernetes Master trust the Node).
 
-see [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) , [design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
+see [Authenticating with Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) , [design proposal](https://git.k8s.io/community/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
 
 ### Preflight checks
 
-`kubeadm` executes a set of preflight checks before starting the join, with the aim to verify preconditions and avoid common cluster startup problems. 
+`kubeadm` executes a set of preflight checks before starting the join, with the aim to verify preconditions and avoid common cluster startup problems.
 
 Please note that:
 
@@ -449,7 +449,7 @@ Please note that:
 
 ### Discovery cluster-info
 
-There are 2 main schemes for discovery. The first is to use a shared token along with the IP address of the API server. The second is to provide a file (a subset of the standard kubeconfig file). 
+There are 2 main schemes for discovery. The first is to use a shared token along with the IP address of the API server. The second is to provide a file (a subset of the standard kubeconfig file).
 
 #### Shared token discovery
 
@@ -458,7 +458,7 @@ If `kubeadm join` is invoked with `--discovery-token`, token discovery is used; 
 In order to prevent "man in the middle" attacks, several steps are taken:
 
 - First, the CA certificate is retrieved via insecure connection (note: this is possible because `kubeadm init` granted access to  `cluster-info` users for `system:unauthenticated` )
-- Then the CA certificate goes through following validation steps: 
+- Then the CA certificate goes through following validation steps:
   - "Basic validation", using the token ID against a JWT signature
   - "Pub key validation", using provided `--discovery-token-ca-cert-hash`. This value is available in the output of "kubeadm init" or can be calculated using standard tools (the hash is calculated over the bytes of the Subject Public Key Info (SPKI) object as in RFC7469). The `--discovery-token-ca-cert-hash flag` may be repeated multiple times to allow more than one public key.
   - as a additional validation, the CA certificate is retrieved via secure connection and then compared with the CA retrieved initially
@@ -493,19 +493,19 @@ Finally, when the connection with the cluster is established, kubeadm try to acc
 
 Once the cluster info are known, the file `bootstrap-kubelet.conf` is written, allowing kubelet to do TLS Bootstrapping (conversely in v.1.7 TLS were managed by kubeadm).
 
-The TLS bootstrap mechanism uses the shared token to temporarily authenticate with the Kubernetes Master to submit a certificate signing request (CSR) for a locally created key pair. 
+The TLS bootstrap mechanism uses the shared token to temporarily authenticate with the Kubernetes Master to submit a certificate signing request (CSR) for a locally created key pair.
 
 The request is then automatically approved and the operation completes saving `ca.crt` file and `kubelet.conf` file to be used by kubelet for joining the cluster, while`bootstrap-kubelet.conf` is deleted.
 
 Please note that:
 
-- The temporary authentication is validated against the token saved during the `kubeadm init` process (or with additional tokens created with `kubeadm token`) 
+- The temporary authentication is validated against the token saved during the `kubeadm init` process (or with additional tokens created with `kubeadm token`)
 - The temporary authentication resolve to a user member of  `system:bootstrappers:kubeadm:default-node-token` group which was granted access to CSR api during the `kubeadm init` process
 - The automatic CSR approval is managed by the csrapprover controller, according with configuration done the `kubeadm init` process
 
 ### (optional) Write init kubelet configuration
 
-If kubeadm is invoked with `--feature-gates=DynamicKubeletConfig`: 
+If kubeadm is invoked with `--feature-gates=DynamicKubeletConfig`:
 
 1. Read the kubelet base configuration from the `kubelet-base-config-v1.9` ConfigMap in the `kube-system` namespace  using the Bootstrap Token credentials, and write it to disk as kubelet init configuration file  `/var/lib/kubelet/config/init/kubelet`.
 2. As soon as kubelet starts with the Node's own credential (`/etc/kubernetes/kubelet.conf`), update current node configuration specifying that the source for the node/kubelet configuration is the above ConfigMap.

--- a/docs/managing-e2e-tests.md
+++ b/docs/managing-e2e-tests.md
@@ -2,20 +2,20 @@
 
 ### Overview
 
-Kubernetes has a rich end-to-end (e2e) testing infrastructure, which allows detailed testing of clusters and their assets. Most settings and tools for that can be found in the [test-infra](https://github.com/kubernetes/test-infra) GitHub repository.
+Kubernetes has a rich end-to-end (e2e) testing infrastructure, which allows detailed testing of clusters and their assets. Most settings and tools for that can be found in the [test-infra](https://git.k8s.io/test-infra) GitHub repository.
 
 Kubernetes uses applications such as the web-based [testgrid](https://k8s-testgrid.appspot.com/) for monitoring the status of e2e tests. test-infra also hosts the configuration on individual test jobs and Docker images that contain tools to invoke the jobs.
 
 ### Prow job configuration
 
 The following folder contains all the SIG Cluster Lifecycle (the SIG that maintains kubeadm) originated test jobs:
-[sig-cluster-lifecycle](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/sig-cluster-lifecycle)
+[sig-cluster-lifecycle](https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle)
 
 Please note that this document will only cover details on the `kubeadm*.yaml` files and only on some of the parameters
 these files contain.
 
 For example, let's have a look at this file:
-[kubeadm-kinder.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml)
+[kubeadm-kinder.yaml](https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml)
 
 It contains a list of jobs such as:
 ```
@@ -26,18 +26,18 @@ It contains a list of jobs such as:
 
 In this case, `ci-kubernetes-e2e-kubeadm-kind-master` is a test job that runs every 2 hours and it also
 has a set of other parameters defined for it. Such test jobs use an image that will run as a container inside
-a Pod of the Kubernetes [Prow](https://github.com/kubernetes/test-infra/tree/master/prow) cluster.
+a Pod of the Kubernetes [Prow](https://git.k8s.io/test-infra/prow) cluster.
 
 For this example job the deployment tool is called [kind](https://github.com/kubernetes-sigs/kind).
 As a very high level summary, the way this works is when a job is invoked all the job parameters
 are passed to a CLI tool called kubetest, which then instantiates the job container and then the deployment tool
 inside it. Please note that kubetest is not required and test authors can decide to call any bash script instead.
 
-The SIG also uses another deployment tool called [kinder](https://github.com/kubernetes/kubeadm/tree/master/kinder).
+The SIG also uses another deployment tool called [kinder](https://git.k8s.io/kubeadm/kinder).
 kinder is based on kind and it's used for upgrades and version skew tests, but it does not require kubetest integration.
 
 Kinder uses test workflow files that run sequences of tasks, such as "upgrade", "run e2e conformance tests", "run e2e kubeadm tests".
-An example of such a workflow file can be seen [here](https://github.com/kubernetes/kubeadm/blob/master/kinder/ci/workflows/presubmit-upgrade-latest.yaml).
+An example of such a workflow file can be seen [here](https://git.k8s.io/kubeadm/kinder/ci/workflows/presubmit-upgrade-latest.yaml).
 
 ### Testgrid configuration
 
@@ -67,11 +67,11 @@ These annotations configure the testgrid entries for this job from the job confi
 They contain information such as dashboards where this job will appear, tab name, where to send email alerts,
 description and other.
 
-For more information about configuring testgrid see [this page](https://github.com/kubernetes/test-infra/blob/master/testgrid/config.md).
+For more information about configuring testgrid see [this page](https://git.k8s.io/test-infra/testgrid/config.md).
 
 ### Updates to kubeadm tests
 
-Before each new Kubernetes release and during the second month of the [release-cycle](https://github.com/kubernetes/kubeadm/blob/master/docs/release-cycle.md), a set of manual actions have to be performed, so that the kubeadm e2e tests are up to date with the new release.
+Before each new Kubernetes release and during the second month of the [release-cycle](https://git.k8s.io/kubeadm/docs/release-cycle.md), a set of manual actions have to be performed, so that the kubeadm e2e tests are up to date with the new release.
 
 The operation can be broken down into:
 - Sending a PR for updating kinder workflows.
@@ -94,7 +94,7 @@ The summary of the actions is the following:
 #### Updating kinder workflows
 
 Kinder workflows need to be updated each cycle in this location:
-https://github.com/kubernetes/kubeadm/blob/master/kinder/ci/workflows/
+https://git.k8s.io/kubeadm/kinder/ci/workflows/
 
 Additional actions to be performed:
 - Make sure that workflows include the correct `ci/latest-x` labels.
@@ -103,24 +103,24 @@ Additional actions to be performed:
 #### Updating test jobs in kubernetes/test-infra
 
 This document will cover information on how to perform updates on these files:
-- [kubeadm-kinder.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml)
+- [kubeadm-kinder.yaml](https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml)
 
 Holds test jobs where the kubeadm version matches the Kubernetes control-plane and the kubelet versions.
 
-- [kubeadm-kinder-upgrade.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml)
+- [kubeadm-kinder-upgrade.yaml](https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml)
 
 Holds test jobs that perform a upgrade from version X to version Y (usually `Y = X + 1`).
 
-- [kubeadm-kinder-x-on-y.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml)
+- [kubeadm-kinder-x-on-y.yaml](https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml)
 
 Holds test jobs that run kubeadm version X, on a control plane and kubelet version Y,
 as kubeadm does support `Y = X - 1`
 
-- [kubeadm-kinder-external-etcd.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml)
+- [kubeadm-kinder-external-etcd.yaml](https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml)
 
 Holds tests that deploy a kubeadm / kinder cluster using external etcd, instead of the default stacked etcd.
 
-The files can be found in the [sig-cluster-lifecycle](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/sig-cluster-lifecycle) folder.
+The files can be found in the [sig-cluster-lifecycle](https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle) folder.
 
 
 Additional actions to be performed:

--- a/docs/release-cycle.md
+++ b/docs/release-cycle.md
@@ -75,4 +75,4 @@ by the kubeadm maintainers.
 ### Other links
 
 - A document on managing kubeadm e2e tests:
-  https://github.com/kubernetes/kubeadm/blob/master/docs/managing-e2e-tests.md
+  https://git.k8s.io/kubeadm/docs/managing-e2e-tests.md

--- a/docs/testing-pre-releases.md
+++ b/docs/testing-pre-releases.md
@@ -203,7 +203,7 @@ instructions are provided for bazel only, but other builds methods supported by 
 
 See also:
 
-- [Build and test with Bazel](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/bazel.md)
+- [Build and test with Bazel](https://git.k8s.io/community/contributors/devel/sig-testing/bazel.md)
 - [Change the target version number when building a local release](#change-the-target-version-number-when-building-a-local-release)
 
 ### Build .debs packages
@@ -217,7 +217,7 @@ bazel build //build/debs
 
 build output will be stored in `bazel-bin/build/debs`.
 
-> cross build not supported yet; the unofficial [Planter tool](https://github.com/kubernetes/test-infra/tree/master/planter)
+> cross build not supported yet; the unofficial [Planter tool](https://git.k8s.io/test-infra/planter)
 > can be used to overcome the problem
 
 > currently bazel does not provide target for building rpm packages
@@ -280,9 +280,9 @@ According to selected versions to be installed (the version of .deb or .rpm pack
 
   ```bash
   array=(kube-apiserver kube-controller-manager kube-scheduler kube-proxy)
-  for i in "${array[@]}"; do 
+  for i in "${array[@]}"; do
     sudo docker load -i path/to/$i.tar
-  done 
+  done
   ```
 
   Then, you should take care of passing the exact version of your images to `kubeadm init` using `--kubernetes-version` flag

--- a/kinder/OWNERS
+++ b/kinder/OWNERS
@@ -1,5 +1,5 @@
 # See the OWNERS file documentation:
-#  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
+#  https://git.k8s.io/community/contributors/devel/owners.md
 approvers:
 - fabriziopandini
 - neolit123

--- a/kinder/ci/workflows/discovery-1.17.yaml
+++ b/kinder/ci/workflows/discovery-1.17.yaml
@@ -3,7 +3,7 @@ summary: |
   This workflow implements a sequence of tasks used for testing alternative
   discovery methods for kubeadm join.
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-discovery-1-17
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.17` }}"
 tasks:

--- a/kinder/ci/workflows/discovery-1.18.yaml
+++ b/kinder/ci/workflows/discovery-1.18.yaml
@@ -3,7 +3,7 @@ summary: |
   This workflow implements a sequence of tasks used for testing alternative
   discovery methods for kubeadm join.
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-discovery-1-18
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.18` }}"
 tasks:

--- a/kinder/ci/workflows/discovery-1.19.yaml
+++ b/kinder/ci/workflows/discovery-1.19.yaml
@@ -3,7 +3,7 @@ summary: |
   This workflow implements a sequence of tasks used for testing alternative
   discovery methods for kubeadm join.
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-discovery-1-19
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
 tasks:

--- a/kinder/ci/workflows/discovery-latest.yaml
+++ b/kinder/ci/workflows/discovery-latest.yaml
@@ -3,7 +3,7 @@ summary: |
   This workflow implements a sequence of tasks used for testing alternative
   discovery methods for kubeadm join.
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-discovery-latest
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest` }}"
 tasks:

--- a/kinder/ci/workflows/external-ca-1.17.yaml
+++ b/kinder/ci/workflows/external-ca-1.17.yaml
@@ -2,7 +2,7 @@ version: 1
 summary: |
   This workflow implements a sequence of tasks for testing the external CA functionality.
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-ca-1-17
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.17` }}"
 tasks:

--- a/kinder/ci/workflows/external-ca-1.18.yaml
+++ b/kinder/ci/workflows/external-ca-1.18.yaml
@@ -2,7 +2,7 @@ version: 1
 summary: |
   This workflow implements a sequence of tasks for testing the external CA functionality.
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-ca-1-18
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.18` }}"
 tasks:

--- a/kinder/ci/workflows/external-ca-1.19.yaml
+++ b/kinder/ci/workflows/external-ca-1.19.yaml
@@ -2,7 +2,7 @@ version: 1
 summary: |
   This workflow implements a sequence of tasks for testing the external CA functionality.
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-ca-1-19
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
 tasks:

--- a/kinder/ci/workflows/external-ca-latest.yaml
+++ b/kinder/ci/workflows/external-ca-latest.yaml
@@ -2,7 +2,7 @@ version: 1
 summary: |
   This workflow implements a sequence of tasks for testing the external CA functionality.
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-ca-latest
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest` }}"
 tasks:

--- a/kinder/ci/workflows/external-etcd-1.17.yaml
+++ b/kinder/ci/workflows/external-etcd-1.17.yaml
@@ -3,8 +3,8 @@ summary: |
   This workflow tests the proper functioning of deploying an HA
   cluster with secret copy using an external etcd cluster
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-etcd-1.17
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
-  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.17` }}"
 tasks:

--- a/kinder/ci/workflows/external-etcd-1.18.yaml
+++ b/kinder/ci/workflows/external-etcd-1.18.yaml
@@ -3,8 +3,8 @@ summary: |
   This workflow tests the proper functioning of deploying an HA
   cluster with secret copy using an external etcd cluster
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-etcd-1.18
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
-  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.18` }}"
 tasks:

--- a/kinder/ci/workflows/external-etcd-1.19.yaml
+++ b/kinder/ci/workflows/external-etcd-1.19.yaml
@@ -3,8 +3,8 @@ summary: |
   This workflow tests the proper functioning of deploying an HA
   cluster with secret copy using an external etcd cluster
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-etcd-1.19
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
-  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
 tasks:

--- a/kinder/ci/workflows/external-etcd-latest.yaml
+++ b/kinder/ci/workflows/external-etcd-latest.yaml
@@ -3,8 +3,8 @@ summary: |
   This workflow tests the proper functioning of deploying an HA
   cluster with secret copy using an external etcd cluster
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-etcd-latest
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
-  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest` }}"
 tasks:

--- a/kinder/ci/workflows/patches-1.19.yaml
+++ b/kinder/ci/workflows/patches-1.19.yaml
@@ -2,7 +2,7 @@ version: 1
 summary: |
   This workflow implements a sequence of tasks for testing the patches functionality.
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-patches-1-19
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
 tasks:

--- a/kinder/ci/workflows/patches-latest.yaml
+++ b/kinder/ci/workflows/patches-latest.yaml
@@ -2,7 +2,7 @@ version: 1
 summary: |
   This workflow implements a sequence of tasks for testing the patches functionality.
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-patches-latest
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest` }}"
 tasks:

--- a/kinder/ci/workflows/presubmit-upgrade-latest.yaml
+++ b/kinder/ci/workflows/presubmit-upgrade-latest.yaml
@@ -2,7 +2,7 @@ version: 1
 summary: |
   This workflow tests upgrades to Kubernetes ci/latest and also a set of other actions for pull requests
   name      > pull-kubeadm-kinder-upgrade-latest
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
 vars:
   initVersion: "{{ resolve `ci/latest` }}"
   upgradeVersion: "{{ resolve `ci/latest` }}"
@@ -46,7 +46,7 @@ tasks:
     - --control-plane-nodes={{ .vars.controlPlaneNodes }}
     - --worker-nodes={{ .vars.workerNodes }}
     - --loglevel=debug
-  timeout: 5m
+  timeout: 10m
 - name: init
   description: |
     Initializes the Kubernetes cluster with version "initVersion"

--- a/kinder/ci/workflows/regular-1.17.yaml
+++ b/kinder/ci/workflows/regular-1.17.yaml
@@ -2,7 +2,7 @@ version: 1
 summary: |
   This workflow tests the proper functioning of the latest 1.17 version of both kubeadm and Kubernetes
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1.17
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.17` }}"
 tasks:

--- a/kinder/ci/workflows/regular-1.18.yaml
+++ b/kinder/ci/workflows/regular-1.18.yaml
@@ -2,7 +2,7 @@ version: 1
 summary: |
   This workflow tests the proper functioning of the latest 1.18 version of both kubeadm and Kubernetes
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1.18
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.18` }}"
 tasks:

--- a/kinder/ci/workflows/regular-1.19.yaml
+++ b/kinder/ci/workflows/regular-1.19.yaml
@@ -2,7 +2,7 @@ version: 1
 summary: |
   This workflow tests the proper functioning of the latest 1.19 version of both kubeadm and Kubernetes
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1.19
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
 tasks:

--- a/kinder/ci/workflows/regular-latest.yaml
+++ b/kinder/ci/workflows/regular-latest.yaml
@@ -2,7 +2,7 @@ version: 1
 summary: |
   This workflow tests the proper functioning of the latest version of both kubeadm and Kubernetes
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-latest
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest` }}"
 tasks:

--- a/kinder/ci/workflows/skew-1.17-on-1.16.yaml
+++ b/kinder/ci/workflows/skew-1.17-on-1.16.yaml
@@ -2,8 +2,8 @@ version: 1
 summary: |
   This workflow tests the proper functioning of kubeadm version v1.17 with Kubernetes v1.16
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1-17-on-1-16
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
-  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.17` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.16` }}"

--- a/kinder/ci/workflows/skew-1.18-on-1.17.yaml
+++ b/kinder/ci/workflows/skew-1.18-on-1.17.yaml
@@ -2,8 +2,8 @@ version: 1
 summary: |
   This workflow tests the proper functioning of kubeadm version v1.18 with Kubernetes v1.17
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1-18-on-1-17
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
-  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.18` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.17` }}"

--- a/kinder/ci/workflows/skew-1.19-on-1.18.yaml
+++ b/kinder/ci/workflows/skew-1.19-on-1.18.yaml
@@ -2,8 +2,8 @@ version: 1
 summary: |
   This workflow tests the proper functioning of kubeadm version v1.19 with Kubernetes v1.18
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1-19-on-1-18
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
-  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.19` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.18` }}"

--- a/kinder/ci/workflows/skew-latest-on-1.19.yaml
+++ b/kinder/ci/workflows/skew-latest-on-1.19.yaml
@@ -2,8 +2,8 @@ version: 1
 summary: |
   This workflow tests the proper functioning of kubeadm version from latest with Kubernetes v1.19
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-latest-on-1.19
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
-  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubeadmVersion: "{{ resolve `ci/latest` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"

--- a/kinder/ci/workflows/upgrade-1.16-1.17.yaml
+++ b/kinder/ci/workflows/upgrade-1.16-1.17.yaml
@@ -2,8 +2,8 @@ version: 1
 summary: |
   this workflow test kubeadm upgrades from Kubernetes ci/latest-1.16 version to Kubernetes ci/latest-1.17 version
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-upgrade-1-16-1-17
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
-  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   initVersion: "{{ resolve `ci/latest-1.16` }}"
   upgradeVersion: "{{ resolve `ci/latest-1.17` }}"

--- a/kinder/ci/workflows/upgrade-1.17-1.18.yaml
+++ b/kinder/ci/workflows/upgrade-1.17-1.18.yaml
@@ -2,8 +2,8 @@ version: 1
 summary: |
   this workflow test kubeadm upgrades from Kubernetes ci/latest-1.17 version to Kubernetes ci/latest-1.18 version
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-upgrade-1-17-1-18
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
-  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   initVersion: "{{ resolve `ci/latest-1.17` }}"
   upgradeVersion: "{{ resolve `ci/latest-1.18` }}"

--- a/kinder/ci/workflows/upgrade-1.18-1.19.yaml
+++ b/kinder/ci/workflows/upgrade-1.18-1.19.yaml
@@ -2,8 +2,8 @@ version: 1
 summary: |
   this workflow test kubeadm upgrades from Kubernetes ci/latest-1.18 version to Kubernetes ci/latest-1.19 version
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-upgrade-1-18-1-19
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
-  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   initVersion: "{{ resolve `ci/latest-1.18` }}"
   upgradeVersion: "{{ resolve `ci/latest-1.19` }}"

--- a/kinder/ci/workflows/upgrade-1.19-latest.yaml
+++ b/kinder/ci/workflows/upgrade-1.19-latest.yaml
@@ -2,8 +2,8 @@ version: 1
 summary: |
   this workflow test kubeadm upgrades from Kubernetes ci/latest-1.19 version to Kubernetes ci/latest version
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-upgrade-1-19-latest
-  config    > https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
-  config    > https://github.com/kubernetes/test-infra/blob/master/testgrid/config.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   initVersion: "{{ resolve `ci/latest-1.19` }}"
   upgradeVersion: "{{ resolve `ci/latest` }}"

--- a/kinder/cmd/kinder/test/e2e/e2e.go
+++ b/kinder/cmd/kinder/test/e2e/e2e.go
@@ -94,9 +94,9 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	// if --conformance is set, adds well know flag/values for instructing ginkgo for running only tests required for conformance in testgrid
 	if flags.TestGridConformance {
 		// instruct ginkgo to run only Conformance test as defined in [Display Conformance Tests with Testgrid]
-		// (https://github.com/kubernetes/test-infra/tree/master/testgrid/conformance)
+		// (https://git.k8s.io/test-infra/testgrid/conformance)
 
-		// see https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md
+		// see https://git.k8s.io/community/contributors/devel/sig-testing/e2e-tests.md
 		// for description of test labels
 		ginkgoFlags.AddFocusRegex(regexp.QuoteMeta("[Conformance]"))
 		ginkgoFlags.AddSkipRegex("Aggregator|Alpha|Kubectl|\\[(Disruptive|Feature:[^\\]]+|Flaky)\\]")

--- a/kinder/doc/e2e-test.md
+++ b/kinder/doc/e2e-test.md
@@ -8,7 +8,7 @@ those suites to validate your cluster.
 E2E Kubernetes is a rich set of test aimed at verifying the proper functioning of a Kubernetes cluster.
 
 By default Kinder selects a subset of test the corresponds to the "Conformance" as defined in the
-Kubernetes [test grid](https://github.com/kubernetes/test-infra/tree/master/testgrid/conformance).
+Kubernetes [test grid](https://git.k8s.io/test-infra/testgrid/conformance).
 
 ```bash
 kinder test e2e

--- a/kinder/doc/reference.md
+++ b/kinder/doc/reference.md
@@ -277,7 +277,7 @@ Instead, when reading from a local folder or from a remote repository, a `versio
 E2E Kubernetes is a rich set of test aimed at verifying the proper functioning of a Kubernetes cluster.
 
 By default Kinder selects a subset of test the corresponds to the "Conformance" as defined in the
-Kubernetes [test grid](https://github.com/kubernetes/test-infra/tree/master/testgrid/conformance).
+Kubernetes [test grid](https://git.k8s.io/test-infra/testgrid/conformance).
 
 ```bash
 kinder test e2e

--- a/kinder/hack/verify-all.sh
+++ b/kinder/hack/verify-all.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # IMPORTANT! This script is called by pull-kubeadm-kinder-verify presubmits job
-# see https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+# see https://git.k8s.io/test-infra/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
 
 set -o errexit
 set -o nounset

--- a/kinder/pkg/kubeadm/kustomize.go
+++ b/kinder/pkg/kubeadm/kustomize.go
@@ -49,7 +49,7 @@ type PatchJSON6902 struct {
 }
 
 // Build takes a set of resource blobs (yaml), patches (strategic merge patch)
-// https://github.com/kubernetes/community/blob/master/contributors/devel/strategic-merge-patch.md
+// https://git.k8s.io/community/contributors/devel/strategic-merge-patch.md
 // and returns the `kustomize build` result as a yaml blob
 // It does this in-memory using the build cobra command
 func Build(resources, patches []string, patchesJSON6902 []PatchJSON6902) (string, error) {

--- a/operator/README.md
+++ b/operator/README.md
@@ -3,4 +3,4 @@
 The kubeadm-operator is an experimental project, still WIP.
 Do not use in production.
 
-See [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/20190916-kubeadm-operator.md) for more details.
+See [KEP](https://git.k8s.io/enhancements/keps/sig-cluster-lifecycle/kubeadm/20190916-kubeadm-operator.md) for more details.


### PR DESCRIPTION
The the "master" -> "main" branch rename can happen in k8s repositories,
in the near future, which will break the links in this repository.

We can avoid referencing a "master" branch if the URL:
"https://git.k8s.io/repo" is used instead of
"https://github.com/kubernetes/{blob|tree}/master""