### PR TITLE
Use /bin/bash instead of /bin/sh for verify-rootless task.

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/rootless-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/rootless-tasks.yaml
@@ -47,12 +47,12 @@ tasks:
   - --loglevel=debug
   timeout: 5m
 - name: prepare verify-rootless.sh script
-  cmd: /bin/sh
+  cmd: /bin/bash
   args:
   - -c
   - |
     cat <<EOF >/tmp/verify-rootless.sh
-    #!/usr/bin/env bash
+    #!/bin/bash
     res=0
     users=("kubeadm-kas" "kubeadm-ks" "kubeadm-kcm" "kubeadm-etcd")
     for d in ${users[@]}; do

--- a/kinder/ci/workflows/rootless-tasks.yaml
+++ b/kinder/ci/workflows/rootless-tasks.yaml
@@ -48,12 +48,12 @@ tasks:
   - --loglevel=debug
   timeout: 5m
 - name: prepare verify-rootless.sh script
-  cmd: /bin/sh
+  cmd: /bin/bash
   args:
   - -c
   - |
     cat <<EOF >/tmp/verify-rootless.sh
-    #!/usr/bin/env bash
+    #!/bin/bash
     res=0
     users=("kubeadm-kas" "kubeadm-ks" "kubeadm-kcm" "kubeadm-etcd")
     for d in ${users[@]}; do


### PR DESCRIPTION
tertgrid fails with the following error:

```
/bin/sh: 1: Bad substitution
chmod: cannot access '/tmp/verify-rootless.sh': No such file or directory
 exit status 1
```

https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-rootless-latest 