### PR TITLE
kinder: switch all workflows to containerd

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/discovery-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/discovery-tasks.yaml
@@ -7,7 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-discovery
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-ca-tasks.yaml
@@ -6,7 +6,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-external-ca
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/external-etcd-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-etcd-tasks.yaml
@@ -4,7 +4,7 @@ summary: |
   cluster with an external etcd cluster.
 vars:
   kubernetesVersion: v1.14.1
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-external-etcd
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/patches-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/patches-tasks.yaml
@@ -6,7 +6,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-patches
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/presubmit-upgrade-latest.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/presubmit-upgrade-latest.yaml
@@ -8,7 +8,7 @@ vars:
   upgradeVersion: "{{ resolve `ci/latest` }}"
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-pull
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y-tasks.yaml
@@ -11,7 +11,7 @@ vars:
   kubernetesVersion: v1.12.8
   controlPlaneNodes: 1
   workerNodes: 2
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-xony
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/upgrade-latest-no-addon-config-maps.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/upgrade-latest-no-addon-config-maps.yaml
@@ -6,7 +6,7 @@ vars:
   initVersion: "{{ resolve `ci/latest` }}"
   controlPlaneNodes: 1
   workerNodes: 1
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-upgrade
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/upgrade-tasks.yaml
@@ -9,7 +9,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 1
   workerNodes: 2
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-upgrade
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/discovery-tasks.yaml
+++ b/kinder/ci/workflows/discovery-tasks.yaml
@@ -8,7 +8,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-discovery
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/workflows/external-ca-tasks.yaml
@@ -7,7 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-external-ca
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/external-etcd-tasks.yaml
+++ b/kinder/ci/workflows/external-etcd-tasks.yaml
@@ -5,7 +5,7 @@ summary: |
   cluster with an external etcd cluster.
 vars:
   kubernetesVersion: v1.14.1
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-external-etcd
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/patches-tasks.yaml
+++ b/kinder/ci/workflows/patches-tasks.yaml
@@ -7,7 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-patches
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/presubmit-upgrade-latest.yaml
+++ b/kinder/ci/workflows/presubmit-upgrade-latest.yaml
@@ -9,7 +9,7 @@ vars:
   upgradeVersion: "{{ resolve `ci/latest` }}"
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-pull
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -12,7 +12,7 @@ vars:
   kubernetesVersion: v1.12.8
   controlPlaneNodes: 1
   workerNodes: 2
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-xony
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/upgrade-latest-no-addon-config-maps.yaml
+++ b/kinder/ci/workflows/upgrade-latest-no-addon-config-maps.yaml
@@ -7,7 +7,7 @@ vars:
   initVersion: "{{ resolve `ci/latest` }}"
   controlPlaneNodes: 1
   workerNodes: 1
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-upgrade
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-tasks.yaml
@@ -10,7 +10,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 1
   workerNodes: 2
-  baseImage: kindest/base:v20190403-1ebf15f
+  baseImage: kindest/base:v20191105-ee880e9b # has containerd
   image: kindest/node:test
   clusterName: kinder-upgrade
   kubeadmVerbosity: 6


### PR DESCRIPTION
Switch all e2e test workflows to use containerd as the CR for the time
being. Dockershim is being removed from k/k and until cri-dockerd
gains maintainer traction we should avoid setting it up our selfs
for the sake of testing Docker as the CR.

Technically the dockershim removal only affects "latest" workflows
but this change will apply it to all k/k branches. Once and if
cri-dockerd is testable we can add a single workflow for Docker
as the CR.

xref https://github.com/kubernetes/kubeadm/issues/1412#issuecomment-989127286