### PR TITLE
kinder: fix failing patches e2e tests

### DIFF
--- a/kinder/pkg/cluster/manager/actions/kubeadm-join.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-join.go
@@ -41,11 +41,8 @@ func joinControlPlanes(c *status.Cluster, usePhases bool, copyCertsMode CopyCert
 	cpX := []*status.Node{c.BootstrapControlPlane()}
 
 	for _, cp2 := range c.SecondaryControlPlanes().EligibleForActions() {
-		// if patcheDir is defined, copy the patches to the node
-		if patchesDir != "" {
-			if err := copyPatchesToNode(cp2, patchesDir); err != nil {
-				return err
-			}
+		if err := copyPatchesToNode(cp2, patchesDir); err != nil {
+			return err
 		}
 
 		// if not automatic copy certs, simulate manual copy

--- a/kinder/pkg/cluster/manager/actions/kubeadm-upgrade.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-upgrade.go
@@ -44,11 +44,8 @@ func KubeadmUpgrade(c *status.Cluster, upgradeVersion *K8sVersion.Version, patch
 	nodeList := c.K8sNodes().EligibleForActions()
 
 	for _, n := range nodeList {
-		// if patcheDir is defined, copy the patches to the node
-		if patchesDir != "" {
-			if err := copyPatchesToNode(n, patchesDir); err != nil {
-				return err
-			}
+		if err := copyPatchesToNode(n, patchesDir); err != nil {
+			return err
 		}
 
 		if err := upgradeKubeadmBinary(n, upgradeVersion); err != nil {

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -113,7 +113,7 @@ const (
 	DiscoveryFile = "/kinder/discovery.conf"
 
 	// PatchesDir defines the path to patches stored on node
-	PatchesDir = "/tmp/kubeadm-patches"
+	PatchesDir = "/kinder/patches"
 )
 
 // kubernetes releases, used for branching code according to K8s release or kubeadm release version

--- a/kinder/pkg/kubeadm/componentpatches.go
+++ b/kinder/pkg/kubeadm/componentpatches.go
@@ -18,7 +18,6 @@ package kubeadm
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -28,12 +27,7 @@ import (
 // GetPatchesDirectoryPatches returns the kubeadm config patches that will instruct kubeadm
 // to use patches directory.
 func GetPatchesDirectoryPatches(kubeadmConfigVersion string) ([]string, error) {
-	// select the patches for the kubeadm config version
 	log.Debugf("Preparing patches directory for kubeadm config %s", kubeadmConfigVersion)
-	if _, err := os.Stat(constants.PatchesDir); os.IsNotExist(err) {
-		return []string{}, nil
-	}
-
 	var patchInit, patchJoin string
 	switch kubeadmConfigVersion {
 	case "v1beta3":


### PR DESCRIPTION
    - Looks like /tmp is not a good location to copy files to.
    Either they silently fail to copy to /tmp or they throw an
    error that a /tmp/sub-dir like "kinder-patches" is not a directory
    (but it is). Searching for the related errors online:
      - Error response from daemon: extraction point is not a directory
      - Error: No such container:path: kinder-patches-control-plane-1:/tmp/kubeadm-patches
    does not provide much context on why this is happening.
    Use "/kinder/patches" instead of "/tmp...".
    
    - Include missing error return in copyPatchesToNode()
    
    - Remove host OS check about the patch directory. We don't need this check
    because an earlier step should copy the patches from host to container.
    If the patch directory in the container is different from the patch
    directory on the host it would fail.
    
    - Given patches.directory is always part of the kubeadm config,
    always create the patch directory with copyPatchesToNode(). Skip
    copying patches if the source directory is not defined.

fixes: https://github.com/kubernetes/kubeadm/issues/2547