### PR TITLE
Kubeadm patches: use config for newer versions; --experimental-patches for older

### DIFF
--- a/kinder/pkg/cluster/manager/actions/kubeadm-config.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-config.go
@@ -276,6 +276,13 @@ func getKubeadmConfig(c *status.Cluster, n *status.Node, data kubeadm.ConfigData
 		}
 		patches = append(patches, fileDiscoveryPatch)
 
+		// add patches directory to the config
+		patchesDirectoryPatch, err := kubeadm.GetPatchesDirectoryPatch(kubeadmConfigVersion)
+		if err != nil {
+			return "", err
+		}
+		patches = append(patches, patchesDirectoryPatch)
+
 		// if the file discovery does not contains the authorization credentials, add tls discovery token
 		if options.discoveryMode == FileDiscoveryWithoutCredentials {
 			tlsBootstrapPatch, err := kubeadm.GetTLSBootstrapPatch(kubeadmConfigVersion)

--- a/kinder/pkg/cluster/manager/actions/kubeadm-init.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-init.go
@@ -42,9 +42,6 @@ func KubeadmInit(c *status.Cluster, usePhases bool, copyCertsMode CopyCertsMode,
 
 	// if patcheDir is defined, copy the patches to the node
 	if patchesDir != "" {
-		if cp1.MustKubeadmVersion().LessThan(constants.V1_19) {
-			return errors.New("--patches can't be used with kubeadm older than v1.19")
-		}
 		if err := copyPatchesToNode(cp1, patchesDir); err != nil {
 			return err
 		}
@@ -102,7 +99,9 @@ func kubeadmInit(cp1 *status.Node, copyCertsMode CopyCertsMode, patchesDir, igno
 		)
 	}
 	if patchesDir != "" {
-		initArgs = append(initArgs, "--experimental-patches", constants.PatchesDir)
+		if cp1.MustKubeadmVersion().LessThan(constants.V1_22) {
+			initArgs = append(initArgs, "--experimental-patches", constants.PatchesDir)
+		}
 	}
 
 	if err := cp1.Command(
@@ -144,7 +143,9 @@ func kubeadmInitWithPhases(cp1 *status.Node, copyCertsMode CopyCertsMode, patche
 		"init", "phase", "control-plane", "all", fmt.Sprintf("--config=%s", constants.KubeadmConfigPath), fmt.Sprintf("--v=%d", vLevel),
 	}
 	if patchesDir != "" {
-		controlplaneArgs = append(controlplaneArgs, "--experimental-patches", constants.PatchesDir)
+		if cp1.MustKubeadmVersion().LessThan(constants.V1_22) {
+			controlplaneArgs = append(controlplaneArgs, "--experimental-patches", constants.PatchesDir)
+		}
 	}
 	if err := cp1.Command(
 		"kubeadm", controlplaneArgs...,
@@ -156,7 +157,9 @@ func kubeadmInitWithPhases(cp1 *status.Node, copyCertsMode CopyCertsMode, patche
 		"init", "phase", "etcd", "local", fmt.Sprintf("--config=%s", constants.KubeadmConfigPath), fmt.Sprintf("--v=%d", vLevel),
 	}
 	if patchesDir != "" {
-		etcdArgs = append(etcdArgs, "--experimental-patches", constants.PatchesDir)
+		if cp1.MustKubeadmVersion().LessThan(constants.V1_22) {
+			etcdArgs = append(etcdArgs, "--experimental-patches", constants.PatchesDir)
+		}
 	}
 	if err := cp1.Command(
 		"kubeadm", etcdArgs...,

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -118,8 +118,8 @@ const (
 
 // kubernetes releases, used for branching code according to K8s release or kubeadm release version
 var (
-	// V1.19 minor version
-	V1_19 = K8sVersion.MustParseSemantic("v1.19.0-0")
+	// V1.22 minor version
+	V1_22 = K8sVersion.MustParseSemantic("v1.22.0-0")
 )
 
 // other constants

--- a/kinder/pkg/kubeadm/discovery.go
+++ b/kinder/pkg/kubeadm/discovery.go
@@ -93,6 +93,30 @@ discovery:
   file:
     kubeConfigPath: %s`
 
+// GetPatchesDirectoryPatch returns the kubeadm config patch that will instruct kubeadm
+// to use patches directory.
+func GetPatchesDirectoryPatch(kubeadmConfigVersion string) (string, error) {
+	// select the patches for the kubeadm config version
+	log.Debugf("Preparing patches directory for kubeadm config %s", kubeadmConfigVersion)
+
+	var patch string
+	switch kubeadmConfigVersion {
+	case "v1beta3":
+		patch = patchesDirectoryPatchv1beta3
+	default:
+		return "", errors.Errorf("unknown kubeadm config version: %s", kubeadmConfigVersion)
+	}
+
+	return fmt.Sprintf(patch, constants.PatchesDir), nil
+}
+
+const patchesDirectoryPatchv1beta3 = `apiVersion: kubeadm.k8s.io/v1beta3
+kind: JoinConfiguration
+metadata:
+  name: config
+patches:
+  directory: %s`
+
 // GetTLSBootstrapPatch returns the kubeadm config patch that will instruct kubeadm
 // to use a TLSBootstrap token.
 // NB. for sake of semplicity, we are using the same Token already used for Token discovery


### PR DESCRIPTION
https://github.com/kubernetes/kubeadm/tree/master/kinder/pkg/cluster/manager/actions

use --config for "init|join" and --patches for "upgrade"
for https://github.com/kubernetes/kubeadm/issues/2046 and https://github.com/kubernetes/kubernetes/pull/104065