### PR TITLE
exit 0 after checking addon configmap existences

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/upgrade-no-addon-config-maps-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/upgrade-no-addon-config-maps-tasks.yaml
@@ -112,6 +112,8 @@ tasks:
     - |
       docker exec {{ .vars.clusterName }}-control-plane-1 kubectl get cm kube-proxy -n kube-system --kubeconfig /etc/kubernetes/admin.conf && exit 1
       docker exec {{ .vars.clusterName }}-control-plane-1 kubectl get cm coredns -n kube-system --kubeconfig /etc/kubernetes/admin.conf && exit 1
+      # Ensure exit status of 0
+      exit 0
   timeout: 5m
 - name: delete
   description: |

--- a/kinder/ci/workflows/upgrade-no-addon-config-maps-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-no-addon-config-maps-tasks.yaml
@@ -113,6 +113,8 @@ tasks:
     - |
       docker exec {{ .vars.clusterName }}-control-plane-1 kubectl get cm kube-proxy -n kube-system --kubeconfig /etc/kubernetes/admin.conf && exit 1
       docker exec {{ .vars.clusterName }}-control-plane-1 kubectl get cm coredns -n kube-system --kubeconfig /etc/kubernetes/admin.conf && exit 1
+      # Ensure exit status of 0
+      exit 0
   timeout: 5m
 - name: delete
   description: |


### PR DESCRIPTION
Fixes https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-no-addons-latest
Fixes #3144

```

# task-08-check-addons-after-upgrade
/bin/sh -c docker exec kinder-upgrade-control-plane-1 kubectl get cm kube-proxy -n kube-system --kubeconfig /etc/kubernetes/admin.conf && exit 1
docker exec kinder-upgrade-control-plane-1 kubectl get cm coredns -n kube-system --kubeconfig /etc/kubernetes/admin.conf && exit 1
Error from server (NotFound): configmaps "kube-proxy" not found
Error from server (NotFound): configmaps "coredns" not found
 exit status 1

```

/cc @neolit123 