### PR TITLE
kinder: configure containerd to use the sandbox image recommended by kubeadm when building the node image

### DIFF
--- a/kinder/go.mod
+++ b/kinder/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/google/uuid v1.1.2
 	github.com/imdario/mergo v0.3.11 // indirect
+	github.com/pelletier/go-toml v1.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1

--- a/kinder/pkg/cri/nodes/containerd/config/config.go
+++ b/kinder/pkg/cri/nodes/containerd/config/config.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+
+	"github.com/pelletier/go-toml"
+	"github.com/pkg/errors"
+)
+
+var (
+	// DefaultConfigPath is the default location of the containerd config file.
+	DefaultConfigPath = "/etc/containerd/config.toml"
+)
+
+var (
+	sandboxImageFieldPath = []string{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"}
+)
+
+// GetCRISandboxImage returns the sandbox image defined in the containerd config file.
+func GetCRISandboxImage(path string) (string, error) {
+	if _, err := os.Stat(path); err != nil {
+		return "", err
+	}
+
+	tree, err := toml.LoadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	if !tree.HasPath(sandboxImageFieldPath) {
+		return "", errors.Errorf("the field %v doesn't exist in the config file %s", sandboxImageFieldPath, path)
+	}
+
+	return tree.GetPath(sandboxImageFieldPath).(string), nil
+}
+
+// SetCRISandboxImage sets the sandbox image field of the containerd config file to the specified value.
+func SetCRISandboxImage(path string, sandboxImage string) error {
+	if _, err := os.Stat(path); err != nil {
+		return err
+	}
+
+	tree, err := toml.LoadFile(path)
+	if err != nil {
+		return err
+	}
+
+	tree.SetPath(sandboxImageFieldPath, sandboxImage)
+
+	data, err := tree.ToTomlString()
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(path, []byte(data), 0666); err != nil {
+		return errors.Errorf("failed to write to config file %s, error: %v", path, err)
+	}
+
+	return nil
+}

--- a/kinder/pkg/cri/nodes/containerd/config/config_test.go
+++ b/kinder/pkg/cri/nodes/containerd/config/config_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"path/filepath"
+)
+
+func TestGetCRISandboxImage(t *testing.T) {
+	expectedSandboxImage := "registry.k8s.io/pause:3.7"
+
+	data := fmt.Sprintf(`version = 2
+[plugins."io.containerd.grpc.v1.cri"]
+  sandbox_image = "%s"
+`, expectedSandboxImage)
+
+	tempDir := t.TempDir()
+
+	emptyFilePath := filepath.Join(tempDir, "empty.toml")
+	if err := os.WriteFile(emptyFilePath, []byte(""), 0600); err != nil {
+		t.Fatalf("couldn't write to file %s: %v", emptyFilePath, err)
+	}
+
+	defaultFilePath := filepath.Join(tempDir, "default.toml")
+	if err := os.WriteFile(defaultFilePath, []byte(data), 0600); err != nil {
+		t.Fatalf("couldn't write to file %s: %v", defaultFilePath, err)
+	}
+
+	var tests = []struct {
+		name          string
+		path          string
+		expectedError bool
+	}{
+		{
+			name:          "the containerd config file doesn't exist",
+			path:          filepath.Join(tempDir, "invalid.toml"),
+			expectedError: true,
+		},
+		{
+			name:          "the containerd config file doesn't contain the sandbox_image field",
+			path:          emptyFilePath,
+			expectedError: true,
+		},
+		{
+			name:          "the containerd config file contains the sandbox_image field",
+			path:          defaultFilePath,
+			expectedError: false,
+		},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t *testing.T) {
+			sandboxImage, err := GetCRISandboxImage(rt.path)
+			if (err != nil) != rt.expectedError {
+				t.Errorf("failed GetCRISandboxImage:\n\texpected error: %t\n\tactual error: %v", rt.expectedError, err)
+			}
+
+			if err == nil {
+				if sandboxImage != expectedSandboxImage {
+					t.Errorf("failed GetCRISandboxImage:\n\texpected sandbox image: %s\n\tactual sandbox image: %s", expectedSandboxImage, sandboxImage)
+				}
+			}
+		})
+	}
+}
+
+func TestSetCRISandboxImage(t *testing.T) {
+	data := `version = 2
+[plugins."io.containerd.grpc.v1.cri"]
+  sandbox_image = "registry.k8s.io/pause:3.7"
+`
+	tempDir := t.TempDir()
+
+	emptyFilePath := filepath.Join(tempDir, "empty.toml")
+	if err := os.WriteFile(emptyFilePath, []byte(""), 0600); err != nil {
+		t.Fatalf("couldn't write to file %s: %v", emptyFilePath, err)
+	}
+
+	defaultFilePath := filepath.Join(tempDir, "default.toml")
+	if err := os.WriteFile(defaultFilePath, []byte(data), 0600); err != nil {
+		t.Fatalf("couldn't write to file %s: %v", defaultFilePath, err)
+	}
+
+	var tests = []struct {
+		name          string
+		path          string
+		expectedError bool
+	}{
+		{
+			name:          "the containerd config file doesn't exist",
+			path:          filepath.Join(tempDir, "invalid.toml"),
+			expectedError: true,
+		},
+		{
+			name:          "the containerd config file doesn't contain the sandbox_image field",
+			path:          emptyFilePath,
+			expectedError: false,
+		},
+		{
+			name:          "the containerd config file contains the sandbox_image field",
+			path:          defaultFilePath,
+			expectedError: false,
+		},
+	}
+
+	expectedSandboxImage := "registry.k8s.io/pause:3.9"
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t *testing.T) {
+			err := SetCRISandboxImage(rt.path, expectedSandboxImage)
+			if (err != nil) != rt.expectedError {
+				t.Errorf("failed SetCRISandboxImage:\n\texpected error: %t\n\tactual error: %v", rt.expectedError, err)
+			}
+
+			if err == nil {
+				sandboxImage, err := GetCRISandboxImage(rt.path)
+				if err != nil {
+					t.Fatalf("failed to get sandbox image from config file %s: %v", rt.path, err)
+				}
+
+				if sandboxImage != expectedSandboxImage {
+					t.Errorf("failed SetCRISandboxImage:\n\texpected sandbox image: %s\n\tactual sandbox image: %s", expectedSandboxImage, sandboxImage)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
kinder: configure containerd to use the sandbox image recommended by kubeadm when building the node image