### PR TITLE
Use errors.Is to check for a specific error

### DIFF
--- a/kinder/hack/orderimports/orderimports.go
+++ b/kinder/hack/orderimports/orderimports.go
@@ -145,7 +145,7 @@ func processFile(filename string, in io.Reader, out io.Writer) error {
 		if *doDiff {
 			data, err := diffWithReplaceTempFile(src, res, filename)
 			if err != nil {
-				return fmt.Errorf("computing diff: %s", err)
+				return fmt.Errorf("computing diff: %w", err)
 			}
 			fmt.Printf("diff -u %s %s\n", filepath.ToSlash(filename+".orig"), filepath.ToSlash(filename))
 			out.Write(data)

--- a/kinder/pkg/cri/host/archive.go
+++ b/kinder/pkg/cri/host/archive.go
@@ -49,7 +49,7 @@ func GetArchiveTags(path string) ([]string, error) {
 	var hdr *tar.Header
 	for {
 		hdr, err = tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil, errors.New("could not find image metadata")
 		}
 		if err != nil {
@@ -114,7 +114,7 @@ func EditArchiveRepositories(reader io.Reader, writer io.Writer, editRepositorie
 	for {
 		// read an entry
 		hdr, err := tarReader.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return tarWriter.Close()
 		} else if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error