### PR TITLE
Revert "kinder: use eks cluster in test-infra jobs"

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-addons.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-addons.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-no-addons-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-discovery.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-discovery.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-discovery-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-dryrun.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-dryrun.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-dryrun-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-ca.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-ca.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-etcd.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-external-etcd.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-{{ dashVer .KubeletVersion }}-on-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-learner-mode.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-learner-mode.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-learner-mode-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-patches.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-patches.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-patches-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-rootless.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-rootless.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-rootless-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-upgrade-addons-before-controlplane.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-upgrade-addons-before-controlplane.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-addons-before-controlplane-{{ dashVer .InitVersion }}-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-upgrade.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-upgrade.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-{{ dashVer .InitVersion }}-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-x-on-y.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder-x-on-y.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-{{ dashVer .KubeadmVersion }}-on-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:

--- a/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder.yaml
+++ b/kinder/ci/tools/update-workflows/templates/testinfra/kubeadm-kinder.yaml
@@ -1,5 +1,5 @@
 - name: ci-kubernetes-e2e-kubeadm-kinder-{{ dashVer .KubernetesVersion }}
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: {{ .JobInterval }}
   decorate: true
   labels:


### PR DESCRIPTION
This reverts commit e47366886e79972fa4e825e754219cda8546c08a.

Because of [EKS cluster instability](https://github.com/kubernetes/k8s.io/issues/5473) issues we decided to move kubeadm jobs back to GKE cluster. This has been discussed on yesterday's sig-infra-meeting (unfortunately the video hasn't been uploaded yet). Putting it shortly, we have a suspicion that those jobs are problematic and want to see if moving them back to GKE improves stability of EKS clusters.

/assign @xmudrii 
/cc @dims @ameukam 