### PR TITLE
kinder: apply a hack to handle the registry.k8s.io transition bugs

### DIFF
--- a/kinder/pkg/build/alter/alter.go
+++ b/kinder/pkg/build/alter/alter.go
@@ -149,11 +149,16 @@ func (c *Context) Alter() (err error) {
 	// initialize bits installers
 	var bitsInstallers []bits.Installer
 
+	// TODO: remove the KubeadmBinaryVer workaround once we no longer test the kubeadm 1.25 / k8s 1.24 skew.
+	// See pkg/cri/host/archive.go.
+
+	host.KubeadmBinaryVer = c.initArtifactsSrc
 	if c.initArtifactsSrc != "" {
 		bitsInstallers = append(bitsInstallers, bits.NewInitBits(c.initArtifactsSrc))
 	}
 
 	if c.kubeadmSrc != "" {
+		host.KubeadmBinaryVer = c.kubeadmSrc
 		bitsInstallers = append(bitsInstallers, bits.NewBinaryBits(c.kubeadmSrc, "kubeadm"))
 	}
 	if c.kubeletSrc != "" {

--- a/kinder/pkg/cri/host/archive.go
+++ b/kinder/pkg/cri/host/archive.go
@@ -24,6 +24,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/version"
 )
 
 // TODO: investigate if we can get rid of this or simplify it.
@@ -75,6 +77,24 @@ func GetArchiveTags(path string) ([]string, error) {
 		}
 	}
 	return res, nil
+}
+
+// Temporary workaround to allow detecting the transition to registry.k8s.io in kubeadm 1.25.
+// TODO: remove KubeadmVer and replaceKubeadm125Repository() once we no longer test the
+// kubeadm 1.25 / k8s 1.24 skew
+
+// KubeadmBinaryVer tracks the version of the kubeadm binary
+var KubeadmBinaryVer string
+
+func replaceKubeadm125Repository(repository string) string {
+	if len(KubeadmBinaryVer) == 0 {
+		return repository
+	}
+	v := version.MustParseSemantic(KubeadmBinaryVer)
+	if v.AtLeast(version.MustParseSemantic("v1.25.0-0")) && strings.HasPrefix(repository, "k8s.gcr.io") {
+		return strings.Replace(repository, "k8s.gcr.io", "registry.k8s.io", -1)
+	}
+	return repository
 }
 
 // EditArchiveRepositories applies edit to reader's image repositories,
@@ -148,6 +168,7 @@ func editRepositoriesFile(raw []byte, editRepositories func(string) string) ([]b
 
 	fixed := make(archiveRepositories)
 	for repository, tagsToRefs := range tags {
+		repository = replaceKubeadm125Repository(repository)
 		fixed[editRepositories(repository)] = tagsToRefs
 	}
 
@@ -176,6 +197,7 @@ func editManifestRepositories(raw []byte, editRepositories func(string) string) 
 				return nil, fmt.Errorf("invalid repotag: %s", entry)
 			}
 			parts[0] = editRepositories(parts[0])
+			parts[0] = replaceKubeadm125Repository(parts[0])
 			fixed[i] = strings.Join(parts, ":")
 		}
 


### PR DESCRIPTION
During the fixup of image tarbals if the kubeadm binary is
at least 1.25.0-0, modify k8s.gcr.io to registry.k8s.io.

Leave to TODOs to clean the hack once 1.25 kubeadm / 1.24 k8s
is no longer tested.

https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-latest-on-1-24

xref https://github.com/kubernetes/kubeadm/issues/2671