### PR TITLE
kinder: remove the handling of 1.25 and older versions of k8s

### DIFF
--- a/kinder/pkg/build/alter/alter.go
+++ b/kinder/pkg/build/alter/alter.go
@@ -149,16 +149,11 @@ func (c *Context) Alter() (err error) {
 	// initialize bits installers
 	var bitsInstallers []bits.Installer
 
-	// TODO: remove the KubeadmBinaryVer workaround once we no longer test the kubeadm 1.25 / k8s 1.24 skew.
-	// See pkg/cri/host/archive.go.
-
-	host.KubeadmBinaryVer = c.initArtifactsSrc
 	if c.initArtifactsSrc != "" {
 		bitsInstallers = append(bitsInstallers, bits.NewInitBits(c.initArtifactsSrc))
 	}
 
 	if c.kubeadmSrc != "" {
-		host.KubeadmBinaryVer = c.kubeadmSrc
 		bitsInstallers = append(bitsInstallers, bits.NewBinaryBits(c.kubeadmSrc, "kubeadm"))
 	}
 	if c.kubeletSrc != "" {

--- a/kinder/pkg/cluster/manager/actions/kubeadm-upgrade.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-upgrade.go
@@ -125,11 +125,7 @@ func kubeadmUpgradeApply(c *status.Cluster, cp1 *status.Node, upgradeVersion *K8
 		"upgrade", "apply", "-f", fmt.Sprintf("v%s", upgradeVersion), fmt.Sprintf("--v=%d", vLevel),
 	}
 	if patchesDir != "" {
-		if cp1.MustKubeadmVersion().LessThan(constants.V1_22) {
-			applyArgs = append(applyArgs, "--experimental-patches", constants.PatchesDir)
-		} else {
-			applyArgs = append(applyArgs, "--patches", constants.PatchesDir)
-		}
+		applyArgs = append(applyArgs, "--patches", constants.PatchesDir)
 	}
 	if len(featureGate) > 0 {
 		applyArgs = append(applyArgs, fmt.Sprintf("--feature-gates=%s", featureGate))
@@ -160,11 +156,7 @@ func kubeadmUpgradeNode(c *status.Cluster, n *status.Node, upgradeVersion *K8sVe
 		"upgrade", "node", fmt.Sprintf("--v=%d", vLevel),
 	}
 	if patchesDir != "" {
-		if n.MustKubeadmVersion().LessThan(constants.V1_22) {
-			nodeArgs = append(nodeArgs, fmt.Sprintf("--experimental-patches=%s", constants.PatchesDir))
-		} else {
-			nodeArgs = append(nodeArgs, fmt.Sprintf("--patches=%s", constants.PatchesDir))
-		}
+		nodeArgs = append(nodeArgs, fmt.Sprintf("--patches=%s", constants.PatchesDir))
 	}
 	if err := n.Command(
 		"kubeadm", nodeArgs...,

--- a/kinder/pkg/cluster/manager/actions/waiter.go
+++ b/kinder/pkg/cluster/manager/actions/waiter.go
@@ -329,12 +329,6 @@ func staticPodHasVersion(pod, version string) func(c *status.Cluster, n *status.
 func kubeletHasRBAC(major, minor uint) func(c *status.Cluster, n *status.Node) bool {
 	return func(c *status.Cluster, n *status.Node) bool {
 		for i := 0; i < 5; i++ {
-			// Try the new kubelet config naming scheme and fallback to the old one.
-			//
-			// TODO: remove handling of the old CM once kinder no longer
-			// manages clusters with the legacy kubelet ConfigMap -
-			// i.e. when 1.24 is out of support.
-			// https://github.com/kubernetes/kubeadm/issues/1582
 			output1 := kubectlOutput(n,
 				"auth",
 				"can-i",
@@ -343,16 +337,6 @@ func kubeletHasRBAC(major, minor uint) func(c *status.Cluster, n *status.Node) b
 				"--namespace=kube-system",
 				"configmaps/kubelet-config",
 			)
-			if output1 != "yes" {
-				output1 = kubectlOutput(n,
-					"auth",
-					"can-i",
-					"get",
-					"--kubeconfig=/etc/kubernetes/kubelet.conf",
-					"--namespace=kube-system",
-					fmt.Sprintf("configmaps/kubelet-config-%d.%d", major, minor),
-				)
-			}
 			output2 := kubectlOutput(n,
 				"auth",
 				"can-i",

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package constants
 
-import (
-	K8sVersion "k8s.io/apimachinery/pkg/util/version"
-)
-
 // constants inherited from kind.
 // those values are replicated here with the goal to keep under strict control kind dependencies
 const (
@@ -114,12 +110,6 @@ const (
 
 	// PatchesDir defines the path to patches stored on node
 	PatchesDir = "/kinder/patches"
-)
-
-// kubernetes releases, used for branching code according to K8s release or kubeadm release version
-var (
-	// V1.22 minor version
-	V1_22 = K8sVersion.MustParseSemantic("v1.22.0-0")
 )
 
 // other constants


### PR DESCRIPTION
- Remove the repository replace from k8s.gcr.io -> registry.k8s.io
- Remove "kubelet-config-x.yy" handling, use "kubelet-config"
- Stop untainting "master" taints, only untaint control-plane taints
- Stop handling --experimental-patches, use --patches

xref https://github.com/kubernetes/kubeadm/issues/2910