### PR TITLE
sig-k8s-infra: Default prowjobs to k8s-infra

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-addons.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-addons.yaml
@@ -1,4 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-no-addons-{{ dashVer .KubernetesVersion }}
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -34,6 +35,9 @@
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-discovery.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-discovery.yaml
@@ -1,4 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-discovery-{{ dashVer .KubernetesVersion }}
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:
@@ -33,6 +34,9 @@
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-dryrun.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-dryrun.yaml
@@ -1,4 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-dryrun-{{ dashVer .KubernetesVersion }}
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:
@@ -33,6 +34,9 @@
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-ca.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-ca.yaml
@@ -1,4 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-{{ dashVer .KubernetesVersion }}
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:
@@ -33,6 +34,9 @@
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-etcd.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-etcd.yaml
@@ -1,4 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-{{ dashVer .KubernetesVersion }}
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:
@@ -33,6 +34,9 @@
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -1,4 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-{{ dashVer .KubeletVersion }}-on-{{ dashVer .KubernetesVersion }}
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:
@@ -33,6 +34,9 @@
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-patches.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-patches.yaml
@@ -1,4 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-patches-{{ dashVer .KubernetesVersion }}
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:
@@ -33,6 +34,9 @@
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-rootless.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-rootless.yaml
@@ -1,4 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-rootless-{{ dashVer .KubernetesVersion }}
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:
@@ -33,6 +34,9 @@
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-upgrade.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-upgrade.yaml
@@ -1,4 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-{{ dashVer .InitVersion }}-{{ dashVer .KubernetesVersion }}
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:
@@ -33,6 +34,9 @@
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-x-on-y.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-x-on-y.yaml
@@ -1,4 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-{{ dashVer .KubeadmVersion }}-on-{{ dashVer .KubernetesVersion }}
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:
@@ -33,6 +34,9 @@
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder.yaml
@@ -1,4 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-{{ dashVer .KubernetesVersion }}
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:
@@ -33,6 +34,9 @@
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m


### PR DESCRIPTION
Ensure prowjobs will run in the community infrastructure

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>