### PR TITLE
kinder: use "--config" for kubeadm "reset" and "upgrade"

### DIFF
--- a/kinder/pkg/cluster/manager/actions/actions.go
+++ b/kinder/pkg/cluster/manager/actions/actions.go
@@ -40,7 +40,7 @@ var actionRegistry = map[string]func(*status.Cluster, *RunOptions) error{
 	"kubeadm-config": func(c *status.Cluster, flags *RunOptions) error {
 		// Nb. this action is invoked automatically at kubeadm init/join time, but it is possible
 		// to invoke it separately as well
-		return KubeadmConfig(c, flags.kubeadmConfigVersion, flags.copyCertsMode, flags.discoveryMode, flags.featureGate, flags.encryptionAlgorithm, c.K8sNodes().EligibleForActions()...)
+		return KubeadmConfig(c, flags.kubeadmConfigVersion, flags.copyCertsMode, flags.discoveryMode, flags.featureGate, flags.encryptionAlgorithm, flags.upgradeVersion, c.K8sNodes().EligibleForActions()...)
 	},
 	"kubeadm-init": func(c *status.Cluster, flags *RunOptions) error {
 		return KubeadmInit(c, flags.usePhases, flags.copyCertsMode, flags.kubeadmConfigVersion, flags.patchesDir, flags.ignorePreflightErrors, flags.featureGate, flags.encryptionAlgorithm, flags.wait, flags.vLevel)
@@ -49,7 +49,7 @@ var actionRegistry = map[string]func(*status.Cluster, *RunOptions) error{
 		return KubeadmJoin(c, flags.usePhases, flags.copyCertsMode, flags.discoveryMode, flags.kubeadmConfigVersion, flags.patchesDir, flags.ignorePreflightErrors, flags.wait, flags.vLevel)
 	},
 	"kubeadm-upgrade": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmUpgrade(c, flags.upgradeVersion, flags.patchesDir, flags.featureGate, flags.wait, flags.vLevel)
+		return KubeadmUpgrade(c, flags.upgradeVersion, flags.patchesDir, flags.wait, flags.vLevel)
 	},
 	"kubeadm-reset": func(c *status.Cluster, flags *RunOptions) error {
 		return KubeadmReset(c, flags.vLevel)

--- a/kinder/pkg/cluster/manager/actions/kubeadm-reset.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-reset.go
@@ -19,16 +19,36 @@ package actions
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"k8s.io/kubeadm/kinder/pkg/cluster/status"
+	"k8s.io/kubeadm/kinder/pkg/constants"
+	"k8s.io/kubeadm/kinder/pkg/kubeadm"
 )
 
 // KubeadmReset executes the kubeadm reset workflow
 func KubeadmReset(c *status.Cluster, vLevel int) error {
 	//TODO: implements kubeadm reset with phases
 	for _, n := range c.K8sNodes().EligibleForActions() {
-		if err := n.Command(
-			"kubeadm", "reset", "--force", fmt.Sprintf("--v=%d", vLevel),
-		).RunWithEcho(); err != nil {
+		flags := []string{"reset", fmt.Sprintf("--v=%d", vLevel)}
+
+		// After upgrade, the 'kubeadm version' should return the version of the kubeadm used
+		// to perform the upgrade. Use this version to determine if v1beta4 is enabled. If yes,
+		// use ResetConfiguration with a 'force: true', else just use the '--force' flag.
+		v, err := n.KubeadmVersion()
+		if err != nil {
+			return errors.Wrap(err, "could not obtain the kubeadm version before calling 'kubeadm reset'")
+		}
+		if kubeadm.GetKubeadmConfigVersion(v) == "v1beta4" {
+			if err := KubeadmResetConfig(c, n); err != nil {
+				return errors.Wrap(err, "could not write kubeadm config before calling 'kubeadm reset'")
+			}
+			flags = append(flags, "--config", constants.KubeadmConfigPath)
+		} else {
+			flags = append(flags, "--force")
+		}
+
+		if err := n.Command("kubeadm", flags...).RunWithEcho(); err != nil {
 			return err
 		}
 	}

--- a/kinder/pkg/kubeadm/componentpatches.go
+++ b/kinder/pkg/kubeadm/componentpatches.go
@@ -28,21 +28,29 @@ import (
 // to use patches directory.
 func GetPatchesDirectoryPatches(kubeadmConfigVersion string) ([]string, error) {
 	log.Debugf("Preparing patches directory for kubeadm config %s", kubeadmConfigVersion)
-	var patchInit, patchJoin string
+	var patchInit, patchJoin, patchUpgradeApply, patchUpgradeNode string
 	switch kubeadmConfigVersion {
 	case "v1beta3":
 		patchInit = patchesDirectoryPatchInitv1beta3
 		patchJoin = patchesDirectoryPatchJoinv1beta3
+		return []string{
+			fmt.Sprintf(patchInit, constants.PatchesDir),
+			fmt.Sprintf(patchJoin, constants.PatchesDir),
+		}, nil
 	case "v1beta4":
 		patchInit = patchesDirectoryPatchInitv1beta4
 		patchJoin = patchesDirectoryPatchJoinv1beta4
+		patchUpgradeApply = patchesDirectoryPatchUpgradeApplyv1beta4
+		patchUpgradeNode = patchesDirectoryPatchUpgradeNodev1beta4
+		return []string{
+			fmt.Sprintf(patchInit, constants.PatchesDir),
+			fmt.Sprintf(patchJoin, constants.PatchesDir),
+			fmt.Sprintf(patchUpgradeApply, constants.PatchesDir),
+			fmt.Sprintf(patchUpgradeNode, constants.PatchesDir),
+		}, nil
 	default:
 		return []string{}, errors.Errorf("unknown kubeadm config version: %s", kubeadmConfigVersion)
 	}
-	return []string{
-		fmt.Sprintf(patchInit, constants.PatchesDir),
-		fmt.Sprintf(patchJoin, constants.PatchesDir),
-	}, nil
 }
 
 const patchesDirectoryPatchInitv1beta3 = `apiVersion: kubeadm.k8s.io/v1beta3
@@ -64,3 +72,15 @@ const patchesDirectoryPatchJoinv1beta4 = `apiVersion: kubeadm.k8s.io/v1beta4
 kind: JoinConfiguration
 patches:
   directory: %s`
+
+const patchesDirectoryPatchUpgradeApplyv1beta4 = `apiVersion: kubeadm.k8s.io/v1beta4
+kind: UpgradeConfiguration
+apply:
+  patches:
+    directory: %s`
+
+const patchesDirectoryPatchUpgradeNodev1beta4 = `apiVersion: kubeadm.k8s.io/v1beta4
+kind: UpgradeConfiguration
+node:
+  patches:
+    directory: %s`

--- a/kinder/pkg/kubeadm/config.go
+++ b/kinder/pkg/kubeadm/config.go
@@ -100,6 +100,8 @@ type ConfigData struct {
 	FeatureGateValue string
 	// The encryption algorithm
 	EncryptionAlgorithm string
+	// UpgradeVersion is the version passed to kubeadm upgrade
+	UpgradeVersion string
 	// DerivedConfigData is populated by Derive()
 	// These auto-generated fields are available to Config templates,
 	// but not meant to be set by hand
@@ -194,6 +196,29 @@ discovery:
     apiServerEndpoint: "{{ .ControlPlaneEndpoint }}"
     token: "{{ .Token }}"
     unsafeSkipCAVerification: true
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: UpgradeConfiguration
+plan:
+  kubernetesVersion: {{.UpgradeVersion}}
+  allowExperimentalUpgrades: true
+  allowRCUpgrades: true
+node:
+  patches:
+    directory: "/kinder/patches"
+diff:
+  kubernetesVersion: {{.UpgradeVersion}}
+apply:
+  kubernetesVersion: {{.UpgradeVersion}}
+  allowExperimentalUpgrades: true
+  allowRCUpgrades: true
+  forceUpgrade: true
+  patches:
+    directory: "/kinder/patches"
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ResetConfiguration
+force: true
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration


### PR DESCRIPTION
When executing "kubeadm reset" or "kubeadm upgrade", if the kubeadm version is 1.31 (or pre-release) pass the "--config" flag with the v1beta4 kinds. Else,
continue to call the flags for a given command.

Additionally:
- Call "kubeadm upgrade diff" on the primary CP node after calling "upgrade plan".
- Fallback to the /kinder/upgrade/version during upgrade if the provided version is different.

includes some smaller improvements like printing a config that is prepared for a command on multiple lines.

xref https://github.com/kubernetes/kubeadm/issues/2890
