### PR TITLE
move ignore preflight checks from flag to kubeadm configurations

### DIFF
--- a/kinder/pkg/cluster/manager/actions/actions.go
+++ b/kinder/pkg/cluster/manager/actions/actions.go
@@ -40,7 +40,7 @@ var actionRegistry = map[string]func(*status.Cluster, *RunOptions) error{
 	"kubeadm-config": func(c *status.Cluster, flags *RunOptions) error {
 		// Nb. this action is invoked automatically at kubeadm init/join time, but it is possible
 		// to invoke it separately as well
-		return KubeadmConfig(c, flags.kubeadmConfigVersion, flags.copyCertsMode, flags.discoveryMode, flags.featureGate, flags.encryptionAlgorithm, flags.upgradeVersion, c.K8sNodes().EligibleForActions()...)
+		return KubeadmConfig(c, flags.kubeadmConfigVersion, flags.copyCertsMode, flags.discoveryMode, flags.featureGate, flags.encryptionAlgorithm, flags.ignorePreflightErrors, flags.upgradeVersion, c.K8sNodes().EligibleForActions()...)
 	},
 	"kubeadm-init": func(c *status.Cluster, flags *RunOptions) error {
 		return KubeadmInit(c, flags.usePhases, flags.copyCertsMode, flags.kubeadmConfigVersion, flags.patchesDir, flags.ignorePreflightErrors, flags.featureGate, flags.encryptionAlgorithm, flags.wait, flags.vLevel)

--- a/kinder/pkg/cluster/manager/actions/actions.go
+++ b/kinder/pkg/cluster/manager/actions/actions.go
@@ -49,7 +49,7 @@ var actionRegistry = map[string]func(*status.Cluster, *RunOptions) error{
 		return KubeadmJoin(c, flags.usePhases, flags.copyCertsMode, flags.discoveryMode, flags.kubeadmConfigVersion, flags.patchesDir, flags.ignorePreflightErrors, flags.wait, flags.vLevel)
 	},
 	"kubeadm-upgrade": func(c *status.Cluster, flags *RunOptions) error {
-		return KubeadmUpgrade(c, flags.upgradeVersion, flags.patchesDir, flags.wait, flags.vLevel)
+		return KubeadmUpgrade(c, flags.upgradeVersion, flags.patchesDir, flags.ignorePreflightErrors, flags.wait, flags.vLevel)
 	},
 	"kubeadm-reset": func(c *status.Cluster, flags *RunOptions) error {
 		return KubeadmReset(c, flags.vLevel)

--- a/kinder/pkg/cluster/manager/actions/kubeadm-init.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-init.go
@@ -54,7 +54,7 @@ func KubeadmInit(c *status.Cluster, usePhases bool, copyCertsMode CopyCertsMode,
 	}
 
 	// prepares the kubeadm config on this node
-	if err := KubeadmInitConfig(c, kubeadmConfigVersion, copyCertsMode, featureGates, encryptionAlgorithm, cp1); err != nil {
+	if err := KubeadmInitConfig(c, kubeadmConfigVersion, copyCertsMode, featureGates, encryptionAlgorithm, ignorePreflightErrors, cp1); err != nil {
 		return err
 	}
 
@@ -65,9 +65,9 @@ func KubeadmInit(c *status.Cluster, usePhases bool, copyCertsMode CopyCertsMode,
 
 	// execs the kubeadm init workflow
 	if usePhases {
-		err = kubeadmInitWithPhases(cp1, copyCertsMode, ignorePreflightErrors, vLevel)
+		err = kubeadmInitWithPhases(cp1, copyCertsMode, vLevel)
 	} else {
-		err = kubeadmInit(cp1, copyCertsMode, ignorePreflightErrors, vLevel)
+		err = kubeadmInit(cp1, copyCertsMode, vLevel)
 	}
 	if err != nil {
 		return err
@@ -81,10 +81,9 @@ func KubeadmInit(c *status.Cluster, usePhases bool, copyCertsMode CopyCertsMode,
 	return nil
 }
 
-func kubeadmInit(cp1 *status.Node, copyCertsMode CopyCertsMode, ignorePreflightErrors string, vLevel int) error {
+func kubeadmInit(cp1 *status.Node, copyCertsMode CopyCertsMode, vLevel int) error {
 	initArgs := []string{
 		"init",
-		fmt.Sprintf("--ignore-preflight-errors=%s", ignorePreflightErrors),
 		fmt.Sprintf("--config=%s", constants.KubeadmConfigPath),
 		fmt.Sprintf("--v=%d", vLevel),
 	}
@@ -104,10 +103,9 @@ func kubeadmInit(cp1 *status.Node, copyCertsMode CopyCertsMode, ignorePreflightE
 	return nil
 }
 
-func kubeadmInitWithPhases(cp1 *status.Node, copyCertsMode CopyCertsMode, ignorePreflightErrors string, vLevel int) error {
+func kubeadmInitWithPhases(cp1 *status.Node, copyCertsMode CopyCertsMode, vLevel int) error {
 	if err := cp1.Command(
 		"kubeadm", "init", "phase", "preflight", fmt.Sprintf("--config=%s", constants.KubeadmConfigPath), fmt.Sprintf("--v=%d", vLevel),
-		fmt.Sprintf("--ignore-preflight-errors=%s", ignorePreflightErrors),
 	).RunWithEcho(); err != nil {
 		return err
 	}

--- a/kinder/pkg/cluster/manager/actions/kubeadm-join.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-join.go
@@ -63,15 +63,15 @@ func joinControlPlanes(c *status.Cluster, usePhases bool, copyCertsMode CopyCert
 		}
 
 		// prepares the kubeadm config on this node
-		if err := KubeadmJoinConfig(c, kubeadmConfigVersion, copyCertsMode, discoveryMode, cp2); err != nil {
+		if err := KubeadmJoinConfig(c, kubeadmConfigVersion, copyCertsMode, discoveryMode, ignorePreflightErrors, cp2); err != nil {
 			return err
 		}
 
 		// executes the kubeadm join control-plane workflow
 		if usePhases {
-			err = kubeadmJoinControlPlaneWithPhases(cp2, ignorePreflightErrors, vLevel)
+			err = kubeadmJoinControlPlaneWithPhases(cp2, vLevel)
 		} else {
-			err = kubeadmJoinControlPlane(cp2, ignorePreflightErrors, vLevel)
+			err = kubeadmJoinControlPlane(cp2, vLevel)
 		}
 		if err != nil {
 			return err
@@ -90,11 +90,10 @@ func joinControlPlanes(c *status.Cluster, usePhases bool, copyCertsMode CopyCert
 	return nil
 }
 
-func kubeadmJoinControlPlane(cp *status.Node, ignorePreflightErrors string, vLevel int) (err error) {
+func kubeadmJoinControlPlane(cp *status.Node, vLevel int) (err error) {
 	joinArgs := []string{
 		"join",
 		fmt.Sprintf("--config=%s", constants.KubeadmConfigPath),
-		fmt.Sprintf("--ignore-preflight-errors=%s", ignorePreflightErrors),
 		fmt.Sprintf("--v=%d", vLevel),
 	}
 
@@ -107,12 +106,11 @@ func kubeadmJoinControlPlane(cp *status.Node, ignorePreflightErrors string, vLev
 	return nil
 }
 
-func kubeadmJoinControlPlaneWithPhases(cp *status.Node, ignorePreflightErrors string, vLevel int) (err error) {
+func kubeadmJoinControlPlaneWithPhases(cp *status.Node, vLevel int) (err error) {
 	// kubeadm join phase preflight
 	preflightArgs := []string{
 		"join", "phase", "preflight",
 		fmt.Sprintf("--config=%s", constants.KubeadmConfigPath),
-		fmt.Sprintf("--ignore-preflight-errors=%s", ignorePreflightErrors),
 		fmt.Sprintf("--v=%d", vLevel),
 	}
 
@@ -177,15 +175,15 @@ func joinWorkers(c *status.Cluster, usePhases bool, discoveryMode DiscoveryMode,
 		}
 
 		// prepares the kubeadm config on this node
-		if err := KubeadmJoinConfig(c, kubeadmConfigVersion, CopyCertsModeNone, discoveryMode, w); err != nil {
+		if err := KubeadmJoinConfig(c, kubeadmConfigVersion, CopyCertsModeNone, discoveryMode, ignorePreflightErrors, w); err != nil {
 			return err
 		}
 
 		// executes the kubeadm join workflow
 		if usePhases {
-			err = kubeadmJoinWorkerWithPhases(w, ignorePreflightErrors, vLevel)
+			err = kubeadmJoinWorkerWithPhases(w, vLevel)
 		} else {
-			err = kubeadmJoinWorker(w, ignorePreflightErrors, vLevel)
+			err = kubeadmJoinWorker(w, vLevel)
 		}
 		if err != nil {
 			return err
@@ -198,11 +196,10 @@ func joinWorkers(c *status.Cluster, usePhases bool, discoveryMode DiscoveryMode,
 	return nil
 }
 
-func kubeadmJoinWorker(w *status.Node, ignorePreflightErrors string, vLevel int) (err error) {
+func kubeadmJoinWorker(w *status.Node, vLevel int) (err error) {
 	if err := w.Command(
 		"kubeadm", "join",
 		fmt.Sprintf("--config=%s", constants.KubeadmConfigPath),
-		fmt.Sprintf("--ignore-preflight-errors=%s", ignorePreflightErrors),
 		fmt.Sprintf("--v=%d", vLevel),
 	).RunWithEcho(); err != nil {
 		return err
@@ -211,12 +208,11 @@ func kubeadmJoinWorker(w *status.Node, ignorePreflightErrors string, vLevel int)
 	return nil
 }
 
-func kubeadmJoinWorkerWithPhases(w *status.Node, ignorePreflightErrors string, vLevel int) (err error) {
+func kubeadmJoinWorkerWithPhases(w *status.Node, vLevel int) (err error) {
 	// kubeadm join phase preflight
 	if err := w.Command(
 		"kubeadm", "join", "phase", "preflight",
 		fmt.Sprintf("--config=%s", constants.KubeadmConfigPath),
-		fmt.Sprintf("--ignore-preflight-errors=%s", ignorePreflightErrors),
 		fmt.Sprintf("--v=%d", vLevel),
 	).RunWithEcho(); err != nil {
 		return err

--- a/kinder/pkg/cluster/manager/actions/kubeadm-reset.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-reset.go
@@ -40,7 +40,7 @@ func KubeadmReset(c *status.Cluster, vLevel int) error {
 			return errors.Wrap(err, "could not obtain the kubeadm version before calling 'kubeadm reset'")
 		}
 		if kubeadm.GetKubeadmConfigVersion(v) == "v1beta4" {
-			if err := KubeadmResetConfig(c, n); err != nil {
+			if err := KubeadmResetConfig(c, "", n); err != nil {
 				return errors.Wrap(err, "could not write kubeadm config before calling 'kubeadm reset'")
 			}
 			flags = append(flags, "--config", constants.KubeadmConfigPath)

--- a/kinder/pkg/cluster/manager/actions/kubeadm-upgrade.go
+++ b/kinder/pkg/cluster/manager/actions/kubeadm-upgrade.go
@@ -37,7 +37,7 @@ import (
 //
 // The implementation assumes that the kubeadm/kubelet/kubectl binaries and all the necessary images
 // for the new kubernetes version are available in the /kinder/upgrade/{version} folder.
-func KubeadmUpgrade(c *status.Cluster, upgradeVersion *version.Version, patchesDir string, wait time.Duration, vLevel int) (err error) {
+func KubeadmUpgrade(c *status.Cluster, upgradeVersion *version.Version, patchesDir, ignorePreflightErrors string, wait time.Duration, vLevel int) (err error) {
 	if upgradeVersion == nil {
 		return errors.New("kubeadm-upgrade actions requires the --upgrade-version parameter to be set")
 	}
@@ -90,15 +90,15 @@ func KubeadmUpgrade(c *status.Cluster, upgradeVersion *version.Version, patchesD
 		kubeadmConfigVersion := kubeadm.GetKubeadmConfigVersion(v)
 
 		if n.Name() == c.BootstrapControlPlane().Name() {
-			if err := kubeadmUpgradePlan(c, n, kubeadmConfigVersion, upgradeVersion, vLevel); err != nil {
+			if err := kubeadmUpgradePlan(c, n, kubeadmConfigVersion, upgradeVersion, ignorePreflightErrors, vLevel); err != nil {
 				return err
 			}
 			if err := kubeadmUpgradeDiff(c, n, kubeadmConfigVersion, upgradeVersion, vLevel); err != nil {
 				return err
 			}
-			err = kubeadmUpgradeApply(c, n, kubeadmConfigVersion, upgradeVersion, patchesDir, wait, vLevel)
+			err = kubeadmUpgradeApply(c, n, kubeadmConfigVersion, upgradeVersion, patchesDir, ignorePreflightErrors, wait, vLevel)
 		} else {
-			err = kubeadmUpgradeNode(c, n, kubeadmConfigVersion, upgradeVersion, patchesDir, wait, vLevel)
+			err = kubeadmUpgradeNode(c, n, kubeadmConfigVersion, upgradeVersion, patchesDir, ignorePreflightErrors, wait, vLevel)
 		}
 		if err != nil {
 			return err
@@ -180,9 +180,10 @@ func kubeadmUpgradeDiff(c *status.Cluster, cp1 *status.Node, configVersion strin
 	return nil
 }
 
-func kubeadmUpgradePlan(c *status.Cluster, cp1 *status.Node, configVersion string, upgradeVersion *version.Version, vLevel int) error {
+func kubeadmUpgradePlan(c *status.Cluster, cp1 *status.Node, configVersion string, upgradeVersion *version.Version, ignorePreflightErrors, vLevel int) error {
 	planArgs := []string{
 		"upgrade", "plan", fmt.Sprintf("--v=%d", vLevel),
+		fmt.Sprintf("--ignore-preflight-errors=%s", ignorePreflightErrors),
 	}
 
 	if configVersion == "v1beta4" {
@@ -200,9 +201,10 @@ func kubeadmUpgradePlan(c *status.Cluster, cp1 *status.Node, configVersion strin
 	return nil
 }
 
-func kubeadmUpgradeApply(c *status.Cluster, cp1 *status.Node, configVersion string, upgradeVersion *version.Version, patchesDir string, wait time.Duration, vLevel int) error {
+func kubeadmUpgradeApply(c *status.Cluster, cp1 *status.Node, configVersion string, upgradeVersion *version.Version, patchesDir, ignorePreflightErrors string, wait time.Duration, vLevel int) error {
 	applyArgs := []string{
 		"upgrade", "apply", fmt.Sprintf("--v=%d", vLevel),
+		fmt.Sprintf("--ignore-preflight-errors=%s", ignorePreflightErrors),
 	}
 
 	if configVersion == "v1beta4" {
@@ -227,7 +229,7 @@ func kubeadmUpgradeApply(c *status.Cluster, cp1 *status.Node, configVersion stri
 	return nil
 }
 
-func kubeadmUpgradeNode(c *status.Cluster, n *status.Node, configVersion string, upgradeVersion *version.Version, patchesDir string, wait time.Duration, vLevel int) error {
+func kubeadmUpgradeNode(c *status.Cluster, n *status.Node, configVersion string, upgradeVersion *version.Version, patchesDir, ignorePreflightErrors string, wait time.Duration, vLevel int) error {
 	// waitKubeletHasRBAC waits for the kubelet to have access to the expected config map
 	// please note that this is a temporary workaround for a problem we are observing on upgrades while
 	// executing node upgrades immediately after control-plane upgrade.
@@ -238,6 +240,7 @@ func kubeadmUpgradeNode(c *status.Cluster, n *status.Node, configVersion string,
 	// kubeadm upgrade node
 	nodeArgs := []string{
 		"upgrade", "node", fmt.Sprintf("--v=%d", vLevel),
+		fmt.Sprintf("--ignore-preflight-errors=%s", ignorePreflightErrors),
 	}
 
 	if configVersion == "v1beta4" {

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -79,7 +79,7 @@ const (
 	KubeadmConfigPath = "/kind/kubeadm.conf"
 
 	// KubeadmIgnorePreflightErrors holds the default list of preflight errors to skip
-	// on "kubeadm init" and "kubeadm join"
+	// on "kubeadm init", "kubeadm join" and "kubeadm upgrade"
 	KubeadmIgnorePreflightErrors = "Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables"
 
 	// APIServerPort is the expected default APIServerPort on the control plane node(s)

--- a/kinder/pkg/kubeadm/config.go
+++ b/kinder/pkg/kubeadm/config.go
@@ -106,6 +106,8 @@ type ConfigData struct {
 	// These auto-generated fields are available to Config templates,
 	// but not meant to be set by hand
 	DerivedConfigData
+	// IgnorePreflightErrors is a list of preflight errors to ignore
+	IgnorePreflightErrors []string
 }
 
 // DerivedConfigData fields are automatically derived by
@@ -176,6 +178,9 @@ nodeRegistration:
   kubeletExtraArgs:
   - name: node-ip
     value: "{{ .NodeAddress }}"
+  ignorePreflightErrors:
+  {{range .IgnorePreflightErrors }}  - {{.}}
+  {{end}}
 ---
 # no-op entry that exists solely so it can be patched
 apiVersion: kubeadm.k8s.io/v1beta4
@@ -191,6 +196,9 @@ nodeRegistration:
   kubeletExtraArgs:
   - name: node-ip
     value: "{{ .NodeAddress }}"
+  ignorePreflightErrors:
+  {{range .IgnorePreflightErrors }}  - {{.}}
+  {{end}}
 discovery:
   bootstrapToken:
     apiServerEndpoint: "{{ .ControlPlaneEndpoint }}"
@@ -203,7 +211,13 @@ plan:
   kubernetesVersion: {{.UpgradeVersion}}
   allowExperimentalUpgrades: true
   allowRCUpgrades: true
+  ignorePreflightErrors:
+  {{range .IgnorePreflightErrors }}  - {{.}}
+  {{end}}
 node:
+  ignorePreflightErrors:
+  {{range .IgnorePreflightErrors }}  - {{.}}
+  {{end}}
   patches:
     directory: "/kinder/patches"
 diff:
@@ -213,6 +227,9 @@ apply:
   allowExperimentalUpgrades: true
   allowRCUpgrades: true
   forceUpgrade: true
+  ignorePreflightErrors:
+  {{range .IgnorePreflightErrors }}  - {{.}}
+  {{end}}
   patches:
     directory: "/kinder/patches"
 ---
@@ -296,6 +313,10 @@ nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
   kubeletExtraArgs:
     node-ip: "{{ .NodeAddress }}"
+  ignorePreflightErrors:
+  {{range .IgnorePreflightErrors }}  - {{.}}
+  {{end}}
+
 ---
 # no-op entry that exists solely so it can be patched
 apiVersion: kubeadm.k8s.io/v1beta3
@@ -310,6 +331,9 @@ nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
   kubeletExtraArgs:
     node-ip: "{{ .NodeAddress }}"
+  ignorePreflightErrors:
+  {{range .IgnorePreflightErrors }}  - {{.}}
+  {{end}}
 discovery:
   bootstrapToken:
     apiServerEndpoint: "{{ .ControlPlaneEndpoint }}"


### PR DESCRIPTION
refer to https://github.com/kubernetes/kubernetes/pull/129401

After we add `SystemVerification` check in upgrade, we need to skip in some kinder testing.

This PR follows the suggestions https://github.com/kubernetes/kubernetes/pull/129401#pullrequestreview-2525461483 to move flags to configurations.

- don't pass the --ignore-preflight errors as flags for commands.
- pass them via config in the big config that has all the config 'kinds'.