### PR TITLE
kinder: add handling of the new/old kubelet-config map

### DIFF
--- a/kinder/pkg/cluster/manager/actions/waiter.go
+++ b/kinder/pkg/cluster/manager/actions/waiter.go
@@ -329,14 +329,30 @@ func staticPodHasVersion(pod, version string) func(c *status.Cluster, n *status.
 func kubeletHasRBAC(major, minor uint) func(c *status.Cluster, n *status.Node) bool {
 	return func(c *status.Cluster, n *status.Node) bool {
 		for i := 0; i < 5; i++ {
+			// Try the new kubelet config naming scheme and fallback to the old one.
+			//
+			// TODO: remove handling of the old CM once kinder no longer
+			// manages clusters with the legacy kubelet ConfigMap -
+			// i.e. when 1.24 is out of support.
+			// https://github.com/kubernetes/kubeadm/issues/1582
 			output1 := kubectlOutput(n,
 				"auth",
 				"can-i",
 				"get",
 				"--kubeconfig=/etc/kubernetes/kubelet.conf",
 				"--namespace=kube-system",
-				fmt.Sprintf("configmaps/kubelet-config-%d.%d", major, minor),
+				"configmaps/kubelet-config",
 			)
+			if output1 != "yes" {
+				output1 = kubectlOutput(n,
+					"auth",
+					"can-i",
+					"get",
+					"--kubeconfig=/etc/kubernetes/kubelet.conf",
+					"--namespace=kube-system",
+					fmt.Sprintf("configmaps/kubelet-config-%d.%d", major, minor),
+				)
+			}
 			output2 := kubectlOutput(n,
 				"auth",
 				"can-i",


### PR DESCRIPTION
With UnversionedKubeletConfigMap going Beta in 1.24
and enabled by default, we want to match what kubeadm is doing:
- look of the new name of CM
- if that fails fallback to the old CM name

leave a TODO to remove this extra handling once 1.24
goes out of support. This would mean that all tested
versions of kubeadm only have UnversionedKubeletConfigMap=true
and the new CM name.

xref https://github.com/kubernetes/kubeadm/issues/1582
xref https://github.com/kubernetes/kubernetes/pull/108027
(does not depend strictly on the this PR)

NOTE: i'm not touching the only e2e test workflow for this because it already excercises the case for upgrading from a state with old names -> new names.
https://github.com/kubernetes/kubeadm/blob/main/kinder/ci/workflows/unversioned-kubelet-cm-tasks.yaml#L113-L125
we can technically add a new workflow with the FG turned off and tested during init, but i don't think that is necessary.