### PR TITLE
k8s-infra: verify manifests for registry.k8s.io

### DIFF
--- a/tests/e2e/manifests/verify_manifest_lists.go
+++ b/tests/e2e/manifests/verify_manifest_lists.go
@@ -65,7 +65,7 @@ const (
 	// first release that is known to have full support.
 	firstKnownVersion = "v1.12.0-rc.1"
 
-	gcrBucket = "https://k8s.gcr.io/v2"
+	gcrBucket = "https://registry.k8s.io/v2"
 
 	typeManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
 	typeManifest     = "application/vnd.docker.distribution.manifest.v2+json"


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/k8s.io/issues/3411

Verify the manifests lists registry.k8s.io in replacement of k8s.gcr.io

See: https://groups.google.com/d/msgid/kubernetes-sig-testing/CANw6fcFgKaCLLiuY_8TBp%3DKWROHZbuj1FYWAfyGW6XOQ%3D_nLUA%40mail.gmail.com?utm_medium=email&utm_source=footer

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>