### PR TITLE
kinder: include upgrade artifacts in rootless workflow

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/rootless-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/rootless-tasks.yaml
@@ -7,6 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.13.5
+  upgradeVersion: v1.13.5
   controlPlaneNodes: 3
   workerNodes: 2
   baseImage: kindest/base:v20191105-ee880e9b # has containerd
@@ -31,6 +32,7 @@ tasks:
   - --base-image={{ .vars.baseImage }}
   - --image={{ .vars.image }}
   - --with-init-artifacts={{ .vars.kubernetesVersion }}
+  - --with-upgrade-artifacts={{ .vars.upgradeVersion }}
   - --loglevel=debug
   timeout: 15m
 - name: create-cluster

--- a/kinder/ci/tools/update-workflows/templates/workflows/rootless.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/rootless.yaml
@@ -6,5 +6,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/{{ .TargetFile }}
 vars:
   kubernetesVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubernetesVersion }}` \}\}"
+  upgradeVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubernetesVersion }}` \}\}"
 tasks:
 - import: rootless-tasks.yaml

--- a/kinder/ci/workflows/rootless-latest.yaml
+++ b/kinder/ci/workflows/rootless-latest.yaml
@@ -7,5 +7,6 @@ summary: |
   config    > https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
 vars:
   kubernetesVersion: "{{ resolve `ci/latest` }}"
+  upgradeVersion: "{{ resolve `ci/latest` }}"
 tasks:
 - import: rootless-tasks.yaml

--- a/kinder/ci/workflows/rootless-tasks.yaml
+++ b/kinder/ci/workflows/rootless-tasks.yaml
@@ -8,6 +8,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.13.5
+  upgradeVersion: v1.13.5
   controlPlaneNodes: 3
   workerNodes: 2
   baseImage: kindest/base:v20191105-ee880e9b # has containerd
@@ -32,6 +33,7 @@ tasks:
   - --base-image={{ .vars.baseImage }}
   - --image={{ .vars.image }}
   - --with-init-artifacts={{ .vars.kubernetesVersion }}
+  - --with-upgrade-artifacts={{ .vars.upgradeVersion }}
   - --loglevel=debug
   timeout: 15m
 - name: create-cluster


### PR DESCRIPTION
Despite this workflow upgrades from version Foo to version Foo,
kinder uses a mechanism where it searches for artifacts under
"/kinder/upgrade/" on the node image.

This can be improved in the future, but for the time being simply
pass --with-upgrade-artifacts to populate the said folder.