### PR TITLE
kinder: include upgrades and cluster-info in external CA workflows

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-ca-tasks.yaml
@@ -83,9 +83,18 @@ tasks:
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
     timeout: 10m
-  - name: e2e-kubeadm
+  - name: cluster-info-before
     description: |
-      Runs kubeadm e2e tests
+      Runs cluster-info on the cluster before upgrade
+    cmd: kinder
+    args:
+      - do
+      - cluster-info
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+  - name: e2e-kubeadm-before
+    description: |
+      Runs kubeadm e2e test on the cluster before upgrade
     cmd: kinder
     args:
       - test
@@ -94,6 +103,50 @@ tasks:
       - --name={{ .vars.clusterName }}
       - --loglevel=debug
     timeout: 10m
+  - name: upgrade
+    description: |
+      upgrades the cluster to the same version
+    cmd: kinder
+    args:
+      - do
+      - kubeadm-upgrade
+      - --upgrade-version={{ .vars.kubernetesVersion }}
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+      - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    timeout: 15m
+  - name: cluster-info-after
+    description: |
+      Runs cluster-info on the cluster after upgrade
+    cmd: kinder
+    args:
+      - do
+      - cluster-info
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+  - name: e2e-kubeadm-after
+    description: |
+      Runs kubeadm e2e test on the cluster after upgrade
+    cmd: kinder
+    args:
+      - test
+      - e2e-kubeadm
+      - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-kubeadm
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+    timeout: 10m
+  - name: e2e-after
+    description: |
+      Runs Kubernetes e2e test (conformance) on the cluster with Kubernetes "upgradeVersion"
+    cmd: kinder
+    args:
+      - test
+      - e2e
+      - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
+      - --parallel
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+    timeout: 35m
   - name: get-logs
     description: |
       Collects all the test logs

--- a/kinder/ci/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/workflows/external-ca-tasks.yaml
@@ -84,9 +84,18 @@ tasks:
       - --loglevel=debug
       - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
     timeout: 10m
-  - name: e2e-kubeadm
+  - name: cluster-info-before
     description: |
-      Runs kubeadm e2e tests
+      Runs cluster-info on the cluster before upgrade
+    cmd: kinder
+    args:
+      - do
+      - cluster-info
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+  - name: e2e-kubeadm-before
+    description: |
+      Runs kubeadm e2e test on the cluster before upgrade
     cmd: kinder
     args:
       - test
@@ -95,6 +104,50 @@ tasks:
       - --name={{ .vars.clusterName }}
       - --loglevel=debug
     timeout: 10m
+  - name: upgrade
+    description: |
+      upgrades the cluster to the same version
+    cmd: kinder
+    args:
+      - do
+      - kubeadm-upgrade
+      - --upgrade-version={{ .vars.kubernetesVersion }}
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+      - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
+    timeout: 15m
+  - name: cluster-info-after
+    description: |
+      Runs cluster-info on the cluster after upgrade
+    cmd: kinder
+    args:
+      - do
+      - cluster-info
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+  - name: e2e-kubeadm-after
+    description: |
+      Runs kubeadm e2e test on the cluster after upgrade
+    cmd: kinder
+    args:
+      - test
+      - e2e-kubeadm
+      - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e-kubeadm
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+    timeout: 10m
+  - name: e2e-after
+    description: |
+      Runs Kubernetes e2e test (conformance) on the cluster with Kubernetes "upgradeVersion"
+    cmd: kinder
+    args:
+      - test
+      - e2e
+      - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
+      - --parallel
+      - --name={{ .vars.clusterName }}
+      - --loglevel=debug
+    timeout: 35m
   - name: get-logs
     description: |
       Collects all the test logs


### PR DESCRIPTION
The workflow already includes upgrade artifacts with the same k8s version. Perform upgrade and do cluster-info and kubeadm-e2e before and after the upgrade.

xref https://github.com/kubernetes/kubeadm/issues/3055

/hold
hold until https://github.com/kubernetes/kubernetes/pull/124682 merges as these changes will fail on 1.29 otherwise.