### PR TITLE
kinder: fix missing quotes in super-admin-tasks.yaml

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/super-admin-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/super-admin-tasks.yaml
@@ -56,7 +56,7 @@ tasks:
     - -c
     - |
       set -x
-      CMD=docker exec {{ .vars.clusterName }}-control-plane-1
+      CMD="docker exec {{ .vars.clusterName }}-control-plane-1"
 
       # Generate CA, and kubeconfig files
       ${CMD} kubeadm init phase certs ca || exit 1
@@ -109,7 +109,7 @@ tasks:
     - -c
     - |
       set -x
-      CMD=docker exec {{ .vars.clusterName }}-control-plane-1
+      CMD="docker exec {{ .vars.clusterName }}-control-plane-1"
 
       # Both admin.conf and super-admin.conf must exist
       ${CMD} test -f /etc/kubernetes/admin.conf || exit 1
@@ -145,7 +145,7 @@ tasks:
     - -c
     - |
       set -x
-      CMD=docker exec {{ .vars.clusterName }}-control-plane-2
+      CMD="docker exec {{ .vars.clusterName }}-control-plane-2"
 
       # admin.conf must exist
       ${CMD} test -f /etc/kubernetes/admin.conf || exit 1
@@ -182,7 +182,7 @@ tasks:
     - -c
     - |
       set -x
-      CMD=docker exec {{ .vars.clusterName }}-control-plane-1
+      CMD="docker exec {{ .vars.clusterName }}-control-plane-1"
 
       # Both admin.conf and super-admin.conf must exist
       ${CMD} test -f /etc/kubernetes/admin.conf || exit 1
@@ -206,7 +206,7 @@ tasks:
     - -c
     - |
       set -x
-      CMD=docker exec {{ .vars.clusterName }}-control-plane-2
+      CMD="docker exec {{ .vars.clusterName }}-control-plane-2"
 
       # admin.conf must exist
       ${CMD} test -f /etc/kubernetes/admin.conf || exit 1
@@ -278,7 +278,7 @@ tasks:
     - -c
     - |
       set -x
-      CMD=docker exec {{ .vars.clusterName }}-control-plane-1
+      CMD="docker exec {{ .vars.clusterName }}-control-plane-1"
 
       # Both admin.conf and super-admin.conf must not exist after reset
       ${CMD} test -f /etc/kubernetes/admin.conf && exit 1

--- a/kinder/ci/workflows/super-admin-tasks.yaml
+++ b/kinder/ci/workflows/super-admin-tasks.yaml
@@ -57,7 +57,7 @@ tasks:
     - -c
     - |
       set -x
-      CMD=docker exec {{ .vars.clusterName }}-control-plane-1
+      CMD="docker exec {{ .vars.clusterName }}-control-plane-1"
 
       # Generate CA, and kubeconfig files
       ${CMD} kubeadm init phase certs ca || exit 1
@@ -110,7 +110,7 @@ tasks:
     - -c
     - |
       set -x
-      CMD=docker exec {{ .vars.clusterName }}-control-plane-1
+      CMD="docker exec {{ .vars.clusterName }}-control-plane-1"
 
       # Both admin.conf and super-admin.conf must exist
       ${CMD} test -f /etc/kubernetes/admin.conf || exit 1
@@ -146,7 +146,7 @@ tasks:
     - -c
     - |
       set -x
-      CMD=docker exec {{ .vars.clusterName }}-control-plane-2
+      CMD="docker exec {{ .vars.clusterName }}-control-plane-2"
 
       # admin.conf must exist
       ${CMD} test -f /etc/kubernetes/admin.conf || exit 1
@@ -183,7 +183,7 @@ tasks:
     - -c
     - |
       set -x
-      CMD=docker exec {{ .vars.clusterName }}-control-plane-1
+      CMD="docker exec {{ .vars.clusterName }}-control-plane-1"
 
       # Both admin.conf and super-admin.conf must exist
       ${CMD} test -f /etc/kubernetes/admin.conf || exit 1
@@ -207,7 +207,7 @@ tasks:
     - -c
     - |
       set -x
-      CMD=docker exec {{ .vars.clusterName }}-control-plane-2
+      CMD="docker exec {{ .vars.clusterName }}-control-plane-2"
 
       # admin.conf must exist
       ${CMD} test -f /etc/kubernetes/admin.conf || exit 1
@@ -279,7 +279,7 @@ tasks:
     - -c
     - |
       set -x
-      CMD=docker exec {{ .vars.clusterName }}-control-plane-1
+      CMD="docker exec {{ .vars.clusterName }}-control-plane-1"
 
       # Both admin.conf and super-admin.conf must not exist after reset
       ${CMD} test -f /etc/kubernetes/admin.conf && exit 1


### PR DESCRIPTION
Without the quotes these (CMD) commands cannot be expanded properly.

xref https://github.com/kubernetes/kubeadm/pull/2949
xref https://github.com/kubernetes/kubeadm/issues/2414