### PR TITLE
OWNERS: sync the file with k/k

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,8 +5,11 @@ approvers:
 - neolit123
 - SataQiu
 reviewers:
-- yagonobre
+- fabriziopandini
+- neolit123
+- SataQiu
 - pacoxu
+- RA489
 emeritus_approvers:
 - luxas
 - timothysc


### PR DESCRIPTION
This matches the same OWNERS as in k/k/cmd/kubeadm.

- adds some missing reviewers which means the bots would not have assigned them even if they are in the approver list
- removes `@yagonobre`. thank you!

xref https://github.com/kubernetes/kubernetes/pull/106920