### PR TITLE
fix broken links to testgrid dashboard

### DIFF
--- a/docs/managing-e2e-tests.md
+++ b/docs/managing-e2e-tests.md
@@ -4,7 +4,7 @@
 
 Kubernetes has a rich end-to-end (e2e) testing infrastructure, which allows detailed testing of clusters and their assets. Most settings and tools for that can be found in the [test-infra](https://git.k8s.io/test-infra) GitHub repository.
 
-Kubernetes uses applications such as the web-based [testgrid](https://k8s-testgrid.appspot.com/) for monitoring the status of e2e tests. test-infra also hosts the configuration on individual test jobs and Docker images that contain tools to invoke the jobs.
+Kubernetes uses applications such as the web-based [testgrid](https://testgrid.k8s.io/) for monitoring the status of e2e tests. test-infra also hosts the configuration on individual test jobs and Docker images that contain tools to invoke the jobs.
 
 ### Prow job configuration
 
@@ -45,8 +45,8 @@ The same document must be updated every time kinder workflows are added/deleted.
 Testgrid contains elements like dashboard groups, dashboards and tabs.
 
 As an overview:
-- SIG Cluster Lifecycle dashboards reside in a dashboard group that can be found [here](https://k8s-testgrid.appspot.com).
-- Inside this dashboard group there is a [dashboard for kubeadm](https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm).
+- SIG Cluster Lifecycle dashboards reside in a dashboard group that can be found [here](https://testgrid.k8s.io).
+- Inside this dashboard group there is a [dashboard for kubeadm](https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm).
 - Inside this dashboard there are individual tabs such as `kubeadm-foo` (which is the tab name for the
 job `ci-kubernetes-e2e-kubeadm-foo`).
 
@@ -128,7 +128,7 @@ Jobs that runs against the development kubernetes/kubernetes branch should send 
 ### Release informing and blocking jobs
 
 Certain test jobs maintained by SIG Cluster Lifecycle can be present in release blocking or informing dashboards, such as:
-https://k8s-testgrid.appspot.com/sig-release-master-informing
+https://testgrid.k8s.io/sig-release-master-informing
 
 These test jobs are of higher importance as they can block a Kubernetes release in case they are failing.
 Such dashboards are managed by SIG Release, but SIG Cluster Lifecycle can propose changes by adding or removing

--- a/docs/release-cycle.md
+++ b/docs/release-cycle.md
@@ -53,7 +53,7 @@ https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/
 - Watch for new features in core Kubernetes that may affect kubeadm. Discuss what action has to be taken
 by the kubeadm maintainers.
 - Make sure that existing e2e test jobs are green at all times:
-  https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm
+  https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm
   Without good signal there is no indication if new PRs are introducing regressions.
 
 #### Third month of the quarter (stabilization)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -5,4 +5,4 @@ This folder contains kubeadm e2e tests that run as periodic jobs.
 The definitions for these jobs can be found in the test-infra repository
 [here](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/sig-cluster-lifecycle).
 
-Test results can be monitored in this [testgrid dashboard](https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-all).
+Test results can be monitored in this [testgrid dashboard](https://testgrid.k8s.io/sig-cluster-lifecycle-all).

--- a/tests/e2e/manifests/README.md
+++ b/tests/e2e/manifests/README.md
@@ -4,7 +4,7 @@ The `verify_manifest_lists.sh` script in this folder verifies that the necessary
 manifest lists are pushed to the GCR bucket that kubeadm uses by default.
 The script is just a wrapper for a Go application.
 
-It is run periodically and results are available at https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-all#periodic-e2e-verify-manifest-lists
+It is run periodically and results are available at https://testgrid.k8s.io/sig-cluster-lifecycle-all#periodic-e2e-verify-manifest-lists
 
 ### Running
 


### PR DESCRIPTION
**What this PR does / why we need it:**
Fixes a bunch of broken links to testgrid dashboard.

**Which issue(s) this PR fixes:**
This is related to an umbrella issue and fixes a task of the same:
https://github.com/kubernetes/test-infra/issues/30370