### PR TITLE
kinder: remove 1.18 constant

### DIFF
--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -118,9 +118,6 @@ const (
 
 // kubernetes releases, used for branching code according to K8s release or kubeadm release version
 var (
-	// V1.18 minor version
-	V1_18 = K8sVersion.MustParseSemantic("v1.18.0-0")
-
 	// V1.19 minor version
 	V1_19 = K8sVersion.MustParseSemantic("v1.19.0-0")
 )


### PR DESCRIPTION
This constant is unused and 1.18 is out of support.