### PR TITLE
change config.yaml instead of args for fail-swap-on

### DIFF
--- a/kinder/pkg/build/bits/initBits.go
+++ b/kinder/pkg/build/bits/initBits.go
@@ -278,14 +278,6 @@ func configureKubelet(c *BuildContext) error {
 		return err
 	}
 
-	// ensure we don't fail if swap is enabled on the host
-	if err := c.RunInContainer("/bin/sh", "-c",
-		`echo "KUBELET_EXTRA_ARGS=--fail-swap-on=false" >> /etc/default/kubelet`,
-	); err != nil {
-		log.Errorf("failed to set kubelet fail-swap-on! %v", err)
-		return err
-	}
-
 	return nil
 }
 

--- a/kinder/pkg/kubeadm/config.go
+++ b/kinder/pkg/kubeadm/config.go
@@ -172,7 +172,6 @@ localAPIEndpoint:
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
   kubeletExtraArgs:
-    fail-swap-on: "false"
     node-ip: "{{ .NodeAddress }}"
 ---
 # no-op entry that exists solely so it can be patched
@@ -189,7 +188,6 @@ controlPlane:
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
   kubeletExtraArgs:
-    fail-swap-on: "false"
     node-ip: "{{ .NodeAddress }}"
 discovery:
   bootstrapToken:
@@ -210,6 +208,7 @@ healthzBindAddress: "::"
 # kubelet will see the host disk that the inner container runtime
 # is ultimately backed by and attempt to recover disk space. we don't want that.
 imageGCHighThresholdPercent: 100
+failSwapOn: false
 evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
@@ -269,7 +268,6 @@ localAPIEndpoint:
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
   kubeletExtraArgs:
-    fail-swap-on: "false"
     node-ip: "{{ .NodeAddress }}"
 ---
 # no-op entry that exists solely so it can be patched
@@ -286,7 +284,6 @@ controlPlane:
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
   kubeletExtraArgs:
-    fail-swap-on: "false"
     node-ip: "{{ .NodeAddress }}"
 discovery:
   bootstrapToken:
@@ -307,6 +304,7 @@ healthzBindAddress: "::"
 # kubelet will see the host disk that the inner container runtime
 # is ultimately backed by and attempt to recover disk space. we don't want that.
 imageGCHighThresholdPercent: 100
+failSwapOn: false
 evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"


### PR DESCRIPTION
> Mar 26 02:30:25 kind-control-plane kubelet[244]: Flag --fail-swap-on has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.

https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/100573/pull-kubernetes-e2e-kind-ipv6/1375269122421559296/artifacts/logs/kind-control-plane/kubelet.log

Fix warning logs in e2e testing envs.