### PR TITLE
kinder: call "upgrade plan" before "upgrade apply"

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/upgrade-latest-no-addon-config-maps.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/upgrade-latest-no-addon-config-maps.yaml
@@ -83,12 +83,13 @@ tasks:
 - name: upgrade-control-plane
   description: |
     Upgrades the control-plane node to the same version of the existing control-plane. This verifies
-    that "kubeadm upgrade apply" tolerates missing addon ConfigMaps. Ignoring preflight errors
+    that "kubeadm upgrade apply/plan" tolerate missing addon ConfigMaps. Ignoring preflight errors
     is still required due to CoreDNS checks.
   cmd: /bin/sh
   args:
     - -c
     - |
+      docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm upgrade plan --ignore-preflight-errors=CoreDNSMigration,CoreDNSUnsupportedPlugins --v={{ .vars.kubeadmVerbosity }} {{ .vars.initVersion }}
       docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm upgrade apply -f --ignore-preflight-errors=CoreDNSMigration,CoreDNSUnsupportedPlugins --v={{ .vars.kubeadmVerbosity }} {{ .vars.initVersion }}
   timeout: 5m
 - name: delete

--- a/kinder/ci/workflows/upgrade-latest-no-addon-config-maps.yaml
+++ b/kinder/ci/workflows/upgrade-latest-no-addon-config-maps.yaml
@@ -84,12 +84,13 @@ tasks:
 - name: upgrade-control-plane
   description: |
     Upgrades the control-plane node to the same version of the existing control-plane. This verifies
-    that "kubeadm upgrade apply" tolerates missing addon ConfigMaps. Ignoring preflight errors
+    that "kubeadm upgrade apply/plan" tolerate missing addon ConfigMaps. Ignoring preflight errors
     is still required due to CoreDNS checks.
   cmd: /bin/sh
   args:
     - -c
     - |
+      docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm upgrade plan --ignore-preflight-errors=CoreDNSMigration,CoreDNSUnsupportedPlugins --v={{ .vars.kubeadmVerbosity }} {{ .vars.initVersion }}
       docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm upgrade apply -f --ignore-preflight-errors=CoreDNSMigration,CoreDNSUnsupportedPlugins --v={{ .vars.kubeadmVerbosity }} {{ .vars.initVersion }}
   timeout: 5m
 - name: delete


### PR DESCRIPTION
During the kinder "kubeadm-upgrade" action, "upgrade apply"
is executed, but "upgrade plan" is not. To ensure better coverage
ensure "upgrade plan" is called as well. We have this command
as part of the kubeadm upgrade docs, so it makes sense to have
it here.

Ensure that "plan" is also called during the
"upgrade-latest-no-addon-config-maps" workflow.

NOTE: untested locally, but the presubmit job here should catch problems. i think this is all that has to be done.

fixes https://github.com/kubernetes/kubeadm/issues/2971
