### PR TITLE
kinder: ensure the container runtime is started before executing dryrun e2e test

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/dryrun-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/dryrun-tasks.yaml
@@ -55,6 +55,7 @@ tasks:
   args:
     - -c
     - |
+      docker exec {{ .vars.clusterName }}-control-plane-1 bash -c "until crictl ps &> /dev/null; do echo 'Waiting for the container runtime to be running ...'; sleep 1; done"
       docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm init --ignore-preflight-errors={{ .vars.kubeadmIgnorePreflightErrors }} --kubernetes-version={{ .vars.kubernetesVersion }} --dry-run=true --v={{ .vars.kubeadmVerbosity }} || exit 1
       docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm init --ignore-preflight-errors={{ .vars.kubeadmIgnorePreflightErrors }} --kubernetes-version={{ .vars.kubernetesVersion }} --upload-certs=true --dry-run=true --v={{ .vars.kubeadmVerbosity }} || exit 1
   timeout: 5m
@@ -77,6 +78,7 @@ tasks:
   args:
     - -c
     - |
+      docker exec {{ .vars.clusterName }}-worker-1 bash -c "until crictl ps &> /dev/null; do echo 'Waiting for the container runtime to be running ...'; sleep 1; done"
       docker exec {{ .vars.clusterName }}-worker-1 $(docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm token create --print-join-command) --ignore-preflight-errors={{ .vars.kubeadmIgnorePreflightErrors }} --dry-run=true --v={{ .vars.kubeadmVerbosity }} || exit 1
   timeout: 10m
 - name: join

--- a/kinder/ci/workflows/dryrun-tasks.yaml
+++ b/kinder/ci/workflows/dryrun-tasks.yaml
@@ -56,6 +56,7 @@ tasks:
   args:
     - -c
     - |
+      docker exec {{ .vars.clusterName }}-control-plane-1 bash -c "until crictl ps &> /dev/null; do echo 'Waiting for the container runtime to be running ...'; sleep 1; done"
       docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm init --ignore-preflight-errors={{ .vars.kubeadmIgnorePreflightErrors }} --kubernetes-version={{ .vars.kubernetesVersion }} --dry-run=true --v={{ .vars.kubeadmVerbosity }} || exit 1
       docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm init --ignore-preflight-errors={{ .vars.kubeadmIgnorePreflightErrors }} --kubernetes-version={{ .vars.kubernetesVersion }} --upload-certs=true --dry-run=true --v={{ .vars.kubeadmVerbosity }} || exit 1
   timeout: 5m
@@ -78,6 +79,7 @@ tasks:
   args:
     - -c
     - |
+      docker exec {{ .vars.clusterName }}-worker-1 bash -c "until crictl ps &> /dev/null; do echo 'Waiting for the container runtime to be running ...'; sleep 1; done"
       docker exec {{ .vars.clusterName }}-worker-1 $(docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm token create --print-join-command) --ignore-preflight-errors={{ .vars.kubeadmIgnorePreflightErrors }} --dry-run=true --v={{ .vars.kubeadmVerbosity }} || exit 1
   timeout: 10m
 - name: join


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubeadm/issues/2653#issuecomment-1104535529