### PR TITLE
kinder: use "k8s-release-dev" for CI artifacts

### DIFF
--- a/kinder/pkg/extract/extract.go
+++ b/kinder/pkg/extract/extract.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	ciBuildRepository       = "https://storage.googleapis.com/kubernetes-release-dev/ci"
+	ciBuildRepository       = "https://storage.googleapis.com/k8s-release-dev/ci"
 	releaseBuildURepository = "https://storage.googleapis.com/kubernetes-release/release"
 
 	kubeadmBinary = "kubeadm"


### PR DESCRIPTION
The CI artifact location is moving to community maintained.

As part of that the location is changing from:
- gs://kubernetes-release-dev
to:
- gs://k8s-release-dev

Apply this change to kinder.

fixes https://github.com/kubernetes/kubeadm/issues/2355
xref https://github.com/kubernetes/k8s.io/issues/1460

