### PR TITLE
kinder: pin the CR cgroup driver to "systemd"

### DIFF
--- a/kinder/pkg/build/alter/alter.go
+++ b/kinder/pkg/build/alter/alter.go
@@ -332,6 +332,11 @@ func (c *Context) alterImage(bitsInstallers []bits.Installer, bc *bits.BuildCont
 		}
 	}
 
+	log.Info("Setup CRI ...")
+	if err := alterHelper.SetupCRI(bc); err != nil {
+		return errors.Wrapf(err, "image build Failed! Failed to setup %s", runtime)
+	}
+
 	log.Info("Start CRI ...")
 	if err := alterHelper.StartCRI(bc); err != nil {
 		return errors.Wrapf(err, "image build Failed! Failed to start %s", runtime)

--- a/kinder/pkg/cri/nodes/alterhelper.go
+++ b/kinder/pkg/cri/nodes/alterhelper.go
@@ -61,6 +61,17 @@ func (h *AlterHelper) StartCRI(bc *bits.BuildContext) error {
 	return errors.Errorf("unknown cri: %s", h.cri)
 }
 
+// SetupCRI setups the container runtime.
+func (h *AlterHelper) SetupCRI(bc *bits.BuildContext) error {
+	switch h.cri {
+	case status.ContainerdRuntime:
+		return containerd.SetupRuntime(bc)
+	case status.DockerRuntime:
+		return docker.SetupRuntime(bc)
+	}
+	return errors.Errorf("unknown cri: %s", h.cri)
+}
+
 // PreLoadInitImages preload images required by kubeadm-init into the selected container runtime that exists inside a kind(er) node
 func (h *AlterHelper) PreLoadInitImages(bc *bits.BuildContext, srcFolder string) error {
 	switch h.cri {

--- a/kinder/pkg/cri/nodes/containerd/alterhelper.go
+++ b/kinder/pkg/cri/nodes/containerd/alterhelper.go
@@ -46,6 +46,18 @@ func GetAlterContainerArgs() ([]string, []string) {
 	return runArgs, runCommands
 }
 
+// SetupRuntime setups the runtime
+func SetupRuntime(bc *bits.BuildContext) error {
+	// Append the containerd settings for a systemd cgroup driver at the end of the config.toml.
+	// This assumes runc is used as the underlying runtime.
+	if err := bc.RunInContainer("bash", "-c",
+		"printf '[plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options]\nsystemdCgroup = true\n' >> /etc/containerd/config.toml",
+	); err != nil {
+		return errors.Wrap(err, "could not append to /etc/containerd/config.toml")
+	}
+	return nil
+}
+
 // StartRuntime starts the runtime
 func StartRuntime(bc *bits.BuildContext) error {
 	log.Info("starting containerd")

--- a/kinder/pkg/kubeadm/config.go
+++ b/kinder/pkg/kubeadm/config.go
@@ -206,6 +206,9 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+# pin the cgroup driver to systemd.
+# this assumes that the CR on the node image is configured accordingly.
+cgroupDriver: "systemd"
 ---
 # no-op entry that exists solely so it can be patched
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
@@ -302,6 +305,9 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+# pin the cgroup driver to systemd.
+# this assumes that the CR on the node image is configured accordingly.
+cgroupDriver: "systemd"
 ---
 # no-op entry that exists solely so it can be patched
 apiVersion: kubeproxy.config.k8s.io/v1alpha1


### PR DESCRIPTION
Pin the driver to "systemd" in:
- the Docker / containerd config files during image alter
- KubeletConfiguration that kubeadm deploys

xref https://github.com/kubernetes/kubeadm/issues/874