### PR TITLE
use ben-z/actions-comment-on-issue back

### DIFF
--- a/.github/workflows/support-command.yaml
+++ b/.github/workflows/support-command.yaml
@@ -20,7 +20,7 @@ jobs:
           permission-level: admin
       - name: comment with support text
         if: steps.command.outputs.command-name
-        uses: pacoxu/actions-comment-on-issue@1.0.3
+        uses: ben-z/actions-comment-on-issue@1.0.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: |


### PR DESCRIPTION
https://github.com/ben-z/actions-comment-on-issue/releases/tag/1.0.3  included the fix: https://github.com/ben-z/actions-comment-on-issue/pull/3.

See https://github.com/kubernetes/kubeadm/pull/2893.