### PR TITLE
github/workflows/support-command: don't error on comments with no command

### DIFF
--- a/.github/workflows/support-command.yaml
+++ b/.github/workflows/support-command.yaml
@@ -2,11 +2,12 @@ on: issue_comment
 name: handle the /support command
 jobs:
   support_comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: check for the /support command
         id: command
         uses: xt0rted/slash-command-action@v1
+        continue-on-error: true
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           command: support
@@ -14,6 +15,7 @@ jobs:
           allow-edits: "true"
           permission-level: admin
       - name: comment with support text
+        if: steps.command.outputs.command-name
         uses: ben-z/actions-comment-on-issue@1.0.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -27,8 +29,10 @@ jobs:
             Please see:
             - https://github.com/kubernetes/kubeadm#support
       - name: add support label
+        if: steps.command.outputs.command-name
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: kind/support
       - name: close issue
+        if: steps.command.outputs.command-name
         uses: peter-evans/close-issue@v1


### PR DESCRIPTION
If the commenting GitHub users pass a comment without the "/support"
command the GitHub action will throw an error:
"Error: Comment didn't contain a valid slash command"

This seems like a missing feature in the xt0rted/slash-command-action
extension. Include a workaround that skips the comment/close/label
steps if the command is not present.

Also pin to ubuntu-20.04 instead of latest.

if github actions support regexp conditions, the xt0rted/slash-command-action extension would not have been needed
and one could use something like `if: regexpmatch(somestr, exp`).

https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions