### PR TITLE
add patches for join/init/upgrade to the right place

### DIFF
--- a/kinder/pkg/cluster/manager/actions/kubeadm-config.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-config.go
@@ -253,6 +253,13 @@ func getKubeadmConfig(c *status.Cluster, n *status.Node, data kubeadm.ConfigData
 		patches = append(patches, automaticCopyCertsPatches...)
 	}
 
+	// add patches directory to the config
+	patchesDirectoryPatches, err := kubeadm.GetPatchesDirectoryPatches(kubeadmConfigVersion)
+	// skip if kubeadm config version is not v1beta3
+	if err == nil {
+		patches = append(patches, patchesDirectoryPatches...)
+	}
+
 	// if requested to use file discovery and not the first control-plane, add patches for using file discovery
 	if options.discoveryMode != TokenDiscovery && !(n == c.BootstrapControlPlane()) {
 		// remove token from config
@@ -275,13 +282,6 @@ func getKubeadmConfig(c *status.Cluster, n *status.Node, data kubeadm.ConfigData
 			return "", err
 		}
 		patches = append(patches, fileDiscoveryPatch)
-
-		// add patches directory to the config
-		patchesDirectoryPatch, err := kubeadm.GetPatchesDirectoryPatch(kubeadmConfigVersion)
-		if err != nil {
-			return "", err
-		}
-		patches = append(patches, patchesDirectoryPatch)
 
 		// if the file discovery does not contains the authorization credentials, add tls discovery token
 		if options.discoveryMode == FileDiscoveryWithoutCredentials {

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -113,7 +113,7 @@ const (
 	DiscoveryFile = "/kinder/discovery.conf"
 
 	// PatchesDir defines the path to patches stored on node
-	PatchesDir = "/kinder/patches"
+	PatchesDir = "/tmp/kubeadm-patches"
 )
 
 // kubernetes releases, used for branching code according to K8s release or kubeadm release version

--- a/kinder/pkg/kubeadm/componentpatches.go
+++ b/kinder/pkg/kubeadm/componentpatches.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/kubeadm/kinder/pkg/constants"
+)
+
+// GetPatchesDirectoryPatches returns the kubeadm config patches that will instruct kubeadm
+// to use patches directory.
+func GetPatchesDirectoryPatches(kubeadmConfigVersion string) ([]string, error) {
+	// select the patches for the kubeadm config version
+	log.Debugf("Preparing patches directory for kubeadm config %s", kubeadmConfigVersion)
+	if _, err := os.Stat(constants.PatchesDir); os.IsNotExist(err) {
+		return []string{}, nil
+	}
+
+	var patchInit, patchJoin string
+	switch kubeadmConfigVersion {
+	case "v1beta3":
+		patchInit = patchesDirectoryPatchInitv1beta3
+		patchJoin = patchesDirectoryPatchJoinv1beta3
+	default:
+		return []string{}, errors.Errorf("unknown kubeadm config version: %s", kubeadmConfigVersion)
+	}
+	return []string{
+		fmt.Sprintf(patchInit, constants.PatchesDir),
+		fmt.Sprintf(patchJoin, constants.PatchesDir),
+	}, nil
+}
+
+const patchesDirectoryPatchInitv1beta3 = `apiVersion: kubeadm.k8s.io/v1beta3
+kind: InitConfiguration
+metadata:
+  name: config
+patches:
+  directory: %s`
+
+const patchesDirectoryPatchJoinv1beta3 = `apiVersion: kubeadm.k8s.io/v1beta3
+kind: JoinConfiguration
+metadata:
+  name: config
+patches:
+  directory: %s`

--- a/kinder/pkg/kubeadm/discovery.go
+++ b/kinder/pkg/kubeadm/discovery.go
@@ -93,30 +93,6 @@ discovery:
   file:
     kubeConfigPath: %s`
 
-// GetPatchesDirectoryPatch returns the kubeadm config patch that will instruct kubeadm
-// to use patches directory.
-func GetPatchesDirectoryPatch(kubeadmConfigVersion string) (string, error) {
-	// select the patches for the kubeadm config version
-	log.Debugf("Preparing patches directory for kubeadm config %s", kubeadmConfigVersion)
-
-	var patch string
-	switch kubeadmConfigVersion {
-	case "v1beta3":
-		patch = patchesDirectoryPatchv1beta3
-	default:
-		return "", errors.Errorf("unknown kubeadm config version: %s", kubeadmConfigVersion)
-	}
-
-	return fmt.Sprintf(patch, constants.PatchesDir), nil
-}
-
-const patchesDirectoryPatchv1beta3 = `apiVersion: kubeadm.k8s.io/v1beta3
-kind: JoinConfiguration
-metadata:
-  name: config
-patches:
-  directory: %s`
-
 // GetTLSBootstrapPatch returns the kubeadm config patch that will instruct kubeadm
 // to use a TLSBootstrap token.
 // NB. for sake of semplicity, we are using the same Token already used for Token discovery


### PR DESCRIPTION
The patches adding is inside if-else. 
```
	if options.discoveryMode != TokenDiscovery && !(n == c.BootstrapControlPlane()) {
```

Move it out to fix the ci-kubernetes-e2e-kubeadm-kinder-patches-latest failure

Failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-patches-latest/1425293204315443200

See https://github.com/kubernetes/kubeadm/issues/2046#issuecomment-897035731