### PR TITLE
kinder: add kubelet skew test jobs

### DIFF
--- a/kinder/ci/kubeadm-periodic.tests.md
+++ b/kinder/ci/kubeadm-periodic.tests.md
@@ -53,9 +53,21 @@ Workflow file names: [`upgrade-latest-no-addon-config-maps.yaml`](./workflows)
 
 ### X on Y tests
 
-X on Y tests are meant to verify the proper functioning of kubeadm version X with Kubernetes Y = X-1/minor. Following X on Y tests are implemented:
+X on Y tests are meant to verify the proper functioning of kubeadm version X with Kubernetes Y = X-1/minor.
 
-Workflow file names: [`skew-*`](./workflows)
+Workflow file names: [`skew-[x]-on-[y]`](./workflows)
+
+### kubelet X on Y tests
+
+Kubelet X on Y tests are meant to verify the proper functioning of a version X kubelet against version Y (X+1 or X+2)
+kubeadm and control plane. The coverage of X == Y is already covered by the `regular-*` tests.
+
+Note that for the time being kubeadm version X does not support skew against a kubelet version X-2,
+similarly to how kubeadm does not support X-2 skew with the control plane. This requires skipping
+the `KubeletVersion` preflight check. In the future if these X-2 tests are no longer possible with kubeadm
+they would have to be adapted on the kinder side or dropped.
+
+Workflow file names: [`skew-kubelet-[x]-on-[y]`](./workflows)
 
 ### External etcd with secret copy tests
 

--- a/kinder/ci/workflows/skew-1.18-on-1.17.yaml
+++ b/kinder/ci/workflows/skew-1.18-on-1.17.yaml
@@ -2,10 +2,11 @@ version: 1
 summary: |
   This workflow tests the proper functioning of kubeadm version v1.18 with Kubernetes v1.17
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1-18-on-1-17
-  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
   config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.18` }}"
+  kubeletVersion: "{{ resolve `ci/latest-1.17` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.17` }}"
   controlPlaneNodes: 3
 tasks:

--- a/kinder/ci/workflows/skew-1.19-on-1.18.yaml
+++ b/kinder/ci/workflows/skew-1.19-on-1.18.yaml
@@ -2,10 +2,11 @@ version: 1
 summary: |
   This workflow tests the proper functioning of kubeadm version v1.19 with Kubernetes v1.18
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1-19-on-1-18
-  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
   config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubeletVersion: "{{ resolve `ci/latest-1.18` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.18` }}"
   controlPlaneNodes: 3
 tasks:

--- a/kinder/ci/workflows/skew-1.20-on-1.19.yaml
+++ b/kinder/ci/workflows/skew-1.20-on-1.19.yaml
@@ -2,10 +2,11 @@ version: 1
 summary: |
   This workflow tests the proper functioning of kubeadm version v1.20 with Kubernetes v1.19
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-1-20-on-1-19
-  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
   config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubeletVersion: "{{ resolve `ci/latest-1.19` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
   controlPlaneNodes: 3
 tasks:

--- a/kinder/ci/workflows/skew-kubelet-1.17-on-1.18.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.17-on-1.18.yaml
@@ -1,0 +1,14 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of kubeadm and control plane from 1.18 against 1.17 kubelet
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1.17-on-1.18
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
+vars:
+  kubeadmVersion: "{{ resolve `ci/latest-1.18` }}"
+  kubeletVersion: "{{ resolve `ci/latest-1.17` }}"
+  kubernetesVersion: "{{ resolve `ci/latest-1.18` }}"
+  ignorePreflightErrors: "KubeletVersion"
+  controlPlaneNodes: 3
+tasks:
+- import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.17-on-1.19.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.17-on-1.19.yaml
@@ -1,0 +1,14 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of kubeadm and control plane from 1.19 against 1.17 kubelet
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1.17-on-1.19
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
+vars:
+  kubeadmVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubeletVersion: "{{ resolve `ci/latest-1.17` }}"
+  kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
+  ignorePreflightErrors: "KubeletVersion"
+  controlPlaneNodes: 3
+tasks:
+- import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.18-on-1.19.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.18-on-1.19.yaml
@@ -1,0 +1,14 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of kubeadm and control plane from 1.19 against 1.18 kubelet
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1.18-on-1.19
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
+vars:
+  kubeadmVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubeletVersion: "{{ resolve `ci/latest-1.18` }}"
+  kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
+  ignorePreflightErrors: "KubeletVersion"
+  controlPlaneNodes: 3
+tasks:
+- import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.18-on-1.20.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.18-on-1.20.yaml
@@ -1,0 +1,14 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of kubeadm and control plane from 1.20 against 1.18 kubelet
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1.18-on-1.20
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
+vars:
+  kubeadmVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubeletVersion: "{{ resolve `ci/latest-1.18` }}"
+  kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+  ignorePreflightErrors: "KubeletVersion"
+  controlPlaneNodes: 3
+tasks:
+- import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.19-on-1.20.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.19-on-1.20.yaml
@@ -1,0 +1,14 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of kubeadm and control plane from 1.20 against 1.19 kubelet
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1.19-on-1.20
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
+vars:
+  kubeadmVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubeletVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+  ignorePreflightErrors: "KubeletVersion"
+  controlPlaneNodes: 3
+tasks:
+- import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.19-on-latest.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.19-on-latest.yaml
@@ -1,0 +1,14 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of kubeadm and control plane from latest against 1.19 kubelet
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1.19-on-latest
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
+vars:
+  kubeadmVersion: "{{ resolve `ci/latest` }}"
+  kubeletVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubernetesVersion: "{{ resolve `ci/latest` }}"
+  ignorePreflightErrors: "KubeletVersion"
+  controlPlaneNodes: 3
+tasks:
+- import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.20-on-latest.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.20-on-latest.yaml
@@ -1,0 +1,14 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of kubeadm and control plane from latest against 1.20 kubelet
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1.20-on-latest
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
+vars:
+  kubeadmVersion: "{{ resolve `ci/latest` }}"
+  kubeletVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubernetesVersion: "{{ resolve `ci/latest` }}"
+  ignorePreflightErrors: "KubeletVersion"
+  controlPlaneNodes: 3
+tasks:
+- import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-latest-on-1.20.yaml
+++ b/kinder/ci/workflows/skew-latest-on-1.20.yaml
@@ -2,10 +2,11 @@ version: 1
 summary: |
   This workflow tests the proper functioning of kubeadm version from latest with Kubernetes v1.20
   test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-latest-on-1.20
-  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-X-on-Y.yaml
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
   config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
   kubeadmVersion: "{{ resolve `ci/latest` }}"
+  kubeletVersion: "{{ resolve `ci/latest-1.20` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
   controlPlaneNodes: 3
 tasks:

--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -7,6 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubeadmVersion: v1.13.5
+  kubeletVersion: v1.12.8
   kubernetesVersion: v1.12.8
   controlPlaneNodes: 1
   workerNodes: 2
@@ -14,6 +15,8 @@ vars:
   image: kindest/node:test
   clusterName: kinder-xony
   kubeadmVerbosity: 6
+  defaultIgnorePreflightErrors: Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,
+  ignorePreflightErrors: ""
 tasks:
 - name: pull-base-image
   description: |
@@ -34,6 +37,7 @@ tasks:
     - --image={{ .vars.image }}
     - --with-init-artifacts={{ .vars.kubernetesVersion }}
     - --with-kubeadm={{ .vars.kubeadmVersion }}
+    - --with-kubelet={{ .vars.kubeletVersion }}
     - --loglevel=debug
   timeout: 15m
 - name: create-cluster
@@ -60,6 +64,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
     - --copy-certs=auto
+    - --ignore-preflight-errors={{ .vars.defaultIgnorePreflightErrors }}{{ .vars.ignorePreflightErrors }}
     - --loglevel=debug
   timeout: 5m
 - name: join
@@ -71,6 +76,7 @@ tasks:
     - kubeadm-join
     - --name={{ .vars.clusterName }}
     - --copy-certs=auto
+    - --ignore-preflight-errors={{ .vars.defaultIgnorePreflightErrors }}{{ .vars.ignorePreflightErrors }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   timeout: 10m


### PR DESCRIPTION
on the SIG Node / Arch mailing list there is a discussion around the fact that the kubelet claims support for N-2 skew against the kube-apiserver but currently there are not tests for that.

https://groups.google.com/d/msgid/kubernetes-sig-architecture/CAH1uJ6U4qftRnmWthjYKtBKAzRFFnX7XWLMkSbyVWHUsX8%3DBBg%40mail.gmail.com?utm_medium=email&utm_source=footer

on the side of kubeadm we always recommend that users match their kubelet version with the control plane version and the kubeadm version, but such skew tests can help SIG Node and feature upgrade testing in core.

these commit add tests for version skew testing with kubeadm / kinder:
```
skew-kubelet-1.17-on-1.18.yaml
skew-kubelet-1.17-on-1.19.yaml
skew-kubelet-1.18-on-1.19.yaml
skew-kubelet-1.18-on-1.20.yaml
skew-kubelet-1.19-on-1.20.yaml
skew-kubelet-1.19-on-latest.yaml
skew-kubelet-1.20-on-latest.yaml
```

NOTE: x-on-y jobs that y==x are already covered by the `regular*` jobs.

one caveat (as the note in kubeadm-periodic.tests.md explains) is that kubeadm doesn't really support N-2 kubelet skew (max is N-1), so in the future if changes to the kubelet happen such as these tests are no longer possible with kubeadm directly we need to re-evaluate.
