### PR TITLE
.github/ISSUE_TEMPLATE: update to include CNI/CRI

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -48,6 +48,8 @@ explain why.
 - **Cloud provider or hardware configuration**:
 - **OS** (e.g. from /etc/os-release):
 - **Kernel** (e.g. `uname -a`):
+- **Container runtime (CRI)** (e.g. containerd, cri-o):
+- **Container networking plugin (CNI)** (e.g. Calico, Cilium):
 - **Others**:
 
 


### PR DESCRIPTION
Often tickets are lacking information about the
used container runtime and CNI plugin.

With the built-in Docker support being dropped in 1.24,
kubelet failures would mean the user has not read the release notes
or has not migrated to a different CR yet.