### PR TITLE
use pacoxu/actions-comment-on-issue@1.0.3

### DIFF
--- a/.github/workflows/support-command.yaml
+++ b/.github/workflows/support-command.yaml
@@ -20,7 +20,7 @@ jobs:
           permission-level: admin
       - name: comment with support text
         if: steps.command.outputs.command-name
-        uses: ben-z/actions-comment-on-issue@1.0.2
+        uses: pacoxu/actions-comment-on-issue@1.0.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: |


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubeadm/issues/2892

https://github.com/ben-z/actions-comment-on-issue is not updated for a long time. I will try to fix it there as well in https://github.com/ben-z/actions-comment-on-issue/pull/3. 

The current `pacoxu/actions-comment-on-issue@1.0.3` is verified in https://github.com/pacoxu/kubeadm/issues/1