### PR TITLE
kinder: double-quote 'rm -f' paths to avoid single quotes

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/super-admin-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/super-admin-tasks.yaml
@@ -83,13 +83,13 @@ tasks:
       ${CMD} kubeadm certs check-expiration || exit 1
 
       # Delete super-admin.conf and make sure check-expiration and renew do not return errors
-      ${CMD} rm -f /etc/kubernetes/super-admin.conf || exit 1
+      ${CMD} rm -f "/etc/kubernetes/super-admin.conf" || exit 1
       ${CMD} kubeadm certs renew super-admin.conf || exit 1
       ${CMD} kubeadm certs check-expiration || exit 1
 
       # Cleanup
-      ${CMD} rm -f /etc/kubernetes/pki/*.* || exit 1
-      ${CMD} rm -f /etc/kubernetes/*.* || exit 1
+      ${CMD} rm -f "/etc/kubernetes/pki/*.*" || exit 1
+      ${CMD} rm -f "/etc/kubernetes/*.*" || exit 1
 
       # Ensure exit status of 0
       exit 0
@@ -129,7 +129,7 @@ tasks:
       ${CMD} openssl x509 -subject -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = kubeadm:cluster-admins, CN = kube-apiserver-kubelet-client" || exit 1
 
       # Delete super-admin.conf to make sure this version of kubeadm creates it on upgrade
-      ${CMD} rm -f /etc/kubernetes/super-admin.conf || exit 1
+      ${CMD} rm -f "/etc/kubernetes/super-admin.conf" || exit 1
 
       # Ensure exit status of 0
       exit 0

--- a/kinder/ci/workflows/super-admin-tasks.yaml
+++ b/kinder/ci/workflows/super-admin-tasks.yaml
@@ -84,13 +84,13 @@ tasks:
       ${CMD} kubeadm certs check-expiration || exit 1
 
       # Delete super-admin.conf and make sure check-expiration and renew do not return errors
-      ${CMD} rm -f /etc/kubernetes/super-admin.conf || exit 1
+      ${CMD} rm -f "/etc/kubernetes/super-admin.conf" || exit 1
       ${CMD} kubeadm certs renew super-admin.conf || exit 1
       ${CMD} kubeadm certs check-expiration || exit 1
 
       # Cleanup
-      ${CMD} rm -f /etc/kubernetes/pki/*.* || exit 1
-      ${CMD} rm -f /etc/kubernetes/*.* || exit 1
+      ${CMD} rm -f "/etc/kubernetes/pki/*.*" || exit 1
+      ${CMD} rm -f "/etc/kubernetes/*.*" || exit 1
 
       # Ensure exit status of 0
       exit 0
@@ -130,7 +130,7 @@ tasks:
       ${CMD} openssl x509 -subject -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = kubeadm:cluster-admins, CN = kube-apiserver-kubelet-client" || exit 1
 
       # Delete super-admin.conf to make sure this version of kubeadm creates it on upgrade
-      ${CMD} rm -f /etc/kubernetes/super-admin.conf || exit 1
+      ${CMD} rm -f "/etc/kubernetes/super-admin.conf" || exit 1
 
       # Ensure exit status of 0
       exit 0


### PR DESCRIPTION
During "bash -c" expansion if the following is called:
`  rm -f path/*.*`

bash (for some reason) will single quote the path because of the '*':
`  rm -f 'path/*.*'`

This is actually no longer a valid wildcard, as * inside a '...' is not expanded. To prevent that use double-quotes:
`  rm -f "path/*.*"`

xref https://github.com/kubernetes/kubeadm/pull/2962#discussion_r1392160039