### PR TITLE
kinder: fix typo in kubeadm-config.go

### DIFF
--- a/kinder/pkg/cluster/manager/actions/kubeadm-config.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-config.go
@@ -367,7 +367,7 @@ func getKubeadmConfig(c *status.Cluster, n *status.Node, data kubeadm.ConfigData
 	// otherwise select only the JoinConfiguration
 	return selectYamlFramentByKind(patched,
 		"JoinConfiguration",
-		"UpgradeCOnfiguration",
+		"UpgradeConfiguration",
 		"ResetConfiguration",
 	), nil
 }


### PR DESCRIPTION
fixes failing test job:
https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-patches-latest

fixes https://github.com/kubernetes/kubernetes/issues/125957

after this change:
- https://github.com/kubernetes/kubeadm/pull/3086

because of this the UpgradeConfiguration was missing on secondary control plane nodes and patches (as present in the config) were not applied.
