### PR TITLE
docs: use k8s-staging-ci-images

### DIFF
--- a/docs/testing-pre-releases.md
+++ b/docs/testing-pre-releases.md
@@ -62,7 +62,7 @@ The table below summarize the current state:
 | ----------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | **GA release**          | from .deb or .rpm repository                                 | from [github release page](https://github.com/kubernetes/kubernetes/releases) or from `gs://kubernetes-release/release/` GCS bucket | from `k8s.gcr.io` container registry or from [github release page](https://github.com/kubernetes/kubernetes/releases)           |
 | **alpha/beta release*** | not available.                   | from [github release page](https://github.com/kubernetes/kubernetes/releases) or from `gs://kubernetes-release/release/` GCS bucket | from `k8s.gcr.io` container registry or from [github release page](https://github.com/kubernetes/kubernetes/releases)        |
-| **CI/CD release***      | not available.                   | from `gs://k8s-release-dev/ci/` GCS bucket (built every merge) | from `gcr.io/kubernetes-ci-images` container registry (built every few hours, not by PR) |
+| **CI/CD release***      | not available.                   | from `gs://k8s-release-dev/ci/` GCS bucket (built every merge) | from `gcr.io/k8s-staging-ci-images` container registry (built every few hours, not by PR) |
 
 [*] for alpha/beta and CI/CD currently it is not possible to have exact version number consistency for all the
 components; however you can select version numbers "near to" the desired version.


### PR DESCRIPTION
Related:
- This is part of: https://github.com/kubernetes/k8s.io/issues/2318
- Similar PR: https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/pull/300
- The change this is documenting, which landed 2021-01-14: https://github.com/kubernetes/kubernetes/pull/97087

Document that CI images are pulled from gcr.io/k8s-staging-ci-images, not gcr.io/kubernetes-ci-images