### PR TITLE
kinder: increase the timeout for kubeadm e2e suite on presubmit

### DIFF
--- a/kinder/ci/workflows/presubmit-upgrade-latest.yaml
+++ b/kinder/ci/workflows/presubmit-upgrade-latest.yaml
@@ -103,6 +103,7 @@ tasks:
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-kubeadm --ginkgo.dryRun=true
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
+  timeout: 10m
 - name: e2e
   description: |
     Runs Kubernetes e2e test (conformance)


### PR DESCRIPTION
The default timeout of 5m causes frequent timeouts.

for example:
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubeadm/2313/pull-kubeadm-kinder-upgrade-latest/1311100923589693440