### PR TITLE
print go version and update to go 1.24 of verify-manfiest-lists.sh

### DIFF
--- a/kinder/ci/kinder-run.sh
+++ b/kinder/ci/kinder-run.sh
@@ -39,6 +39,7 @@ WORKFLOW_BUCKET_PATH="${SCRIPT_PATH}/workflows"
 # build kinder
 pushd "${ROOT_PATH}"
 echo "Building kinder..."
+go version
 GO111MODULE=on go build
 popd
 

--- a/tests/e2e/manifests/verify_manifest_lists.sh
+++ b/tests/e2e/manifests/verify_manifest_lists.sh
@@ -27,7 +27,7 @@ fi
 
 # install go if missing
 if ! `go version > /dev/null`; then
-	curl -sSL https://dl.google.com/go/go1.16.linux-amd64.tar.gz -o "/${TMP}/go.tar.gz"
+	curl -sSL https://go.dev/dl/go1.24.0.linux-amd64.tar.gz -o "/${TMP}/go.tar.gz"
 	tar -C /usr/local -xzf "/${TMP}/go.tar.gz"
 	export PATH="$PATH":/usr/local/go/bin
 	rm "/${TMP}/go.tar.gz"
@@ -48,7 +48,10 @@ cd "$LPATH"
 # use go modules. this forces using the latest k8s.io/apimachinery package.
 go mod init verify-manifest-lists
 
-# add module requirements and sums (required in go 1.16)
+# pin the apimachinery version
+printf "\nrequire k8s.io/apimachinery v0.32.2" >> go.mod
+
+# add module requirements and sums (required in go >1.16)
 go mod tidy
 
 # run unit tests

--- a/tests/e2e/manifests/verify_manifest_lists.sh
+++ b/tests/e2e/manifests/verify_manifest_lists.sh
@@ -31,6 +31,7 @@ if ! `go version > /dev/null`; then
 	tar -C /usr/local -xzf "/${TMP}/go.tar.gz"
 	export PATH="$PATH":/usr/local/go/bin
 	rm "/${TMP}/go.tar.gz"
+	go version
 fi
 
 # api-machinery requires gcc


### PR DESCRIPTION
- the old go 1.16 is throwing a strange error
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-kubernetes-e2e-manifest-lists/1896113622615068672

```
# [command-line-arguments]
./verify_manifest_lists.go:186:14: non-constant format string in call to fmt.Printf
FAIL	command-line-arguments [build failed]
FAIL
```

but the code is
`		fmt.Printf("%s%s", v.String(), sep)`

locally with newer go this error is not reproducible.

- bump to go 1.24 in varify_manifest_lists.sh and pin the api-machinery version to 0.32.
- print the go version in kinder / manifest test scripts.
