### PR TITLE
kinder/update-workflows: use gcr.io/k8s-staging-test-infra/kubekins-e2e

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-addons.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-addons.yaml
@@ -25,7 +25,7 @@
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-discovery.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-discovery.yaml
@@ -24,7 +24,7 @@
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-ca.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-ca.yaml
@@ -24,7 +24,7 @@
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-etcd.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-etcd.yaml
@@ -24,7 +24,7 @@
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -24,7 +24,7 @@
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-patches.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-patches.yaml
@@ -24,7 +24,7 @@
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-rootless.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-rootless.yaml
@@ -24,7 +24,7 @@
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-upgrade.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-upgrade.yaml
@@ -24,7 +24,7 @@
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-x-on-y.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-x-on-y.yaml
@@ -24,7 +24,7 @@
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder.yaml
@@ -24,7 +24,7 @@
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:{{ .TestInfraImage }}-{{ imageVer .KubernetesVersion }}
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"


### PR DESCRIPTION
The location of kubekins has changed to the k8s-staging-test-infra
bucket.

See:
https://github.com/kubernetes/test-infra/commit/db192d2e765aac9ecaacdb427cd