### PR TITLE
kinder: import the kindnet manifest as source code

### DIFF
--- a/kinder/pkg/cluster/manager/actions/assets/kindnet.go
+++ b/kinder/pkg/cluster/manager/actions/assets/kindnet.go
@@ -1,3 +1,23 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assets
+
+// KindnetManifest054 holds the kindnet manifest for 0.5.4
+const KindnetManifest054 = `
 # kindnetd networking manifest
 # would you kindly template this file
 ---
@@ -111,3 +131,4 @@ spec:
         - name: lib-modules
           hostPath:
             path: /lib/modules
+`

--- a/kinder/pkg/cluster/manager/actions/kubeadm-init.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-init.go
@@ -18,7 +18,6 @@ package actions
 
 import (
 	"bytes"
-	_ "embed" // enable go:embed
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -31,13 +30,9 @@ import (
 
 	"github.com/pkg/errors"
 
+	"k8s.io/kubeadm/kinder/pkg/cluster/manager/actions/assets"
 	"k8s.io/kubeadm/kinder/pkg/cluster/status"
 	"k8s.io/kubeadm/kinder/pkg/constants"
-)
-
-var (
-	//go:embed assets/kindnet.yaml
-	kindnetManifest string
 )
 
 // KubeadmInit executes the kubeadm init workflow including also post init task
@@ -227,7 +222,7 @@ func postInit(c *status.Cluster, wait time.Duration) error {
 	// Apply a CNI plugin using a hardcoded manifest
 	cmd := cp1.Command("kubectl", "apply", "--kubeconfig=/etc/kubernetes/admin.conf", "-f", "-")
 	cp1.Infof("applying kindnet version 0.5.4")
-	cmd.Stdin(strings.NewReader(kindnetManifest))
+	cmd.Stdin(strings.NewReader(assets.KindnetManifest054))
 	if err := cmd.RunWithEcho(); err != nil {
 		return err
 	}


### PR DESCRIPTION
In CI we use a versioned kubekins image that does not
have go1.16 when testing k8s versions older than 1.21.
This means we have to preserve backwards compatibility
and cannot use "go:embed" until all kubekins versions
in the k8s skew have at least go1.16.

fixes https://github.com/kubernetes/kubeadm/issues/2441
