### PR TITLE
kinder: skip tests tagged with [MinimumKubeletVersion:VERSION]

### DIFF
--- a/kinder/ci/workflows/skew-kubelet-1.17-on-1.18.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.17-on-1.18.yaml
@@ -9,6 +9,7 @@ vars:
   kubeletVersion: "{{ resolve `ci/latest-1.17` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.18` }}"
   ignorePreflightErrors: "KubeletVersion"
+  ginkgoSkip: "\\[MinimumKubeletVersion:(1.18)\\]"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.17-on-1.19.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.17-on-1.19.yaml
@@ -9,6 +9,7 @@ vars:
   kubeletVersion: "{{ resolve `ci/latest-1.17` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
   ignorePreflightErrors: "KubeletVersion"
+  ginkgoSkip: "\\[MinimumKubeletVersion:(1.18|1.19)\\]"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.18-on-1.19.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.18-on-1.19.yaml
@@ -9,6 +9,7 @@ vars:
   kubeletVersion: "{{ resolve `ci/latest-1.18` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
   ignorePreflightErrors: "KubeletVersion"
+  ginkgoSkip: "\\[MinimumKubeletVersion:(1.19)\\]"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.18-on-1.20.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.18-on-1.20.yaml
@@ -9,6 +9,7 @@ vars:
   kubeletVersion: "{{ resolve `ci/latest-1.18` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
   ignorePreflightErrors: "KubeletVersion"
+  ginkgoSkip: "\\[MinimumKubeletVersion:(1.19|1.20)\\]"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.19-on-1.20.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.19-on-1.20.yaml
@@ -9,6 +9,7 @@ vars:
   kubeletVersion: "{{ resolve `ci/latest-1.19` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
   ignorePreflightErrors: "KubeletVersion"
+  ginkgoSkip: "\\[MinimumKubeletVersion:(1.20)\\]"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.19-on-latest.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.19-on-latest.yaml
@@ -9,6 +9,7 @@ vars:
   kubeletVersion: "{{ resolve `ci/latest-1.19` }}"
   kubernetesVersion: "{{ resolve `ci/latest` }}"
   ignorePreflightErrors: "KubeletVersion"
+  ginkgoSkip: "\\[MinimumKubeletVersion:(1.20|1.21)\\]"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.20-on-latest.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.20-on-latest.yaml
@@ -9,6 +9,7 @@ vars:
   kubeletVersion: "{{ resolve `ci/latest-1.20` }}"
   kubernetesVersion: "{{ resolve `ci/latest` }}"
   ignorePreflightErrors: "KubeletVersion"
+  ginkgoSkip: "\\[MinimumKubeletVersion:(1.21)\\]"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -17,6 +17,7 @@ vars:
   kubeadmVerbosity: 6
   defaultIgnorePreflightErrors: Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,
   ignorePreflightErrors: ""
+  ginkgoSkip: ""
 tasks:
 - name: pull-base-image
   description: |
@@ -110,6 +111,7 @@ tasks:
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
     - --parallel
     - --name={{ .vars.clusterName }}
+    - --ginkgo-flags="{{ if .vars.ginkgoSkip }}--skip={{ .vars.ginkgoSkip }}{{ end }}"
     - --loglevel=debug
   timeout: 35m
 - name: get-logs


### PR DESCRIPTION
If a kubelet skew job is running against a kubelet N, skip tests
tagged with:
  [MinimumKubeletVersion:(N+1)]
or
  [MinimumKubeletVersion:(N+1|N+2)]
depending of the size of the skew.

xref https://github.com/kubernetes/kubernetes/issues/99909
