### PR TITLE
ci(kinder): Upgrade encryption algorithm to ECDSA-P384

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/encryption-algorithm-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/encryption-algorithm-tasks.yaml
@@ -60,7 +60,7 @@ tasks:
   - --loglevel=debug
   - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   - --copy-certs=auto
-  - --kubeadm-encryption-algorithm=ECDSA-P256
+  - --kubeadm-encryption-algorithm=ECDSA-P384
   timeout: 5m
 - name: join
   description: |

--- a/kinder/ci/workflows/encryption-algorithm-tasks.yaml
+++ b/kinder/ci/workflows/encryption-algorithm-tasks.yaml
@@ -61,7 +61,7 @@ tasks:
   - --loglevel=debug
   - --kubeadm-verbosity={{ .vars.kubeadmVerbosity }}
   - --copy-certs=auto
-  - --kubeadm-encryption-algorithm=ECDSA-P256
+  - --kubeadm-encryption-algorithm=ECDSA-P384
   timeout: 5m
 - name: join
   description: |


### PR DESCRIPTION
Update the encryption algorithm from ECDSA-P256 to ECDSA-P384 for tasks used in encryption-algorithm-latest CI flow.


Corresponding changes went in  https://github.com/kubernetes/kubernetes/pull/131677