### PR TITLE
verify_manifest_lists: don't test conformance:v1.21.0-beta.1

### DIFF
--- a/tests/e2e/manifests/verify_manifest_lists.go
+++ b/tests/e2e/manifests/verify_manifest_lists.go
@@ -313,8 +313,10 @@ func getImageVersions(ver *version.Version, images map[string]string) error {
 		images["cloud-controller-manager"] = k8sVersionV
 	}
 	// test the conformance image, but only for newer versions as it was added in v1.13.0-alpha.2
+	// also skip v1.21.0-beta.1 due to a bug that caused this image tag to not be released.
 	conformanceMinVer := version.MustParseSemantic("v1.13.0-alpha.2")
-	if ver.AtLeast(conformanceMinVer) {
+	is21beta1, _ := ver.Compare("v1.21.0-beta.1")
+	if ver.AtLeast(conformanceMinVer) && is21beta1 != 0 {
 		images["conformance"] = k8sVersionV
 	}
 


### PR DESCRIPTION
This image is missing in the pre-release, so we have to skip it.
Instead of skipping images like that ideally the release process
should release again this missing image, but looks like this is
complicated.

discussion:
https://kubernetes.slack.com/archives/C2C40FMNF/p1615817136017300?thread_ts=1615817136.017300&cid=C2C40FMNF

fixes https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-all#periodic-manifest-lists
