### PR TITLE
kubeadm: increase timeout for dryrun-without-cluster

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/dryrun-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/dryrun-tasks.yaml
@@ -73,7 +73,7 @@ tasks:
       docker exec {{ .vars.clusterName }}-control-plane-1 /kinder/upgrade/{{ .vars.upgradeVersion }}/kubeadm upgrade apply -f {{ .vars.upgradeVersion }} --ignore-preflight-errors={{ .vars.kubeadmIgnorePreflightErrors }} --allow-release-candidate-upgrades=true --allow-experimental-upgrades=true --dry-run --v={{ .vars.kubeadmVerbosity }} || exit 1
       docker exec {{ .vars.clusterName }}-control-plane-1 /kinder/upgrade/{{ .vars.upgradeVersion }}/kubeadm upgrade node --ignore-preflight-errors={{ .vars.kubeadmIgnorePreflightErrors }} --dry-run --v={{ .vars.kubeadmVerbosity }} || exit 1
       docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm reset --force=true --ignore-preflight-errors={{ .vars.kubeadmIgnorePreflightErrors }} --dry-run --v={{ .vars.kubeadmVerbosity }} || exit 1
-  timeout: 5m
+  timeout: 15m
 - name: init
   description: |
     Initializes the Kubernetes cluster with version "initVersion"

--- a/kinder/ci/workflows/dryrun-tasks.yaml
+++ b/kinder/ci/workflows/dryrun-tasks.yaml
@@ -74,7 +74,7 @@ tasks:
       docker exec {{ .vars.clusterName }}-control-plane-1 /kinder/upgrade/{{ .vars.upgradeVersion }}/kubeadm upgrade apply -f {{ .vars.upgradeVersion }} --ignore-preflight-errors={{ .vars.kubeadmIgnorePreflightErrors }} --allow-release-candidate-upgrades=true --allow-experimental-upgrades=true --dry-run --v={{ .vars.kubeadmVerbosity }} || exit 1
       docker exec {{ .vars.clusterName }}-control-plane-1 /kinder/upgrade/{{ .vars.upgradeVersion }}/kubeadm upgrade node --ignore-preflight-errors={{ .vars.kubeadmIgnorePreflightErrors }} --dry-run --v={{ .vars.kubeadmVerbosity }} || exit 1
       docker exec {{ .vars.clusterName }}-control-plane-1 kubeadm reset --force=true --ignore-preflight-errors={{ .vars.kubeadmIgnorePreflightErrors }} --dry-run --v={{ .vars.kubeadmVerbosity }} || exit 1
-  timeout: 5m
+  timeout: 15m
 - name: init
   description: |
     Initializes the Kubernetes cluster with version "initVersion"


### PR DESCRIPTION
kubeadm: increase timeout for dryrun-without-cluster

Hopefully, the execution can be complete in 15 minutes. Not sure what timeout should be set to.

fix: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kubeadm-kinder-dryrun-latest/1856721175695069184