### PR TITLE
kinder: prepull the kindnet image when building the node image

### DIFF
--- a/kinder/pkg/build/alter/alter.go
+++ b/kinder/pkg/build/alter/alter.go
@@ -28,6 +28,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"k8s.io/kubeadm/kinder/pkg/build/bits"
+	"k8s.io/kubeadm/kinder/pkg/cluster/manager/actions/assets"
 	"k8s.io/kubeadm/kinder/pkg/cluster/status"
 	"k8s.io/kubeadm/kinder/pkg/cri/host"
 	"k8s.io/kubeadm/kinder/pkg/cri/nodes"
@@ -362,6 +363,9 @@ func (c *Context) alterImage(bitsInstallers []bits.Installer, bc *bits.BuildCont
 		if err != nil {
 			return err
 		}
+
+		// add the kindnet image
+		images = append(images, assets.KindnetImage054)
 
 		if err := pullImages(alterHelper, bc, images, filepath.Join(initPath, "images"), containerID); err != nil {
 			return err

--- a/kinder/pkg/cluster/manager/actions/assets/kindnet.go
+++ b/kinder/pkg/cluster/manager/actions/assets/kindnet.go
@@ -16,6 +16,9 @@ limitations under the License.
 
 package assets
 
+// KindnetImage054 is the image for kindnet 0.5.4
+const KindnetImage054 = "kindest/kindnetd:0.5.4"
+
 // KindnetManifest054 holds the kindnet manifest for 0.5.4
 const KindnetManifest054 = `
 # kindnetd networking manifest


### PR DESCRIPTION
The CNI (kindnet) image was the only image that was not prepulled during the creation of a node image. This allows kinder to deploy the cluster without every node having to pull the CNI image.