### PR TITLE
kinder: ignore KubeletVersion preflight error for x-on-y workflows

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y.yaml
@@ -7,6 +7,7 @@ vars:
   kubeadmVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubeadmVersion }}` \}\}"
   kubeletVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubeletVersion }}` \}\}"
   kubernetesVersion: "\{\{ resolve `ci/{{ ciLabelFor .KubernetesVersion }}` \}\}"
+  ignorePreflightErrors: "KubeletVersion"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-1.21-on-1.20.yaml
+++ b/kinder/ci/workflows/skew-1.21-on-1.20.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.21` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.20` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.20` }}"
+  ignorePreflightErrors: "KubeletVersion"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-1.22-on-1.21.yaml
+++ b/kinder/ci/workflows/skew-1.22-on-1.21.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.22` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.21` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.21` }}"
+  ignorePreflightErrors: "KubeletVersion"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-1.23-on-1.22.yaml
+++ b/kinder/ci/workflows/skew-1.23-on-1.22.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest-1.23` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.22` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.22` }}"
+  ignorePreflightErrors: "KubeletVersion"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml

--- a/kinder/ci/workflows/skew-latest-on-1.23.yaml
+++ b/kinder/ci/workflows/skew-latest-on-1.23.yaml
@@ -8,6 +8,7 @@ vars:
   kubeadmVersion: "{{ resolve `ci/latest` }}"
   kubeletVersion: "{{ resolve `ci/latest-1.23` }}"
   kubernetesVersion: "{{ resolve `ci/latest-1.23` }}"
+  ignorePreflightErrors: "KubeletVersion"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml


### PR DESCRIPTION
Once the k/k branch for a new release X is cut, the k/k master branch
starts pointing out at k8s version X+1.

Until we update our workflows (normally we try to
do it on the same date as the new branch cut) we will have failing
"latest" e2e tests because they will try to use kubeadm from master (X+1)
but the tracked version in the workflow will be still at X-1 (because
we don't know about the latest X release branch yet). Example - kubeadm
is at 1.24.0-pre but control plane and kubelet are at 1.22 still.
This n-2 is not a supported skew and kubeadm init/join will fial.

We have a workaround for control plane versions built in kubeadm
when 1.24.0 is a prerelease, but we don't have a solution for the
kubelet version preflight check error that will happen.

To avoid this temporary problem we can ignore the preflight error.
This seems fine for e2e tests and if the kubelet version is somewhat
malformed for other reason, kubeadm will error anyway when parsing it
or even when downloading the artifact.

The problem here is only for the "latest" workflow, but to avoid
complexity around workflow management / templates just ignore
the preflight error for all skew workflows. Note that this preflight
check is already ignored for the other kubelet skew workflows.

xref https://github.com/kubernetes/kubernetes/issues/106669
