### PR TITLE
test/e2e/manifests: update for 1.21

### DIFF
--- a/tests/e2e/manifests/verify_manifest_lists.go
+++ b/tests/e2e/manifests/verify_manifest_lists.go
@@ -297,10 +297,6 @@ func getImageVersions(ver *version.Version, images map[string]string) error {
 	images["kube-proxy"] = k8sVersionV
 	images["etcd"] = ""
 	images["pause"] = ""
-	// TODO(neolit123): kube-dns is being deprecated eventually [*].
-	images["k8s-dns-kube-dns"] = ""
-	images["k8s-dns-sidecar"] = ""
-	images["k8s-dns-dnsmasq-nanny"] = ""
 
 	// images outside the scope of kubeadm, but still using the k8s version
 
@@ -343,13 +339,6 @@ func getImageVersions(ver *version.Version, images map[string]string) error {
 			line = strings.Split(line, "PauseVersion = ")[1]
 			line = strings.Replace(line, `"`, "", -1)
 			images["pause"] = line
-		} else if strings.Contains(line, "KubeDNSVersion = ") { // [*]
-			line = strings.TrimSpace(line)
-			line = strings.Split(line, "KubeDNSVersion = ")[1]
-			line = strings.Replace(line, `"`, "", -1)
-			images["k8s-dns-kube-dns"] = line
-			images["k8s-dns-sidecar"] = line
-			images["k8s-dns-dnsmasq-nanny"] = line
 		}
 	}
 	// hardcode the tag for pause as older k8s branches lack a constant.
@@ -358,7 +347,7 @@ func getImageVersions(ver *version.Version, images map[string]string) error {
 	}
 	// verify.
 	fmt.Printf("* getImageVersions(): [%s] %#v\n", ver.String(), images)
-	if images[coreDNSPath] == "" || images["etcd"] == "" || images["k8s-dns-kube-dns"] == "" { // [*]
+	if images[coreDNSPath] == "" || images["etcd"] == "" {
 		return fmt.Errorf("at least one image version could not be set: %#v", images)
 	}
 	return nil

--- a/tests/e2e/manifests/verify_manifest_lists.sh
+++ b/tests/e2e/manifests/verify_manifest_lists.sh
@@ -22,7 +22,7 @@ fi
 
 # install go if missing
 if ! `go version > /dev/null`; then
-	curl https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -o /tmp/go.tar.gz
+	curl https://golang.org/dl/go1.16.linux-amd64.tar.gz -o /tmp/go.tar.gz
 	tar -C /usr/local -xzf /tmp/go.tar.gz
 	export PATH="$PATH":/usr/local/go/bin
 	rm /tmp/go.tar.gz
@@ -41,6 +41,9 @@ cd "$LPATH"
 
 # use go modules. this forces using the latest k8s.io/apimachinery package.
 go mod init verify-manifest-lists
+
+# add module requirements and sums (required in go 1.16)
+go mod tidy
 
 # run unit tests
 go test -v ./verify_manifest_lists.go ./verify_manifest_lists_test.go


### PR DESCRIPTION
test/e2e/manifests: use go 1.16
upstream k8s is using 1.16 now.

test/e2e/manifests: remove testing for kube-dns
xref https://github.com/kubernetes/kubeadm/issues/1943

test/e2e/manifests: verify the architecture in image config blobs
xref https://github.com/kubernetes/kubernetes/issues/99656
