### PR TITLE
kinder: add leftover test workflows for 1.21

### DIFF
--- a/kinder/ci/workflows/external-ca-1.21.yaml
+++ b/kinder/ci/workflows/external-ca-1.21.yaml
@@ -1,0 +1,9 @@
+version: 1
+summary: |
+  This workflow implements a sequence of tasks for testing the external CA functionality.
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-external-ca-1-21
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.21` }}"
+tasks:
+- import: external-ca-tasks.yaml

--- a/kinder/ci/workflows/patches-1.21.yaml
+++ b/kinder/ci/workflows/patches-1.21.yaml
@@ -1,0 +1,9 @@
+version: 1
+summary: |
+  This workflow implements a sequence of tasks for testing the patches functionality.
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-patches-1-21
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
+vars:
+  kubernetesVersion: "{{ resolve `ci/latest-1.21` }}"
+tasks:
+- import: patches-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.19-on-1.21.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.19-on-1.21.yaml
@@ -1,11 +1,11 @@
 version: 1
 summary: |
-  This workflow tests the proper functioning of kubeadm and control plane from latest against 1.19 kubelet
-  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1.19-on-latest
+  This workflow tests the proper functioning of kubeadm and control plane v1.21 against 1.19 kubelet
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1-19-on-1-21
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
   config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
-  kubeadmVersion: "{{ resolve `ci/latest` }}"
+  kubeadmVersion: "{{ resolve `ci/latest-1.21` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.19` }}"
   kubernetesVersion: "{{ resolve `ci/latest` }}"
   ignorePreflightErrors: "KubeletVersion"

--- a/kinder/ci/workflows/skew-kubelet-1.20-on-1.21.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.20-on-1.21.yaml
@@ -1,11 +1,11 @@
 version: 1
 summary: |
-  This workflow tests the proper functioning of kubeadm and control plane from latest against 1.20 kubelet
-  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1.20-on-latest
+  This workflow tests the proper functioning of kubeadm and control plane v1.21 against 1.20 kubelet
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1-20-on-1-21
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
   config    > https://git.k8s.io/test-infra/testgrid/config.yaml
 vars:
-  kubeadmVersion: "{{ resolve `ci/latest` }}"
+  kubeadmVersion: "{{ resolve `ci/latest-1.21` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.20` }}"
   kubernetesVersion: "{{ resolve `ci/latest` }}"
   ignorePreflightErrors: "KubeletVersion"

--- a/kinder/ci/workflows/skew-kubelet-1.21-on-latest.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.21-on-latest.yaml
@@ -1,0 +1,15 @@
+version: 1
+summary: |
+  This workflow tests the proper functioning of kubeadm and control plane from latest against 1.21 kubelet
+  test grid > https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1.21-on-latest
+  config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+  config    > https://git.k8s.io/test-infra/testgrid/config.yaml
+vars:
+  kubeadmVersion: "{{ resolve `ci/latest` }}"
+  kubeletVersion: "{{ resolve `ci/latest-1.21` }}"
+  kubernetesVersion: "{{ resolve `ci/latest` }}"
+  ignorePreflightErrors: "KubeletVersion"
+  ginkgoSkip: "\\[MinimumKubeletVersion:(1.21)\\]"
+  controlPlaneNodes: 3
+tasks:
+- import: skew-x-on-y-tasks.yaml


### PR DESCRIPTION
xref https://github.com/kubernetes/kubeadm/pull/2412#pullrequestreview-626238534
test infra PR: https://github.com/kubernetes/test-infra/pull/21643
