### PR TITLE
status: expose error message

### DIFF
--- a/kinder/pkg/cluster/status/cluster.go
+++ b/kinder/pkg/cluster/status/cluster.go
@@ -78,7 +78,7 @@ func ListClusters() ([]string, error) {
 	)
 	lines, err := cmd.RunAndCapture()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list clusters")
+		return nil, errors.Wrapf(err, "failed to list clusters: %s", lines)
 	}
 	return sets.NewString(lines...).List(), nil
 }


### PR DESCRIPTION
Not exposing the error logs from the executed command did not make the
error actionable for users.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>