### PR TITLE
Update skew change in v1.29 from n-1 to n-3

### DIFF
--- a/kinder/ci/kubeadm-periodic.tests.md
+++ b/kinder/ci/kubeadm-periodic.tests.md
@@ -71,10 +71,11 @@ Workflow file names: [`skew-[x]-on-[y]`](./workflows)
 Kubelet X on Y tests are meant to verify the proper functioning of a version X kubelet against version Y (X+1 or X+2)
 kubeadm and control plane. The coverage of X == Y is already covered by the `regular-*` tests.
 
-Note that for the time being kubeadm version X does not support skew against a kubelet version X-2,
-similarly to how kubeadm does not support X-2 skew with the control plane. This requires skipping
-the `KubeletVersion` preflight check. In the future if these X-2 tests are no longer possible with kubeadm
-they would have to be adapted on the kinder side or dropped.
+Before kubeadm v1.29, the maximum kubelet skew from the kubeadm version was X-1. This required skipping
+the KubeletVersion preflight check.
+
+After kubeadm v1.29, the maximum kubelet skew from the kubeadm version has become X-3 and KubeletVersion
+preflight check no longer has to be skipped.
 
 Workflow file names: [`skew-kubelet-[x]-on-[y]`](./workflows)
 


### PR DESCRIPTION
- preflight check KubeletVersion behavior change

Only change the comments here.

Leave the remove of the KubeletVersion from ignorePreflightErrors to v1.32 when all skew CI can remove it.