### PR TITLE
kinder: migrate to sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io

### DIFF
--- a/docs/managing-e2e-tests.md
+++ b/docs/managing-e2e-tests.md
@@ -57,7 +57,7 @@ of annotations can be seen:
 annotations:
   testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-master-informing
   testgrid-tab-name: kubeadm-foo
-  testgrid-alert-email: kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com
+  testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
   description: "OWNER: sig-cluster-lifecycle: some description here"
   testgrid-num-columns-recent: "20"
   testgrid-num-failures-to-alert: "4"
@@ -110,12 +110,12 @@ Jobs against the latest development branch run more often.
 Test job failures can trigger email alerts. This can be configured using annotations:
 
 ```
-  testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+  testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
   testgrid-num-failures-to-alert: "4"
   testgrid-alert-stale-results-hours: "8"
 ```
 
-- `testgrid-alert-email` should be set to `kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com`.
+- `testgrid-alert-email` should be set to `sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io`.
 in the case of SIG Cluster Lifecycle. This is a mailing list (Google Group) that will receive the alert.
 - `testgrid-alert-stale-results-hours` means an alert will be sent in case the job is in a stale state
 and is not reporting new status after N hours. Usually a restart by a test-infra "on-call" operator

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-addons.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-addons.yaml
@@ -7,7 +7,7 @@
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-no-addons-{{ dashVer .KubernetesVersion }}
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and test if 'join' and 'upgrade' works with missing addon ConfigMaps"
     testgrid-num-columns-recent: "20"
     testgrid-num-failures-to-alert: "4"

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-discovery.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-discovery.yaml
@@ -7,7 +7,7 @@
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-discovery-{{ dashVer .KubernetesVersion }}
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and test alternative discovery methods for kubeadm join"
     testgrid-num-columns-recent: "20"
 {{ .AlertAnnotations }}

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-ca.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-ca.yaml
@@ -7,7 +7,7 @@
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-external-ca-{{ dashVer .KubernetesVersion }}
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and tests kubeadm's support for external CA mode"
     testgrid-num-columns-recent: "20"
 {{ .AlertAnnotations }}

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-etcd.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-etcd.yaml
@@ -7,7 +7,7 @@
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-external-etcd-{{ dashVer .KubernetesVersion }}
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with external etcd and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
 {{ .AlertAnnotations }}

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -7,7 +7,7 @@
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-node-kubelet
     testgrid-tab-name: kubeadm-kinder-kubelet-{{ dashVer .KubeletVersion }}-on-{{ dashVer .KubernetesVersion }}
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com, kubernetes-sig-node+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node+testgrid@googlegroups.com
     description: "OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
 {{ .AlertAnnotations }}

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-patches.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-patches.yaml
@@ -7,7 +7,7 @@
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-patches-{{ dashVer .KubernetesVersion }}
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with patches on static Pod manifests"
     testgrid-num-columns-recent: "20"
 {{ .AlertAnnotations }}

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-upgrade.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-upgrade.yaml
@@ -7,7 +7,7 @@
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-{{ sigReleaseVer .KubernetesVersion }}-informing
     testgrid-tab-name: kubeadm-kinder-upgrade-{{ dashVer .InitVersion }}-{{ dashVer .KubernetesVersion }}
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com, release-team@kubernetes.io
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster, upgrade it and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
 {{ .AlertAnnotations }}

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-x-on-y.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-x-on-y.yaml
@@ -7,7 +7,7 @@
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-{{ sigReleaseVer .KubeadmVersion }}-informing
     testgrid-tab-name: kubeadm-kinder-{{ dashVer .KubeadmVersion }}-on-{{ dashVer .KubernetesVersion }}
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com, release-team@kubernetes.io
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with version skew and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
 {{ .AlertAnnotations }}

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder.yaml
@@ -7,7 +7,7 @@
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-{{ sigReleaseVer .KubernetesVersion }}-informing
     testgrid-tab-name: kubeadm-kinder-{{ dashVer .KubernetesVersion }}
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com, release-team@kubernetes.io
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
 {{ .AlertAnnotations }}


### PR DESCRIPTION
Migrate the mailing list for kubeadm/kinder e2e job failure
alerts to "sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io"
in testinfra templates.

Update docs/managing-e2e-tests.md.

fixes https://github.com/kubernetes/kubeadm/issues/2451

test-infra PR: https://github.com/kubernetes/test-infra/pull/22206