### PR TITLE
kinder: compatible with Docker CLI 24.0.5+

### DIFF
--- a/kinder/pkg/cluster/status/cluster.go
+++ b/kinder/pkg/cluster/status/cluster.go
@@ -68,7 +68,6 @@ const (
 func ListClusters() ([]string, error) {
 	cmd := exec.NewHostCmd("docker",
 		"ps",
-		"-q",         // quiet output for parsing
 		"-a",         // show stopped nodes
 		"--no-trunc", // don't truncate
 		// filter for nodes with the cluster label
@@ -160,7 +159,6 @@ func (c *Cluster) KubeConfigPath() string {
 func (c *Cluster) listNodes() ([]string, error) {
 	cmd := exec.NewHostCmd("docker",
 		"ps",
-		"-q",         // quiet output for parsing
 		"-a",         // show stopped nodes
 		"--no-trunc", // don't truncate
 		// filter for nodes with the cluster label


### PR DESCRIPTION
Kinder fails during cluster creation, when Docker CLI 24.0.5+ is installed on local machine.
```
DEBU[15:37:35] Reading container list for cluster kind      
DEBU[15:37:35] Running: docker ps -q -a --no-trunc --filter label=io.k8s.sigs.kind.cluster=kind --format {{.Names}} 
DEBU[15:37:35] Adding node WARNING: Ignoring custom format, because both --format and --quiet are set. to the cluster 
DEBU[15:37:35] Running: docker inspect -f {{index .Config.Labels "io.k8s.sigs.kind.role"}} WARNING: Ignoring custom format, because both --format and --quiet are set. 
ERRO[15:37:35] failed to get "io.k8s.sigs.kind.role" label: exit status 1 
```
this is because the most recent `docker ps` command does not allow to specify both --format and --quiet parameters.
(please see similar issue [here](https://github.com/microsoft/navcontainerhelper/issues/3054)).

Removing `-quiet , -q `command line option solves the problem.





