### PR TITLE
flag yaml code snippets as such

### DIFF
--- a/docs/ha-considerations.md
+++ b/docs/ha-considerations.md
@@ -312,7 +312,7 @@ kube-vip manifest pod \
 
 #### Example manifest
 
-```
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -394,7 +394,7 @@ kube-vip manifest pod \
 
 #### Example Manifest 
 
-```
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
For consistency purposes with the rest of the article, yaml code blocks can benefit from syntax coloring