### PR TITLE
kinder: use new kind base image

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/discovery-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/discovery-tasks.yaml
@@ -7,7 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-discovery
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-ca-tasks.yaml
@@ -6,7 +6,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-external-ca
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/external-etcd-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-etcd-tasks.yaml
@@ -4,7 +4,7 @@ summary: |
   cluster with an external etcd cluster.
 vars:
   kubernetesVersion: v1.14.1
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-external-etcd
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/patches-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/patches-tasks.yaml
@@ -6,7 +6,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-patches
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/presubmit-upgrade-latest.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/presubmit-upgrade-latest.yaml
@@ -8,7 +8,7 @@ vars:
   upgradeVersion: "{{ resolve `ci/latest` }}"
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-pull
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/regular-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/regular-tasks.yaml
@@ -9,7 +9,7 @@ vars:
   kubernetesVersion: v1.13.5
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-regular
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/rootless-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/rootless-tasks.yaml
@@ -10,7 +10,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-rootless
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y-tasks.yaml
@@ -11,7 +11,7 @@ vars:
   kubernetesVersion: v1.12.8
   controlPlaneNodes: 1
   workerNodes: 2
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-xony
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/upgrade-latest-no-addon-config-maps.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/upgrade-latest-no-addon-config-maps.yaml
@@ -6,7 +6,7 @@ vars:
   initVersion: "{{ resolve `ci/latest` }}"
   controlPlaneNodes: 1
   workerNodes: 1
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-upgrade
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/upgrade-tasks.yaml
@@ -9,7 +9,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 1
   workerNodes: 2
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-upgrade
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/discovery-tasks.yaml
+++ b/kinder/ci/workflows/discovery-tasks.yaml
@@ -8,7 +8,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-discovery
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/workflows/external-ca-tasks.yaml
@@ -7,7 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-external-ca
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/external-etcd-tasks.yaml
+++ b/kinder/ci/workflows/external-etcd-tasks.yaml
@@ -5,7 +5,7 @@ summary: |
   cluster with an external etcd cluster.
 vars:
   kubernetesVersion: v1.14.1
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-external-etcd
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/patches-tasks.yaml
+++ b/kinder/ci/workflows/patches-tasks.yaml
@@ -7,7 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-patches
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/presubmit-upgrade-latest.yaml
+++ b/kinder/ci/workflows/presubmit-upgrade-latest.yaml
@@ -9,7 +9,7 @@ vars:
   upgradeVersion: "{{ resolve `ci/latest` }}"
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-pull
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/regular-tasks.yaml
+++ b/kinder/ci/workflows/regular-tasks.yaml
@@ -10,7 +10,7 @@ vars:
   kubernetesVersion: v1.13.5
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-regular
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/rootless-tasks.yaml
+++ b/kinder/ci/workflows/rootless-tasks.yaml
@@ -11,7 +11,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-rootless
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -12,7 +12,7 @@ vars:
   kubernetesVersion: v1.12.8
   controlPlaneNodes: 1
   workerNodes: 2
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-xony
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/upgrade-latest-no-addon-config-maps.yaml
+++ b/kinder/ci/workflows/upgrade-latest-no-addon-config-maps.yaml
@@ -7,7 +7,7 @@ vars:
   initVersion: "{{ resolve `ci/latest` }}"
   controlPlaneNodes: 1
   workerNodes: 1
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-upgrade
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-tasks.yaml
@@ -10,7 +10,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 1
   workerNodes: 2
-  baseImage: kindest/base:v20191105-ee880e9b # has containerd
+  baseImage: kindest/base:v20221102-76f15095 # has containerd
   image: kindest/node:test
   clusterName: kinder-upgrade
   kubeadmVerbosity: 6

--- a/kinder/pkg/cri/nodes/containerd/alterhelper.go
+++ b/kinder/pkg/cri/nodes/containerd/alterhelper.go
@@ -48,13 +48,8 @@ func GetAlterContainerArgs() ([]string, []string) {
 
 // SetupRuntime setups the runtime
 func SetupRuntime(bc *bits.BuildContext) error {
-	// Append the containerd settings for a systemd cgroup driver at the end of the config.toml.
-	// This assumes runc is used as the underlying runtime.
-	if err := bc.RunInContainer("bash", "-c",
-		"printf '[plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options]\nsystemdCgroup = true\n' >> /etc/containerd/config.toml",
-	); err != nil {
-		return errors.Wrap(err, "could not append to /etc/containerd/config.toml")
-	}
+	// This used to hold config.toml modifications for the systemd cgroup driver,
+	// but newer kind base images have it baked in.
 	return nil
 }
 


### PR DESCRIPTION

```
kinder: do not patch in systemd driver in config.toml

Newer kind base images have the option already and patching
it results in duplicate entries and errors.
```

```
kinder: update workflows to use the latest kind base image

The latest kind base image has newer containerd, which
hopefully works with all k8s versions that we are testing.
```

fixes https://github.com/kubernetes/kubernetes/issues/113619
