### PR TITLE
kinder: sync ClusterLabelKey and NodeRoleLabelKey with kind

### DIFF
--- a/kinder/pkg/cluster/status/cluster.go
+++ b/kinder/pkg/cluster/status/cluster.go
@@ -72,9 +72,9 @@ func ListClusters() ([]string, error) {
 		"-a",         // show stopped nodes
 		"--no-trunc", // don't truncate
 		// filter for nodes with the cluster label
-		"--filter", "label="+constants.ClusterLabelKey,
+		"--filter", "label="+constants.DeprecatedClusterLabelKey,
 		// format to include the cluster name
-		"--format", fmt.Sprintf(`{{.Label "%s"}}`, constants.ClusterLabelKey),
+		"--format", fmt.Sprintf(`{{.Label "%s"}}`, constants.DeprecatedClusterLabelKey),
 	)
 	lines, err := cmd.RunAndCapture()
 	if err != nil {
@@ -164,7 +164,7 @@ func (c *Cluster) listNodes() ([]string, error) {
 		"-a",         // show stopped nodes
 		"--no-trunc", // don't truncate
 		// filter for nodes with the cluster label
-		"--filter", fmt.Sprintf("label=%s=%s", constants.ClusterLabelKey, c.name),
+		"--filter", fmt.Sprintf("label=%s=%s", constants.DeprecatedClusterLabelKey, c.name),
 		// format to include the cluster name
 		"--format", `{{.Names}}`,
 	)

--- a/kinder/pkg/cluster/status/node.go
+++ b/kinder/pkg/cluster/status/node.go
@@ -69,12 +69,12 @@ type NodeSettings struct {
 // NewNode returns a new kinder.Node wrapper
 func NewNode(name string) (n *Node, err error) {
 	// retrive the role the node using docker inspect
-	lines, err := host.InspectContainer(name, fmt.Sprintf("{{index .Config.Labels %q}}", constants.NodeRoleKey))
+	lines, err := host.InspectContainer(name, fmt.Sprintf("{{index .Config.Labels %q}}", constants.DeprecatedNodeRoleLabelKey))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get %q label", constants.NodeRoleKey)
+		return nil, errors.Wrapf(err, "failed to get %q label", constants.DeprecatedNodeRoleLabelKey)
 	}
 	if len(lines) != 1 {
-		return nil, errors.Errorf("%q label should only be one line, got %d lines", constants.NodeRoleKey, len(lines))
+		return nil, errors.Errorf("%q label should only be one line, got %d lines", constants.DeprecatedNodeRoleLabelKey, len(lines))
 	}
 	role := strings.Trim(lines[0], "'")
 

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -58,12 +58,21 @@ const (
 
 	// ClusterLabelKey is applied to each "node" docker container for identification
 	// TODO: consider if to switch to a kinder specific label
-	ClusterLabelKey = "io.k8s.sigs.kind.cluster"
+	ClusterLabelKey = "io.x-k8s.kind.cluster"
 
-	// NodeRoleKey is applied to each "node" docker container for categorization
+	// DeprecatedClusterLabelKey is applied to each "node" docker container for identification
+	// This is the deprecated value of ClusterLabelKey, and will be removed in a future release
+	DeprecatedClusterLabelKey = "io.k8s.sigs.kind.cluster"
+
+	// NodeRoleLabelKey is applied to each "node" docker container for categorization
 	// of nodes by role
 	// TODO: consider if to switch to a kinder specific label
-	NodeRoleKey = "io.k8s.sigs.kind.role"
+	NodeRoleLabelKey = "io.x-k8s.kind.role"
+
+	// DeprecatedNodeRoleLabelKey is applied to each "node" docker container for categorization
+	// of nodes by role.
+	// This is the deprecated value of NodeRoleKey, and will be removed in a future release
+	DeprecatedNodeRoleLabelKey = "io.k8s.sigs.kind.role"
 
 	// PodSubnet defines the default pod subnet used by kind
 	// TODO: send a PR to define this value in a kind constant (currently it is not)

--- a/kinder/pkg/cri/nodes/common/util.go
+++ b/kinder/pkg/cri/nodes/common/util.go
@@ -38,10 +38,12 @@ func BaseRunArgs(cluster, name, role string) ([]string, error) {
 		"--tty",    // allocate a tty for entrypoint logs
 		// label the node with the cluster ID
 		"--label", fmt.Sprintf("%s=%s", constants.ClusterLabelKey, cluster),
+		"--label", fmt.Sprintf("%s=%s", constants.DeprecatedClusterLabelKey, cluster),
 		"--hostname", name, // make hostname match container name
 		"--name", name, // ... and set the container name
 		// label the node with the role ID
-		"--label", fmt.Sprintf("%s=%s", constants.NodeRoleKey, role),
+		"--label", fmt.Sprintf("%s=%s", constants.NodeRoleLabelKey, role),
+		"--label", fmt.Sprintf("%s=%s", constants.DeprecatedNodeRoleLabelKey, role),
 	}
 
 	// TODO: enable IPv6 if necessary


### PR DESCRIPTION
Kind has migrated to use the new label `io.x-k8s.kind.cluster` and `io.x-k8s.kind.role`.
But Kinder is still using the old labels, this is why the cluster deletion failed.
This PR marks the old labels as DEPRECATED and starts to use the new labels.

Fixes: #2381
Ref: https://github.com/kubernetes-sigs/kind/pull/1074

https://github.com/kubernetes-sigs/kind/commit/a39a4efc8475817f1117026a3259d89524eafc28#diff-980007e783aef4dcb904e3684c6cff1b43a651cbd0134db24f4a45f331adc5fc