### PR TITLE
support-command.yaml: switch to 24.04 ubuntu

### DIFF
--- a/.github/workflows/support-command.yaml
+++ b/.github/workflows/support-command.yaml
@@ -6,7 +6,7 @@ jobs:
     permissions:
       issues: write
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: check for the /support command
         id: command


### PR DESCRIPTION
our `/support` command stopped working with this error: https://github.com/kubernetes/kubeadm/actions/runs/14342826037 seems like the ubuntu 20.04 runners are being removed.

```
This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15.
For more details, see https://github.com/actions/runner-images/issues/11101
```

failed here:
- https://github.com/kubernetes/kubeadm/issues/3179