### PR TITLE
kinder: remove leftover 1.17 workflow and constant

### DIFF
--- a/kinder/ci/workflows/external-ca-1.17.yaml
+++ b/kinder/ci/workflows/external-ca-1.17.yaml
@@ -1,9 +1,0 @@
-version: 1
-summary: |
-  This workflow implements a sequence of tasks for testing the external CA functionality.
-  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-ca-1-17
-  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
-vars:
-  kubernetesVersion: "{{ resolve `ci/latest-1.17` }}"
-tasks:
-- import: external-ca-tasks.yaml

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -118,9 +118,6 @@ const (
 
 // kubernetes releases, used for branching code according to K8s release or kubeadm release version
 var (
-	// V1.17 minor version
-	V1_17 = K8sVersion.MustParseSemantic("v1.17.0-0")
-
 	// V1.18 minor version
 	V1_18 = K8sVersion.MustParseSemantic("v1.18.0-0")
 


### PR DESCRIPTION
```
kinder: remove 1.17 constant …
This constant is unused and 1.17 is out of support.

kinder: remove ci/workflows/external-ca-1.17.yaml …
This workflow was not properly removed when 1.17 went out of support.
```

xref https://github.com/kubernetes/kubeadm/issues/2362

test infra PR:
https://github.com/kubernetes/test-infra/pull/21267