### PR TITLE
kubeadm: fix periodic-kubernetes-e2e-manifest-lists failing test

### DIFF
--- a/tests/e2e/manifests/verify_manifest_lists.go
+++ b/tests/e2e/manifests/verify_manifest_lists.go
@@ -183,7 +183,7 @@ func (s VersionList) print() {
 		if i == len(s)-1 {
 			sep = "\n\n"
 		}
-		fmt.Printf(v.String() + sep)
+		fmt.Printf("%s%s", v.String(), sep)
 	}
 }
 


### PR DESCRIPTION
fix: #3167

