### PR TITLE
kinder/ci/workflows: remove quotes around --ginkgo-flags

### DIFF
--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -111,7 +111,7 @@ tasks:
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
     - --parallel
     - --name={{ .vars.clusterName }}
-    - --ginkgo-flags="{{ if .vars.ginkgoSkip }}--skip={{ .vars.ginkgoSkip }}{{ end }}"
+    - --ginkgo-flags={{ if .vars.ginkgoSkip }}--skip={{ .vars.ginkgoSkip }}{{ end }}
     - --loglevel=debug
   timeout: 35m
 - name: get-logs


### PR DESCRIPTION
Remove the quotes or this would fail parsing with:
  Error: flag "\"--skip=\\[MinimumKubeletVersion:(1.21)\\]\""
  could not be parsed correctly: the argument should start with '--'

added in:
https://github.com/kubernetes/kubeadm/pull/2403

failing tests:
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-20-on-latest/1369480366976405504/artifacts/task-07-e2e-log.txt
https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1-20-on-latest
