### PR TITLE
further cleanup of "master" -> "control plane"

### DIFF
--- a/docs/ha-considerations.md
+++ b/docs/ha-considerations.md
@@ -77,7 +77,7 @@ There are some placeholders in `bash` variable style to fill in:
 - `${STATE}` is `MASTER` for one and `BACKUP` for all other hosts, hence the virtual IP will initially be assigned to the `MASTER`.
 - `${INTERFACE}` is the network interface taking part in the negotiation of the virtual IP, e.g. `eth0`.
 - `${ROUTER_ID}` should be the same for all `keepalived` cluster hosts while unique amongst all clusters in the same subnet. Many distros pre-configure its value to `51`.
-- `${PRIORITY}` should be higher on the master than on the backups. Hence `101` and `100` respectively will suffice.
+- `${PRIORITY}` should be higher on the control plane node than on the backups. Hence `101` and `100` respectively will suffice.
 - `${AUTH_PASS}` should be the same for all `keepalived` cluster hosts, e.g. `42`
 - `${APISERVER_VIP}` is the virtual IP address negotiated between the `keepalived` cluster hosts.
 
@@ -137,7 +137,7 @@ defaults
     timeout check           10s
 
 #---------------------------------------------------------------------
-# apiserver frontend which proxys to the masters
+# apiserver frontend which proxys to the control plane nodes
 #---------------------------------------------------------------------
 frontend apiserver
     bind *:${APISERVER_DEST_PORT}

--- a/docs/managing-e2e-tests.md
+++ b/docs/managing-e2e-tests.md
@@ -50,7 +50,7 @@ As an overview:
 - Inside this dashboard there are individual tabs such as `kubeadm-foo` (which is the tab name for the
 job `ci-kubernetes-e2e-kubeadm-foo`).
 
-In the YAML structure of jobs such as `ci-kubernetes-e2e-kubeadm-kind-master` the following list
+In the YAML structure of jobs such as `ci-kubernetes-e2e-kubeadm-foo` the following list
 of annotations can be seen:
 
 ```

--- a/docs/test-failures.md
+++ b/docs/test-failures.md
@@ -32,7 +32,7 @@ necessary.
 
 If tests fail due to an upstream change to test-infra or a related ecosystem
 project, it is the responsibility of maintainers to correct and recalibrate
-tests.  
+tests.
 
 Ideally, maintainers and those accountable for such upstream projects should
 make it a habit of routinely reaching out to relevant stakeholders when such
@@ -52,5 +52,5 @@ Test failure will look like:
 ```error during make -C /workspace/kubernetes-anywhere WAIT_FOR_KUBECONFIG=y deploy: exit status 2```
 
 To debug further, dig into the collected logs
-1. Determine if master was able to set up with kubeadm. Logs are under: ```/artifacts/master-node-name/serial-1.log```
+1. Determine if a control plane was able to set up with kubeadm. Logs are under: ```/artifacts/control-plane-node-name/serial-1.log```
 2. Determine if nodes were able to set up with kubeadm. Logs are under: ```/artifacts/node-name/serial-1.log```

--- a/docs/updating-command-reference.md
+++ b/docs/updating-command-reference.md
@@ -25,7 +25,7 @@ sub-command in the parent command MD file like so:
 	{{< include "generated/kubeadm_config_newcommand.md" >}}
 	```
 	Full example:
-	* https://raw.githubusercontent.com/kubernetes/website/master/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
+	* https://git.k8s.io/website/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
 - Please note that these files will act only as placeholders with respect to the `kubernetes/website`
 and they will later be overwritten with generated files by a [separate tool](https://github.com/kubernetes-incubator/reference-docs)
 that also supports HTML styles. This process is managed by SIG Docs on each release.
@@ -36,4 +36,4 @@ that also supports HTML styles. This process is managed by SIG Docs on each rele
 - When sending a PR for `kubernetes/website` make sure that you remove files related to `*newcommand*` in:
 `./content/en/docs/reference/setup-tools/kubeadm/generated`
 - Also, remove includes and any notes about this command in the parent command MD file.
-- Make sure that you commit these changes in your PR for `kubernetes/website`. 
+- Make sure that you commit these changes in your PR for `kubernetes/website`.

--- a/kinder/cmd/kinder/cp/cp.go
+++ b/kinder/cmd/kinder/cp/cp.go
@@ -41,7 +41,7 @@ func NewCommand() *cobra.Command {
 			"    @all 	all the control-plane and worker nodes \n" +
 			"    @cp* 	all the control-plane nodes \n" +
 			"    @cp1 	the bootstrap-control plane node \n" +
-			"    @cpN 	the secondary master nodes \n" +
+			"    @cpN 	the secondary control plane nodes \n" +
 			"    @w* 	all the worker nodes\n" +
 			"    @lb 	the external load balancer\n" +
 			"    @etcd 	the external etcd",

--- a/kinder/cmd/kinder/exec/exec.go
+++ b/kinder/cmd/kinder/exec/exec.go
@@ -40,7 +40,7 @@ func NewCommand() *cobra.Command {
 			"    @all 	all the control-plane and worker nodes \n" +
 			"    @cp* 	all the control-plane nodes \n" +
 			"    @cp1 	the bootstrap-control plane node \n" +
-			"    @cpN 	the secondary master nodes \n" +
+			"    @cpN 	the secondary control plane nodes \n" +
 			"    @w* 	all the worker nodes\n" +
 			"    @lb 	the external load balancer\n" +
 			"    @etcd 	the external etcd",

--- a/kinder/doc/reference.md
+++ b/kinder/doc/reference.md
@@ -113,7 +113,7 @@ Following node selectors are available
 | @all     | all the Kubernetes nodes in the cluster.<br />(control-plane and worker nodes are included, load balancer and etcd not) |
 | @cp*     | all the control-plane nodes                                  |
 | @cp1     | the bootstrap-control plane node                             |
-| @cpN     | the secondary master nodes                                   |
+| @cpN     | the secondary control plane nodes                            |
 | @w*      | all the worker nodes                                         |
 | @lb      | the external load balancer                                   |
 | @etcd    | the external etcd                                            |

--- a/kinder/pkg/cluster/status/cluster.go
+++ b/kinder/pkg/cluster/status/cluster.go
@@ -191,7 +191,7 @@ func (c *Cluster) Validate() error {
 	return nil
 }
 
-// ReadSettings read cluster settings from a control-plane node
+// ReadSettings read cluster settings from a control plane node
 func (c *Cluster) ReadSettings() (err error) {
 	log.Debug("Reading cluster settings...")
 	c.Settings, err = c.BootstrapControlPlane().ReadClusterSettings()

--- a/kinder/pkg/cri/host/doc.go
+++ b/kinder/pkg/cri/host/doc.go
@@ -19,6 +19,6 @@ package host
 /*
 Package host provide utilities for dealing with the CRI engine on the host machine (docker).
 
-The current implementation is a fork from "https://github.com/kubernetes-sigs/kind/blob/master/pkg/build/nodeimage/internal/container/docker/",
+The current implementation is a fork from "https://sigs.k8s.io/kind/pkg/build/nodeimage/internal/container/docker/",
 which can't be used because it is internal. The code in this package is now evolving independently from the original.
 */

--- a/kinder/pkg/kubeadm/patch.go
+++ b/kinder/pkg/kubeadm/patch.go
@@ -30,7 +30,7 @@ import (
 /*
 patch.go provides utilities for applying patches to a YAML file.
 
-The current implementation is a fork from "https://github.com/kubernetes-sigs/kind/blob/master/pkg/cluster/internal/patch",
+The current implementation is a fork from "https://sigs.k8s.io/kind/pkg/cluster/internal/patch",
 which can't be used because it is internal. The code in this package is now evolving independently from the original.
 */
 


### PR DESCRIPTION
- remove some more instances of the word "master" and use "control plane"
- migrate links with "master" branch to git.k8s.io/ and sigs.k8s.io.
