### PR TITLE
README/ISSUE_TEMPLATE: fix wrong link to k8s support

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@
 
 Before hitting the submit button, please note that requests for support must be sent
 to the support channels or #kubeadm on k8s Slack and not this issue tracker:
-https://git.k8s.io/SUPPORT.md
+https://git.k8s.io/kubernetes/SUPPORT.md
 
 If you are experiencing a problem make sure you check the Kubernetes and kubeadm
 troubleshooting guides:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Kubernetes and kubeadm troubleshooting guides can be found here:
 - [kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm/)
 
 Support requests should be sent to the community support channels or `#kubeadm` on the k8s Slack:
-- https://git.k8s.io/SUPPORT.md
+- https://git.k8s.io/kubernetes/SUPPORT.md
 
 ## Documentation
 


### PR DESCRIPTION
fixing a broken link from https://github.com/kubernetes/kubeadm/pull/2544

The correct link for k8s support is:
https://git.k8s.io/kubernetes/SUPPORT.md
