### PR TITLE
remove SIG / kubeadm label from OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,5 +15,3 @@ emeritus_approvers:
 - timothysc
 - rosti
 - ereslibre
-labels:
-- sig/cluster-lifecycle

--- a/kinder/OWNERS
+++ b/kinder/OWNERS
@@ -5,5 +5,4 @@ approvers:
 - neolit123
 reviewers:
 labels:
-- area/kubeadm
-- sig/cluster-lifecycle
+- area/kinder


### PR DESCRIPTION
subproject or SIG labels are not needed on subproject PRs/issues as they are implied.
helps for better org wide triage on SIG CL tickets, coming from third parties.

add kinder label to kinder OWNERs file.