### PR TITLE
Update pull.go: Fix Typo, And a suggestion

### DIFF
--- a/kinder/pkg/cri/host/pull.go
+++ b/kinder/pkg/cri/host/pull.go
@@ -28,7 +28,7 @@ import (
 func PullImage(image string, retries int) (bool, error) {
 	// once we have configurable log levels
 	// if this did not return an error, then the image exists locally
-	if err := exec.NewHostCmd("docker", "inspect", "--type=image", image); err == nil {
+	if err := exec.NewHostCmd("docker", "inspect", "--type=image", image).Run(); err == nil {
 		return false, nil
 	}
 


### PR DESCRIPTION
I was wondering why each time I use `kinder create cluster ...`, connections to `auth.docker.io` and `registry-1.docker.io` would be made. Then I found this typo.

Besides, to keep in accordance with KinD, I think that `imagePullPolicy: "Never"` can be provided **(or becoming configurable)** in `kinder/pkg/kubeadm/config.go` (variable `configTemplateBetaV2` and `configTemplateBetaV3`) to make clustion creation process fully offline-friendly.

If I were wrong, please point out. Thanks!

edit neolit123
fixes https://github.com/kubernetes/kubeadm/issues/3059
