### PR TITLE
update references to legacy artifacts locations

### DIFF
--- a/kinder/README.md
+++ b/kinder/README.md
@@ -84,7 +84,7 @@ e.g. if you want to test a kubeadm version already built locally:
 kinder build node-variant \
     --base-image kindest/node:v1.13.4 \
     --image kindest/node:PR1234 \
-    --with-kubeadm $working_dir/kubernetes/bazel-bin/cmd/kubeadm/linux_amd64_pure_stripped/kubeadm
+    --with-kubeadm $working_dir/kubernetes/_output/local/bin/linux/amd64/kubeadm
 ```
 
 see [Prepare for tests](doc/prepare-for-tests.md) for more details.

--- a/kinder/doc/reference.md
+++ b/kinder/doc/reference.md
@@ -52,7 +52,7 @@ docker exec kind-worker1 \
 # override the kubeadm binary on the on the kind-control-plane container
 # with a locally built kubeadm binary
 docker cp \
-      $working_dir/kubernetes/bazel-bin/cmd/kubeadm/linux_amd64_pure_stripped/kubeadm \
+      $working_dir/kubernetes/_output/local/bin/linux/amd64/kubeadm \
       kind-control-plane:/usr/bin/kubeadm
 ```
 
@@ -138,7 +138,7 @@ kinder cp kubeadm.conf @cp1:kind/kubeadm.conf
 
 # override the kubeadm binary on all the nodes with a locally built kubeadm binary
 kinder cp \
-      $working_dir/kubernetes/bazel-bin/cmd/kubeadm/linux_amd64_pure_stripped/kubeadm \
+      $working_dir/kubernetes/_output/local/bin/linux/amd64/kubeadm \
       @all:/usr/bin/kubeadm
 ```
 
@@ -221,7 +221,7 @@ kinder build node-image-variant \
 kinder build node-image-variant \
      --base-image kindest/node:latest \
      --image kindest/node:PR12345 \
-     --with-kubeadm $working_dir/kubernetes/bazel-bin/cmd/kubeadm/linux_amd64_pure_stripped/kubeadm
+     --with-kubeadm $working_dir/kubernetes/_output/local/bin/linux/amd64/kubeadm
 ```
 
 When reading from a local folder, both single file or folder can be used; in case a folder is used, the

--- a/kinder/pkg/build/bits/initBits.go
+++ b/kinder/pkg/build/bits/initBits.go
@@ -168,8 +168,7 @@ func installInitBinaries(c *BuildContext) error {
 	// container as /alter
 	src := filepath.Join(c.ContainerBitsPath(), "init")
 
-	// The destination path for the Kubernetes binaries is /kind/bin, a well known folder where kind adds Kubernetes binaries when
-	// building node-image using --type bazel or --type docker
+	// The destination path for the Kubernetes binaries is /kind/bin, a well known folder where kind adds Kubernetes binaries.
 	dst := filepath.Join("/kind", "bin")
 
 	// create dest folder

--- a/kinder/pkg/test/e2e/binary.go
+++ b/kinder/pkg/test/e2e/binary.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -99,33 +98,10 @@ func findBinary(kubeRoot string, name string) (string, error) {
 	locations := []string{
 		filepath.Join(kubeRoot, "_output", "bin", name),
 		filepath.Join(kubeRoot, "_output", "dockerized", "bin", name),
+		filepath.Join(kubeRoot, "_output", "dockerized", "go", "bin", name),
 		filepath.Join(kubeRoot, "_output", "local", "bin", name),
+		filepath.Join(kubeRoot, "_output", "local", "bin", "go", name),
 		filepath.Join(kubeRoot, "platforms", runtime.GOOS, runtime.GOARCH, name),
-	}
-
-	bazelBin := filepath.Join(kubeRoot, "bazel-bin")
-	bazelBinExists := true
-	if _, err := os.Stat(bazelBin); os.IsNotExist(err) {
-		bazelBinExists = false
-	}
-
-	if bazelBinExists {
-		err := filepath.Walk(bazelBin, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return errors.Wrapf(err, "error walking %s tree", bazelBin)
-			}
-			if info.Name() != name {
-				return nil
-			}
-			if !strings.Contains(path, runtime.GOOS+"_"+runtime.GOARCH) {
-				return nil
-			}
-			locations = append(locations, path)
-			return nil
-		})
-		if err != nil {
-			return "", err
-		}
 	}
 
 	newestLocation := ""


### PR DESCRIPTION
Update references to legacy artifacts locations (`/bazel`, `/ci-cross`, etc).

Fixes: #2529

/hold

I cannot find the `.deb` packages in the `gs://k8s-release-dev/ci/<version>bin/linux/amd64` bucket.
So I worry about `/tests/e2e/packages/verify_packages_install_deb.sh` still doesn't work. 
Did I miss something? @neolit123 