### PR TITLE
[WIP] kinder: pass --kubeadm-config-version flag with v1beta2 for all the jobs that test kubeadm/kubernetes versions older than 1.22

### DIFF
--- a/kinder/ci/tools/update-workflows/pkg/types.go
+++ b/kinder/ci/tools/update-workflows/pkg/types.go
@@ -68,10 +68,11 @@ type job struct {
 }
 
 type templateVars struct {
-	KubernetesVersion string
-	KubeletVersion    string
-	KubeadmVersion    string
-	InitVersion       string
+	KubernetesVersion    string
+	KubeletVersion       string
+	KubeadmVersion       string
+	KubeadmConfigVersion string
+	InitVersion          string
 
 	TargetFile   string
 	SkipVersions string

--- a/kinder/ci/tools/update-workflows/pkg/workflows.go
+++ b/kinder/ci/tools/update-workflows/pkg/workflows.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
+
+	"k8s.io/kubeadm/kinder/pkg/kubeadm"
 )
 
 func processWorkflows(settings *Settings, cfg *jobGroup, oldestVer, minVer *versionutil.Version) error {
@@ -87,6 +89,18 @@ func processWorkflows(settings *Settings, cfg *jobGroup, oldestVer, minVer *vers
 			if err != nil {
 				return errors.Wrapf(err, "malformed SkipVersions %v", job.SkipVersions)
 			}
+		}
+
+		// determine kubeadm config version
+		var kubernetesVersion *versionutil.Version
+		if job.KubernetesVersion == latestVersion {
+			kubernetesVersion = settings.KubernetesVersion.WithMinor(settings.KubernetesVersion.Minor() + 1)
+		} else {
+			kubernetesVersion = versionutil.MustParseGeneric(job.KubernetesVersion)
+		}
+		vars.KubeadmConfigVersion, err = kubeadm.GetKubeadmConfigVersion(kubernetesVersion)
+		if err != nil {
+			return err
 		}
 
 		// execute templates

--- a/kinder/ci/tools/update-workflows/templates/workflows/discovery-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/discovery-tasks.yaml
@@ -7,6 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
+  kubeadmConfigVersion: v1beta2
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-discovery
@@ -55,6 +56,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -68,6 +70,7 @@ tasks:
     - --discovery-mode=file
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -81,6 +84,7 @@ tasks:
     - --discovery-mode=file-with-token
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -94,6 +98,7 @@ tasks:
     - --discovery-mode=file-with-embedded-client-certificates
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -107,6 +112,7 @@ tasks:
     - --discovery-mode=file-with-external-client-certificates
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: e2e-kubeadm
   description: |

--- a/kinder/ci/tools/update-workflows/templates/workflows/discovery.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/discovery.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/{{ .TargetFile }}
 vars:
   kubernetesVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubernetesVersion }}` \}\}"
+  kubeadmConfigVersion: "{{ .KubeadmConfigVersion }}"
 tasks:
 - import: discovery-tasks.yaml

--- a/kinder/ci/tools/update-workflows/templates/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-ca-tasks.yaml
@@ -6,6 +6,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
+  kubeadmConfigVersion: v1beta2
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-external-ca
@@ -67,6 +68,7 @@ tasks:
       - --name={{ .vars.clusterName }}
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+      - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
     timeout: 5m
   - name: join
     description: |
@@ -82,6 +84,7 @@ tasks:
       - --ignore-preflight-errors=FileAvailable--etc-kubernetes-kubelet.conf,FileAvailable--etc-kubernetes-pki-ca.crt,Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+      - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
     timeout: 10m
   - name: e2e-kubeadm
     description: |

--- a/kinder/ci/tools/update-workflows/templates/workflows/external-ca.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-ca.yaml
@@ -5,5 +5,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/{{ .TargetFile }}
 vars:
   kubernetesVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubernetesVersion }}` \}\}"
+  kubeadmConfigVersion: "{{ .KubeadmConfigVersion }}"
 tasks:
 - import: external-ca-tasks.yaml

--- a/kinder/ci/tools/update-workflows/templates/workflows/external-etcd-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-etcd-tasks.yaml
@@ -4,6 +4,7 @@ summary: |
   cluster with an external etcd cluster.
 vars:
   kubernetesVersion: v1.14.1
+  kubeadmConfigVersion: v1beta2
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-external-etcd
@@ -55,6 +56,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -67,6 +69,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 10m
 - name: e2e-kubeadm
   description: |

--- a/kinder/ci/tools/update-workflows/templates/workflows/external-etcd.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-etcd.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/{{ .TargetFile }}
 vars:
   kubernetesVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubernetesVersion }}` \}\}"
+  kubeadmConfigVersion: "{{ .KubeadmConfigVersion }}"
 tasks:
 - import: external-etcd-tasks.yaml

--- a/kinder/ci/tools/update-workflows/templates/workflows/patches-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/patches-tasks.yaml
@@ -6,6 +6,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
+  kubeadmConfigVersion: v1beta2
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-patches
@@ -119,6 +120,7 @@ tasks:
       - --patches=/tmp/kubeadm-patches
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+      - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
     timeout: 5m
   - name: join
     description: |
@@ -131,6 +133,7 @@ tasks:
       - --patches=/tmp/kubeadm-patches
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+      - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
     timeout: 10m
   - name: run verify-patches.sh on controlplane nodes before upgrades
     cmd: kinder
@@ -152,6 +155,7 @@ tasks:
       - --name={{ .vars.clusterName }}
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+      - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
     timeout: 15m
   - name: run verify-patches.sh on controlplane nodes after upgrades
     cmd: kinder

--- a/kinder/ci/tools/update-workflows/templates/workflows/patches.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/patches.yaml
@@ -5,5 +5,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/{{ .TargetFile }}
 vars:
   kubernetesVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubernetesVersion }}` \}\}"
+  kubeadmConfigVersion: "{{ .KubeadmConfigVersion }}"
 tasks:
 - import: patches-tasks.yaml

--- a/kinder/ci/tools/update-workflows/templates/workflows/regular-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/regular-tasks.yaml
@@ -7,6 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.13.5
+  kubeadmConfigVersion: v1beta2
   controlPlaneNodes: 3
   workerNodes: 2
   baseImage: kindest/base:v20191105-ee880e9b # has containerd
@@ -57,6 +58,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -68,6 +70,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 10m
 - name: cluster-info
   description: |

--- a/kinder/ci/tools/update-workflows/templates/workflows/regular.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/regular.yaml
@@ -5,5 +5,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/{{ .TargetFile }}
 vars:
   kubernetesVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubernetesVersion }}` \}\}"
+  kubeadmConfigVersion: "{{ .KubeadmConfigVersion }}"
 tasks:
 - import: regular-tasks.yaml

--- a/kinder/ci/tools/update-workflows/templates/workflows/skew-kubelet-x-on-y.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/skew-kubelet-x-on-y.yaml
@@ -7,6 +7,7 @@ vars:
   kubeadmVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubeadmVersion }}` \}\}"
   kubeletVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubeletVersion }}` \}\}"
   kubernetesVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubernetesVersion }}` \}\}"
+  kubeadmConfigVersion: "{{ .KubeadmConfigVersion }}"
   ignorePreflightErrors: "KubeletVersion"
   ginkgoSkip: "\\[MinimumKubeletVersion:({{ .SkipVersions }})\\]"
   controlPlaneNodes: 3

--- a/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y-tasks.yaml
@@ -9,6 +9,7 @@ vars:
   kubeadmVersion: v1.13.5
   kubeletVersion: v1.12.8
   kubernetesVersion: v1.12.8
+  kubeadmConfigVersion: v1beta2
   controlPlaneNodes: 1
   workerNodes: 2
   baseImage: kindest/base:v20190403-1ebf15f
@@ -67,6 +68,7 @@ tasks:
     - --copy-certs=auto
     - --ignore-preflight-errors={{ .vars.defaultIgnorePreflightErrors }}{{ .vars.ignorePreflightErrors }}
     - --loglevel=debug
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -80,6 +82,7 @@ tasks:
     - --ignore-preflight-errors={{ .vars.defaultIgnorePreflightErrors }}{{ .vars.ignorePreflightErrors }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 10m
 - name: cluster-info
   description: |

--- a/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y.yaml
@@ -7,6 +7,7 @@ vars:
   kubeadmVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubeadmVersion }}` \}\}"
   kubeletVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubeletVersion }}` \}\}"
   kubernetesVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubernetesVersion }}` \}\}"
+  kubeadmConfigVersion: "{{ .KubeadmConfigVersion }}"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/tools/update-workflows/templates/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/upgrade-tasks.yaml
@@ -7,6 +7,7 @@ vars:
   # those values might be overridden when importing this files.
   initVersion: v1.12.8
   upgradeVersion: v1.13.5
+  kubeadmConfigVersion: v1beta2
   controlPlaneNodes: 1
   workerNodes: 2
   baseImage: kindest/base:v20190403-1ebf15f
@@ -61,6 +62,7 @@ tasks:
     - --copy-certs=auto
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -73,6 +75,7 @@ tasks:
     - --copy-certs=auto
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 10m
 - name: cluster-info-before
   description: |
@@ -94,6 +97,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 15m
 - name: e2e-kubeadm-after
   description: |

--- a/kinder/ci/tools/update-workflows/templates/workflows/upgrade.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/upgrade.yaml
@@ -6,6 +6,7 @@ summary: |
 vars:
   initVersion: "\{\{ resolve `ci/{{ ciLabelFor .InitVersion }}` \}\}"
   upgradeVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubernetesVersion }}` \}\}"
+  kubeadmConfigVersion: "{{ .KubeadmConfigVersion }}"
   controlPlaneNodes: 3
 tasks:
 - import: upgrade-tasks.yaml

--- a/kinder/ci/workflows/discovery-1.19.yaml
+++ b/kinder/ci/workflows/discovery-1.19.yaml
@@ -7,5 +7,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: discovery-tasks.yaml

--- a/kinder/ci/workflows/discovery-1.20.yaml
+++ b/kinder/ci/workflows/discovery-1.20.yaml
@@ -7,5 +7,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: discovery-tasks.yaml

--- a/kinder/ci/workflows/discovery-1.21.yaml
+++ b/kinder/ci/workflows/discovery-1.21.yaml
@@ -7,5 +7,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.21` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: discovery-tasks.yaml

--- a/kinder/ci/workflows/discovery-latest.yaml
+++ b/kinder/ci/workflows/discovery-latest.yaml
@@ -7,5 +7,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest` }}"
+  kubeadmConfigVersion: "v1beta3"
 tasks:
 - import: discovery-tasks.yaml

--- a/kinder/ci/workflows/discovery-tasks.yaml
+++ b/kinder/ci/workflows/discovery-tasks.yaml
@@ -8,6 +8,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
+  kubeadmConfigVersion: v1beta2
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-discovery
@@ -56,6 +57,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -69,6 +71,7 @@ tasks:
     - --discovery-mode=file
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -82,6 +85,7 @@ tasks:
     - --discovery-mode=file-with-token
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -95,6 +99,7 @@ tasks:
     - --discovery-mode=file-with-embedded-client-certificates
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -108,6 +113,7 @@ tasks:
     - --discovery-mode=file-with-external-client-certificates
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: e2e-kubeadm
   description: |

--- a/kinder/ci/workflows/external-ca-1.19.yaml
+++ b/kinder/ci/workflows/external-ca-1.19.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: external-ca-tasks.yaml

--- a/kinder/ci/workflows/external-ca-1.20.yaml
+++ b/kinder/ci/workflows/external-ca-1.20.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: external-ca-tasks.yaml

--- a/kinder/ci/workflows/external-ca-1.21.yaml
+++ b/kinder/ci/workflows/external-ca-1.21.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.21` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: external-ca-tasks.yaml

--- a/kinder/ci/workflows/external-ca-latest.yaml
+++ b/kinder/ci/workflows/external-ca-latest.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest` }}"
+  kubeadmConfigVersion: "v1beta3"
 tasks:
 - import: external-ca-tasks.yaml

--- a/kinder/ci/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/workflows/external-ca-tasks.yaml
@@ -7,6 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
+  kubeadmConfigVersion: v1beta2
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-external-ca
@@ -68,6 +69,7 @@ tasks:
       - --name={{ .vars.clusterName }}
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+      - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
     timeout: 5m
   - name: join
     description: |
@@ -83,6 +85,7 @@ tasks:
       - --ignore-preflight-errors=FileAvailable--etc-kubernetes-kubelet.conf,FileAvailable--etc-kubernetes-pki-ca.crt,Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+      - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
     timeout: 10m
   - name: e2e-kubeadm
     description: |

--- a/kinder/ci/workflows/external-etcd-1.19.yaml
+++ b/kinder/ci/workflows/external-etcd-1.19.yaml
@@ -7,5 +7,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: external-etcd-tasks.yaml

--- a/kinder/ci/workflows/external-etcd-1.20.yaml
+++ b/kinder/ci/workflows/external-etcd-1.20.yaml
@@ -7,5 +7,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: external-etcd-tasks.yaml

--- a/kinder/ci/workflows/external-etcd-1.21.yaml
+++ b/kinder/ci/workflows/external-etcd-1.21.yaml
@@ -7,5 +7,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.21` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: external-etcd-tasks.yaml

--- a/kinder/ci/workflows/external-etcd-latest.yaml
+++ b/kinder/ci/workflows/external-etcd-latest.yaml
@@ -7,5 +7,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest` }}"
+  kubeadmConfigVersion: "v1beta3"
 tasks:
 - import: external-etcd-tasks.yaml

--- a/kinder/ci/workflows/external-etcd-tasks.yaml
+++ b/kinder/ci/workflows/external-etcd-tasks.yaml
@@ -5,6 +5,7 @@ summary: |
   cluster with an external etcd cluster.
 vars:
   kubernetesVersion: v1.14.1
+  kubeadmConfigVersion: v1beta2
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-external-etcd
@@ -56,6 +57,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -68,6 +70,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 10m
 - name: e2e-kubeadm
   description: |

--- a/kinder/ci/workflows/patches-1.19.yaml
+++ b/kinder/ci/workflows/patches-1.19.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: patches-tasks.yaml

--- a/kinder/ci/workflows/patches-1.20.yaml
+++ b/kinder/ci/workflows/patches-1.20.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: patches-tasks.yaml

--- a/kinder/ci/workflows/patches-1.21.yaml
+++ b/kinder/ci/workflows/patches-1.21.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.21` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: patches-tasks.yaml

--- a/kinder/ci/workflows/patches-latest.yaml
+++ b/kinder/ci/workflows/patches-latest.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest` }}"
+  kubeadmConfigVersion: "v1beta3"
 tasks:
 - import: patches-tasks.yaml

--- a/kinder/ci/workflows/patches-tasks.yaml
+++ b/kinder/ci/workflows/patches-tasks.yaml
@@ -7,6 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
+  kubeadmConfigVersion: v1beta2
   baseImage: kindest/base:v20190403-1ebf15f
   image: kindest/node:test
   clusterName: kinder-patches
@@ -120,6 +121,7 @@ tasks:
       - --patches=/tmp/kubeadm-patches
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+      - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
     timeout: 5m
   - name: join
     description: |
@@ -132,6 +134,7 @@ tasks:
       - --patches=/tmp/kubeadm-patches
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+      - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
     timeout: 10m
   - name: run verify-patches.sh on controlplane nodes before upgrades
     cmd: kinder
@@ -153,6 +156,7 @@ tasks:
       - --name={{ .vars.clusterName }}
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+      - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
     timeout: 15m
   - name: run verify-patches.sh on controlplane nodes after upgrades
     cmd: kinder

--- a/kinder/ci/workflows/regular-1.19.yaml
+++ b/kinder/ci/workflows/regular-1.19.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: regular-tasks.yaml

--- a/kinder/ci/workflows/regular-1.20.yaml
+++ b/kinder/ci/workflows/regular-1.20.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: regular-tasks.yaml

--- a/kinder/ci/workflows/regular-1.21.yaml
+++ b/kinder/ci/workflows/regular-1.21.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest-1.21` }}"
+  kubeadmConfigVersion: "v1beta2"
 tasks:
 - import: regular-tasks.yaml

--- a/kinder/ci/workflows/regular-latest.yaml
+++ b/kinder/ci/workflows/regular-latest.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest` }}"
+  kubeadmConfigVersion: "v1beta3"
 tasks:
 - import: regular-tasks.yaml

--- a/kinder/ci/workflows/regular-tasks.yaml
+++ b/kinder/ci/workflows/regular-tasks.yaml
@@ -8,6 +8,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.13.5
+  kubeadmConfigVersion: v1beta2
   controlPlaneNodes: 3
   workerNodes: 2
   baseImage: kindest/base:v20191105-ee880e9b # has containerd
@@ -58,6 +59,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -69,6 +71,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 10m
 - name: cluster-info
   description: |

--- a/kinder/ci/workflows/skew-1.20-on-1.19.yaml
+++ b/kinder/ci/workflows/skew-1.20-on-1.19.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.20` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.19` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubeadmConfigVersion: "v1beta2"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-1.21-on-1.20.yaml
+++ b/kinder/ci/workflows/skew-1.21-on-1.20.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.21` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.20` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubeadmConfigVersion: "v1beta2"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-kubelet-1.18-on-1.19.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.18-on-1.19.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.19` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.18` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubeadmConfigVersion: "v1beta2"
   ignorePreflightErrors: "KubeletVersion"
   ginkgoSkip: "\\[MinimumKubeletVersion:(1.19)\\]"
   controlPlaneNodes: 3

--- a/kinder/ci/workflows/skew-kubelet-1.18-on-1.20.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.18-on-1.20.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.20` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.18` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubeadmConfigVersion: "v1beta2"
   ignorePreflightErrors: "KubeletVersion"
   ginkgoSkip: "\\[MinimumKubeletVersion:(1.19|1.20)\\]"
   controlPlaneNodes: 3

--- a/kinder/ci/workflows/skew-kubelet-1.19-on-1.20.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.19-on-1.20.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.20` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.19` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubeadmConfigVersion: "v1beta2"
   ignorePreflightErrors: "KubeletVersion"
   ginkgoSkip: "\\[MinimumKubeletVersion:(1.20)\\]"
   controlPlaneNodes: 3

--- a/kinder/ci/workflows/skew-kubelet-1.19-on-1.21.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.19-on-1.21.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.21` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.19` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.21` }}"
+  kubeadmConfigVersion: "v1beta2"
   ignorePreflightErrors: "KubeletVersion"
   ginkgoSkip: "\\[MinimumKubeletVersion:(1.20|1.21)\\]"
   controlPlaneNodes: 3

--- a/kinder/ci/workflows/skew-kubelet-1.20-on-1.21.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.20-on-1.21.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.21` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.20` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.21` }}"
+  kubeadmConfigVersion: "v1beta2"
   ignorePreflightErrors: "KubeletVersion"
   ginkgoSkip: "\\[MinimumKubeletVersion:(1.21)\\]"
   controlPlaneNodes: 3

--- a/kinder/ci/workflows/skew-kubelet-1.20-on-latest.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.20-on-latest.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.20` }}"
   kubernetesVersion: "{{ resolve `ci/latest` }}"
+  kubeadmConfigVersion: "v1beta3"
   ignorePreflightErrors: "KubeletVersion"
   ginkgoSkip: "\\[MinimumKubeletVersion:(1.21|1.22)\\]"
   controlPlaneNodes: 3

--- a/kinder/ci/workflows/skew-kubelet-1.21-on-latest.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.21-on-latest.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.21` }}"
   kubernetesVersion: "{{ resolve `ci/latest` }}"
+  kubeadmConfigVersion: "v1beta3"
   ignorePreflightErrors: "KubeletVersion"
   ginkgoSkip: "\\[MinimumKubeletVersion:(1.22)\\]"
   controlPlaneNodes: 3

--- a/kinder/ci/workflows/skew-latest-on-1.21.yaml
+++ b/kinder/ci/workflows/skew-latest-on-1.21.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.21` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.21` }}"
+  kubeadmConfigVersion: "v1beta2"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -10,6 +10,7 @@ vars:
   kubeadmVersion: v1.13.5
   kubeletVersion: v1.12.8
   kubernetesVersion: v1.12.8
+  kubeadmConfigVersion: v1beta2
   controlPlaneNodes: 1
   workerNodes: 2
   baseImage: kindest/base:v20190403-1ebf15f
@@ -68,6 +69,7 @@ tasks:
     - --copy-certs=auto
     - --ignore-preflight-errors={{ .vars.defaultIgnorePreflightErrors }}{{ .vars.ignorePreflightErrors }}
     - --loglevel=debug
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -81,6 +83,7 @@ tasks:
     - --ignore-preflight-errors={{ .vars.defaultIgnorePreflightErrors }}{{ .vars.ignorePreflightErrors }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 10m
 - name: cluster-info
   description: |

--- a/kinder/ci/workflows/upgrade-1.18-1.19.yaml
+++ b/kinder/ci/workflows/upgrade-1.18-1.19.yaml
@@ -7,6 +7,7 @@ summary: |
 vars:
   initVersion: "{{ resolve `ci/latest-1.18` }}"
   upgradeVersion: "{{ resolve `ci/latest-1.19` }}"
+  kubeadmConfigVersion: "v1beta2"
   controlPlaneNodes: 3
 tasks:
 - import: upgrade-tasks.yaml

--- a/kinder/ci/workflows/upgrade-1.19-1.20.yaml
+++ b/kinder/ci/workflows/upgrade-1.19-1.20.yaml
@@ -7,6 +7,7 @@ summary: |
 vars:
   initVersion: "{{ resolve `ci/latest-1.19` }}"
   upgradeVersion: "{{ resolve `ci/latest-1.20` }}"
+  kubeadmConfigVersion: "v1beta2"
   controlPlaneNodes: 3
 tasks:
 - import: upgrade-tasks.yaml

--- a/kinder/ci/workflows/upgrade-1.20-1.21.yaml
+++ b/kinder/ci/workflows/upgrade-1.20-1.21.yaml
@@ -7,6 +7,7 @@ summary: |
 vars:
   initVersion: "{{ resolve `ci/latest-1.20` }}"
   upgradeVersion: "{{ resolve `ci/latest-1.21` }}"
+  kubeadmConfigVersion: "v1beta2"
   controlPlaneNodes: 3
 tasks:
 - import: upgrade-tasks.yaml

--- a/kinder/ci/workflows/upgrade-1.21-latest.yaml
+++ b/kinder/ci/workflows/upgrade-1.21-latest.yaml
@@ -7,6 +7,7 @@ summary: |
 vars:
   initVersion: "{{ resolve `ci/latest-1.21` }}"
   upgradeVersion: "{{ resolve `ci/latest` }}"
+  kubeadmConfigVersion: "v1beta3"
   controlPlaneNodes: 3
 tasks:
 - import: upgrade-tasks.yaml

--- a/kinder/ci/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-tasks.yaml
@@ -8,6 +8,7 @@ vars:
   # those values might be overridden when importing this files.
   initVersion: v1.12.8
   upgradeVersion: v1.13.5
+  kubeadmConfigVersion: v1beta2
   controlPlaneNodes: 1
   workerNodes: 2
   baseImage: kindest/base:v20190403-1ebf15f
@@ -62,6 +63,7 @@ tasks:
     - --copy-certs=auto
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 5m
 - name: join
   description: |
@@ -74,6 +76,7 @@ tasks:
     - --copy-certs=auto
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 10m
 - name: cluster-info-before
   description: |
@@ -95,6 +98,7 @@ tasks:
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    - --kubeadm-config-version={{ .vars.kubeadmConfigVersion }}
   timeout: 15m
 - name: e2e-kubeadm-after
   description: |

--- a/kinder/hack/update-workflows.sh
+++ b/kinder/hack/update-workflows.sh
@@ -33,7 +33,7 @@ PATH_WORKFLOWS="${PATH_WORKFLOWS:-./ci/workflows/}"
 
 # set test-infra path
 TEST_INFRA_SIG_DIR="config/jobs/kubernetes/sig-cluster-lifecycle"
-PATH_TEST_INFRA="${PATH_TEST_INFRA:-"$HOME/go/src/k8s.io/test-infra/$TEST_INFRA_SIG_DIR"}"
+PATH_TEST_INFRA="${PATH_TEST_INFRA:-"$GOPATH/src/k8s.io/test-infra/$TEST_INFRA_SIG_DIR"}"
 
 # try to get the image from the provided test-infra path
 if [[ -z "${TEST_INFRA_IMAGE}" ]]; then

--- a/kinder/pkg/cluster/manager/actions/kubeadm-config.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-config.go
@@ -185,7 +185,10 @@ func getKubeadmConfig(c *status.Cluster, n *status.Node, data kubeadm.ConfigData
 
 	kubeadmConfigVersion := options.configVersion
 	if len(kubeadmConfigVersion) == 0 {
-		kubeadmConfigVersion = kubeadm.GetKubeadmConfigVersion(kubeadmVersion)
+		kubeadmConfigVersion, err = kubeadm.GetKubeadmConfigVersion(kubeadmVersion)
+		if err != nil {
+			return "", err
+		}
 	}
 	log.Debugf("using kubeadm config version %s", kubeadmConfigVersion)
 

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -120,6 +120,16 @@ const (
 var (
 	// V1.19 minor version
 	V1_19 = K8sVersion.MustParseSemantic("v1.19.0-0")
+
+	// SupportedKubeadmConfigVersion lists officially supported kubeadm config versions with corresponding Kubernetes releases
+	SupportedKubeadmConfigVersion = map[uint8]string{
+		18: "v1beta2",
+		19: "v1beta2",
+		20: "v1beta2",
+		21: "v1beta2",
+		22: "v1beta3",
+		23: "v1beta3",
+	}
 )
 
 // other constants

--- a/kinder/pkg/kubeadm/config.go
+++ b/kinder/pkg/kubeadm/config.go
@@ -23,8 +23,9 @@ import (
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-
 	K8sVersion "k8s.io/apimachinery/pkg/util/version"
+
+	"k8s.io/kubeadm/kinder/pkg/constants"
 )
 
 // Config returns a kubeadm config generated using the config API version
@@ -61,14 +62,12 @@ func Config(kubeadmConfigVersion string, data ConfigData) (config string, err er
 }
 
 // GetKubeadmConfigVersion returns the kubeadm config version corresponding to a Kubernetes kubeadmVersion
-func GetKubeadmConfigVersion(kubeadmVersion *K8sVersion.Version) string {
-	// v1alpha1 (that is Kubernetes v1.10.0) is out of support
-	// v1alpha2 (that is Kubernetes v1.11.0) is out of support
-	// v1alpha3 (that is Kubernetes v1.13.0) is out of support
-	if kubeadmVersion.Major() > 1 || kubeadmVersion.Minor() >= 22 {
-		return "v1beta3"
+func GetKubeadmConfigVersion(kubeadmVersion *K8sVersion.Version) (string, error) {
+	ver, ok := constants.SupportedKubeadmConfigVersion[uint8(kubeadmVersion.Minor())]
+	if !ok {
+		return ver, errors.Errorf("cannot determine Kubeadm config version for Kubeadm version %s", kubeadmVersion)
 	}
-	return "v1beta2"
+	return ver, nil
 }
 
 // ConfigData is supplied to the kubeadm config template, with values populated


### PR DESCRIPTION
If we are testing the old version of `Kubernetes` with the latest `Kubeadm`, we should use the old compatible Kubeadm config. Otherwise, we may run into problems. 

FYI: https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-latest-on-1-21

Ref: #2428