### PR TITLE
kinder: fix a bug related to --only-node usage

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/discovery-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/discovery-tasks.yaml
@@ -64,7 +64,7 @@ tasks:
     - do
     - kubeadm-join
     - --name={{ .vars.clusterName }}
-    - --only-node=kinder-discovery-worker
+    - --only-node=kinder-discovery-worker-1
     - --discovery-mode=file
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
@@ -77,7 +77,7 @@ tasks:
     - do
     - kubeadm-join
     - --name={{ .vars.clusterName }}
-    - --only-node=kinder-discovery-worker2
+    - --only-node=kinder-discovery-worker-2
     - --discovery-mode=file-with-token
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
@@ -90,7 +90,7 @@ tasks:
     - do
     - kubeadm-join
     - --name={{ .vars.clusterName }}
-    - --only-node=kinder-discovery-worker3
+    - --only-node=kinder-discovery-worker-3
     - --discovery-mode=file-with-embedded-client-certificates
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
@@ -103,7 +103,7 @@ tasks:
     - do
     - kubeadm-join
     - --name={{ .vars.clusterName }}
-    - --only-node=kinder-discovery-worker4
+    - --only-node=kinder-discovery-worker-4
     - --discovery-mode=file-with-external-client-certificates
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}

--- a/kinder/ci/workflows/discovery-tasks.yaml
+++ b/kinder/ci/workflows/discovery-tasks.yaml
@@ -65,7 +65,7 @@ tasks:
     - do
     - kubeadm-join
     - --name={{ .vars.clusterName }}
-    - --only-node=kinder-discovery-worker
+    - --only-node=kinder-discovery-worker-1
     - --discovery-mode=file
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
@@ -78,7 +78,7 @@ tasks:
     - do
     - kubeadm-join
     - --name={{ .vars.clusterName }}
-    - --only-node=kinder-discovery-worker2
+    - --only-node=kinder-discovery-worker-2
     - --discovery-mode=file-with-token
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
@@ -91,7 +91,7 @@ tasks:
     - do
     - kubeadm-join
     - --name={{ .vars.clusterName }}
-    - --only-node=kinder-discovery-worker3
+    - --only-node=kinder-discovery-worker-3
     - --discovery-mode=file-with-embedded-client-certificates
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
@@ -104,7 +104,7 @@ tasks:
     - do
     - kubeadm-join
     - --name={{ .vars.clusterName }}
-    - --only-node=kinder-discovery-worker4
+    - --only-node=kinder-discovery-worker-4
     - --discovery-mode=file-with-external-client-certificates
     - --loglevel=debug
     - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}

--- a/kinder/cmd/kinder/do/do.go
+++ b/kinder/cmd/kinder/do/do.go
@@ -159,7 +159,9 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) (err error) {
 
 	// eventually, instruct the cluster manager to run only commands on one node
 	if flags.OnlyNode != "" {
-		o.OnlyNode(flags.OnlyNode)
+		if err := o.OnlyNode(flags.OnlyNode); err != nil {
+			return err
+		}
 	}
 
 	// eventually, instruct the cluster manager to dry run commands (without actually running them)

--- a/kinder/pkg/cluster/manager/manage.go
+++ b/kinder/pkg/cluster/manager/manage.go
@@ -73,12 +73,20 @@ func (c *ClusterManager) DryRun() {
 }
 
 // OnlyNode instruct the cluster manager to run only commands on one node
-func (c *ClusterManager) OnlyNode(node string) {
+func (c *ClusterManager) OnlyNode(node string) error {
+	found := false
 	for _, n := range c.Cluster.AllNodes() {
-		if n.Name() != node {
-			n.SkipActions()
+		if n.Name() == node {
+			log.Infof("Found matching node for --only-node: %s", node)
+			found = true
+			continue
 		}
+		n.SkipActions()
 	}
+	if !found {
+		return errors.Errorf("did not find a matching node for --only-node: %s", node)
+	}
+	return nil
 }
 
 // DoAction actions on kind(er) cluster


### PR DESCRIPTION
- If the --only-node flag specifies an unknown node name, kinder should throw an error.
- Update discovery workflows to pass correct node suffixes "-N" instead of "N", and also missing number for the first worker.

this actually meant that our discovery tests were not running properly as worker nodes were never joined using the various discovery modes in the discovery-tasks.yaml.

related to CI failures:
https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-discovery-latest

and this PR:
https://github.com/kubernetes/kubernetes/pull/122619
