### PR TITLE
Revert "Revert "kinder: add test workflows for 1.20""

### DIFF
--- a/kinder/ci/workflows/discovery-1.20.yaml
+++ b/kinder/ci/workflows/discovery-1.20.yaml
@@ -1,0 +1,10 @@
+version: 1
+summary: |
+  This workflow implements a sequence of tasks used for testing alternative
+  discovery methods for kubeadm join.
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-discovery-1-20
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+tasks:
+- import: discovery-tasks.yaml

--- a/kinder/ci/workflows/external-etcd-1.20.yaml
+++ b/kinder/ci/workflows/external-etcd-1.20.yaml
@@ -1,0 +1,11 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of deploying an HA
+  cluster with secret copy using an external etcd cluster
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-etcd-1.20
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+tasks:
+- import: external-etcd.yaml

--- a/kinder/ci/workflows/regular-1.20.yaml
+++ b/kinder/ci/workflows/regular-1.20.yaml
@@ -1,0 +1,9 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of the latest 1.20 version of both kubeadm and Kubernetes
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1.20
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+tasks:
+- import: regular-tasks.yaml

--- a/kinder/ci/workflows/skew-1.20-on-1.19.yaml
+++ b/kinder/ci/workflows/skew-1.20-on-1.19.yaml
@@ -1,0 +1,12 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of kubeadm version v1.20 with Kubernetes v1.19
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1-20-on-1-19
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
+vars:
+  kubeadmVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
+  controlPlaneNodes: 3
+tasks:
+- import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-latest-on-1.20.yaml
+++ b/kinder/ci/workflows/skew-latest-on-1.20.yaml
@@ -1,12 +1,12 @@
 version: 1
 summary: |
-  This workflow tests the proper functioning of kubeadm version from latest with Kubernetes v1.19
-  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-latest-on-1.19
+  This workflow tests the proper functioning of kubeadm version from latest with Kubernetes v1.20
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-latest-on-1.20
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
   config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubeadmVersion: "{{ resolve `ci/latest` }}"
-  kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/upgrade-1.19-1.20.yaml
+++ b/kinder/ci/workflows/upgrade-1.19-1.20.yaml
@@ -1,0 +1,12 @@
+version: 1
+summary: |
+  this workflow test kubeadm upgrades from Kubernetes ci/latest-1.19 version to Kubernetes ci/latest-1.20 version
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-upgrade-1-19-1-20
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
+vars:
+  initVersion: "{{ resolve `ci/latest-1.19` }}"
+  upgradeVersion: "{{ resolve `ci/latest-1.20` }}"
+  controlPlaneNodes: 3
+tasks:
+- import: upgrade-tasks.yaml

--- a/kinder/ci/workflows/upgrade-1.20-latest.yaml
+++ b/kinder/ci/workflows/upgrade-1.20-latest.yaml
@@ -1,11 +1,11 @@
 version: 1
 summary: |
-  this workflow test kubeadm upgrades from Kubernetes ci/latest-1.19 version to Kubernetes ci/latest version
-  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-upgrade-1-19-latest
+  this workflow test kubeadm upgrades from Kubernetes ci/latest-1.20 version to Kubernetes ci/latest version
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-upgrade-1-20-latest
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
   config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
-  initVersion: "{{ resolve `ci/latest-1.19` }}"
+  initVersion: "{{ resolve `ci/latest-1.20` }}"
   upgradeVersion: "{{ resolve `ci/latest` }}"
   controlPlaneNodes: 3
 tasks:


### PR DESCRIPTION
reverting the revert:
Reverts kubernetes/kubeadm#2340

bringing back the change from @RA489 that introduced the 1.20 jobs.

the release-1.20 branch of k/k now exists:
https://kubernetes.slack.com/archives/CJH2GBF7Y/p1606827974311000?thread_ts=1606811420.282800&cid=CJH2GBF7Y
https://github.com/kubernetes/kubernetes/tree/release-1.20
