### PR TITLE
kinder: use the "auto" mode for the "rootless" workflow

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/rootless-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/rootless-tasks.yaml
@@ -178,6 +178,7 @@ tasks:
   - --loglevel=debug
   - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   - --kubeadm-feature-gate="RootlessControlPlane=true"
+  - --copy-certs=auto
   timeout: 5m
 - name: join
   description: |
@@ -189,6 +190,7 @@ tasks:
   - --name={{ .vars.clusterName }}
   - --loglevel=debug
   - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+  - --copy-certs=auto
   timeout: 10m
 - name: run verify-rootless.sh on controlplane nodes before upgrades
   cmd: kinder

--- a/kinder/ci/workflows/rootless-tasks.yaml
+++ b/kinder/ci/workflows/rootless-tasks.yaml
@@ -179,6 +179,7 @@ tasks:
   - --loglevel=debug
   - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   - --kubeadm-feature-gate="RootlessControlPlane=true"
+  - --copy-certs=auto
   timeout: 5m
 - name: join
   description: |
@@ -190,6 +191,7 @@ tasks:
   - --name={{ .vars.clusterName }}
   - --loglevel=debug
   - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+  - --copy-certs=auto
   timeout: 10m
 - name: run verify-rootless.sh on controlplane nodes before upgrades
   cmd: kinder


### PR DESCRIPTION
The "rootless" e2e test requires strict permissions
for some files like ca.crt. Apparently our existing
"manual" copy-certs method stomps permissions and
ownership ("docker cp" artifact?)

Use the "auto" mode which uses the native logic in kubeadm
that uses a Secret as the transport medium of certs/keys
between control plane nodes. It also stomps permissions, but
has some logic to write private keys with 600 and public
keys/certs with 644, which is sufficient for the "rootless" use case.
