### PR TITLE
upgrade golang.org/x/sys-upgrade to 20220520151302

### DIFF
--- a/kinder/go.mod
+++ b/kinder/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43 // indirect
-	golang.org/x/sys v0.0.0-20201107080550-4d91cf3a1aaf // indirect
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	k8s.io/apimachinery v0.19.4
 	k8s.io/client-go v0.19.4
 	sigs.k8s.io/kind v0.9.0

--- a/kinder/go.sum
+++ b/kinder/go.sum
@@ -463,8 +463,8 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201107080550-4d91cf3a1aaf h1:kt3wY1Lu5MJAnKTfoMR52Cu4gwvna4VTzNOiT8tY73s=
-golang.org/x/sys v0.0.0-20201107080550-4d91cf3a1aaf/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
When I try to run `../kubeadm/kinder/ci/kinder-run.sh skew-latest-on-1.24`, I met some errors for old x/sys

```
# golang.org/x/sys/unix
/Users/pacoxu/go/pkg/mod/golang.org/x/sys@v0.0.0-20201107080550-4d91cf3a1aaf/unix/syscall_darwin.1_13.go:29:3: //go:linkname must refer to declared function or variable
/Users/pacoxu/go/pkg/mod/golang.org/x/sys@v0.0.0-20201107080550-4d91cf3a1aaf/unix/zsyscall_darwin_amd64.1_13.go:27:3: //go:linkname must refer to declared function or variable
/Users/pacoxu/go/pkg/mod/golang.org/x/sys@v0.0.0-20201107080550-4d91cf3a1aaf/unix/zsyscall_darwin_amd64.1_13.go:40:3: //go:linkname must refer to declared function or variable
/Users/pacoxu/go/pkg/mod/golang.org/x/sys@v0.0.0-20201107080550-4d91cf3a1aaf/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
/Users/pacoxu/go/pkg/mod/golang.org/x/sys@v0.0.0-20201107080550-4d91cf3a1aaf/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
/Users/pacoxu/go/pkg/mod/golang.org/x/sys@v0.0.0-20201107080550-4d91cf3a1aaf/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
/Users/pacoxu/go/pkg/mod/golang.org/x/sys@v0.0.0-20201107080550-4d91cf3a1aaf/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
/Users/pacoxu/go/pkg/mod/golang.org/x/sys@v0.0.0-20201107080550-4d91cf3a1aaf/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
/Users/pacoxu/go/pkg/mod/golang.org/x/sys@v0.0.0-20201107080550-4d91cf3a1aaf/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
/Users/pacoxu/go/pkg/mod/golang.org/x/sys@v0.0.0-20201107080550-4d91cf3a1aaf/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
/Users/pacoxu/go/pkg/mod/golang.org/x/sys@v0.0.0-20201107080550-4d91cf3a1aaf/unix/zsyscall_darwin_amd64.go:121:3: too many errors
```

After upgrading to [20220520151302](https://github.com/kubernetes/kubeadm/commit/00e8aaea9c68ea27cc00a6bd4b69cf8206abc40a), it works.

Not sure if this is needed.