### PR TITLE
Bump xt0rted/slash-command-action from v1 to v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/support-command.yaml
+++ b/.github/workflows/support-command.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: check for the /support command
         id: command
-        uses: xt0rted/slash-command-action@v1
+        uses: xt0rted/slash-command-action@v2
         continue-on-error: true
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Node.js 12 actions are deprecated. need to update `xt0rted/slash-command-action@v1` to use Node.js 16. 

For more information see: [GitHub Actions: All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12)

In addition, I added Dependabot to help automatically update the dependencies.