### PR TITLE
OWNERS: move fabriziopandini to emeritus, remove RA489

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,18 +1,16 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- fabriziopandini
 - neolit123
 - SataQiu
 - pacoxu
 reviewers:
-- fabriziopandini
 - neolit123
 - SataQiu
 - pacoxu
-- RA489
 - chendave
 emeritus_approvers:
+- fabriziopandini
 - luxas
 - timothysc
 - rosti

--- a/kinder/OWNERS
+++ b/kinder/OWNERS
@@ -1,8 +1,4 @@
 # See the OWNERS file documentation:
 #  https://git.k8s.io/community/contributors/devel/owners.md
-approvers:
-- fabriziopandini
-- neolit123
-reviewers:
 labels:
 - area/kinder


### PR DESCRIPTION
kinder/OWNERS: remove the list of approvers / reviewers and only add the labels. The root OWNERS is what should be used.

please see:
https://github.com/kubernetes/kubernetes/pull/120598
https://github.com/kubernetes/kubernetes/pull/120598#issuecomment-1715370149