### PR TITLE
kinder: do proper cleanup in the super-admin-tasks.yaml workflow

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/super-admin-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/super-admin-tasks.yaml
@@ -83,14 +83,13 @@ tasks:
       ${CMD} kubeadm certs check-expiration || exit 1
 
       # Delete super-admin.conf and make sure check-expiration and renew do not return errors
-      ${CMD} rm -f /etc/kubernetes/super-admin.conf
+      ${CMD} rm -f /etc/kubernetes/super-admin.conf || exit 1
       ${CMD} kubeadm certs renew super-admin.conf || exit 1
       ${CMD} kubeadm certs check-expiration || exit 1
 
       # Cleanup
-      ${CMD} rm -f /etc/kubernetes/pki/ca.*
-      ${CMD} rm -f /etc/kubernetes/pki/apiserver-kubelet-client.crt
-      ${CMD} rm -f /etc/kubernetes/*.conf
+      ${CMD} rm -f /etc/kubernetes/pki/*.* || exit 1
+      ${CMD} rm -f /etc/kubernetes/*.* || exit 1
 
       # Ensure exit status of 0
       exit 0
@@ -130,7 +129,7 @@ tasks:
       ${CMD} openssl x509 -subject -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = kubeadm:cluster-admins, CN = kube-apiserver-kubelet-client" || exit 1
 
       # Delete super-admin.conf to make sure this version of kubeadm creates it on upgrade
-      ${CMD} rm -f /etc/kubernetes/super-admin.conf
+      ${CMD} rm -f /etc/kubernetes/super-admin.conf || exit 1
 
       # Ensure exit status of 0
       exit 0

--- a/kinder/ci/workflows/super-admin-tasks.yaml
+++ b/kinder/ci/workflows/super-admin-tasks.yaml
@@ -84,14 +84,13 @@ tasks:
       ${CMD} kubeadm certs check-expiration || exit 1
 
       # Delete super-admin.conf and make sure check-expiration and renew do not return errors
-      ${CMD} rm -f /etc/kubernetes/super-admin.conf
+      ${CMD} rm -f /etc/kubernetes/super-admin.conf || exit 1
       ${CMD} kubeadm certs renew super-admin.conf || exit 1
       ${CMD} kubeadm certs check-expiration || exit 1
 
       # Cleanup
-      ${CMD} rm -f /etc/kubernetes/pki/ca.*
-      ${CMD} rm -f /etc/kubernetes/pki/apiserver-kubelet-client.crt
-      ${CMD} rm -f /etc/kubernetes/*.conf
+      ${CMD} rm -f /etc/kubernetes/pki/*.* || exit 1
+      ${CMD} rm -f /etc/kubernetes/*.* || exit 1
 
       # Ensure exit status of 0
       exit 0
@@ -131,7 +130,7 @@ tasks:
       ${CMD} openssl x509 -subject -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = kubeadm:cluster-admins, CN = kube-apiserver-kubelet-client" || exit 1
 
       # Delete super-admin.conf to make sure this version of kubeadm creates it on upgrade
-      ${CMD} rm -f /etc/kubernetes/super-admin.conf
+      ${CMD} rm -f /etc/kubernetes/super-admin.conf || exit 1
 
       # Ensure exit status of 0
       exit 0


### PR DESCRIPTION
Calling "rm -f" should be done with "exit 1".
Let's see if docker flakes and sometimes this does not work.

Do proper cleanup of all files in /etc/kubernetes and /etc/kubernetes/pki.

fixes https://github.com/kubernetes/kubeadm/issues/2961
