### PR TITLE
status: use a podman-compatible format string

### DIFF
--- a/kinder/pkg/cluster/status/cluster.go
+++ b/kinder/pkg/cluster/status/cluster.go
@@ -74,7 +74,7 @@ func ListClusters() ([]string, error) {
 		// filter for nodes with the cluster label
 		"--filter", "label="+constants.DeprecatedClusterLabelKey,
 		// format to include the cluster name
-		"--format", fmt.Sprintf(`{{.Label "%s"}}`, constants.DeprecatedClusterLabelKey),
+		"--format", fmt.Sprintf(`{{index .Labels "%s"}}`, constants.DeprecatedClusterLabelKey),
 	)
 	lines, err := cmd.RunAndCapture()
 	if err != nil {


### PR DESCRIPTION
Both `docker` and `podman` expose the `.Labels` map, but only `docker`
exposes a method on the `ps` output to index into the map. This method
is superfluous, since Go templates let you index into the map natively.
Using the native indexing allows the `--format` string to work for
`docker` and `podman` both.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

xref: https://docs.docker.com/engine/reference/commandline/ps/#formatting
xref: https://docs.podman.io/en/latest/markdown/podman-ps.1.html#format-format