### PR TITLE
kinder: update version to v1.0.0

### DIFF
--- a/kinder/cmd/kinder/version/version.go
+++ b/kinder/cmd/kinder/version/version.go
@@ -32,7 +32,7 @@ func NewCommand() *cobra.Command {
 		Short: "prints the kinder CLI version",
 		Long:  "prints the kinder CLI version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Printf("kinder version: %s\n", constants.KinderVersion)
+			fmt.Printf("v%s\n", constants.KinderVersion)
 			return nil
 		},
 	}

--- a/kinder/pkg/constants/constants.go
+++ b/kinder/pkg/constants/constants.go
@@ -115,5 +115,5 @@ const (
 // other constants
 const (
 	// KinderVersion is the kinder CLI version
-	KinderVersion = "0.1.0-alpha.3"
+	KinderVersion = "1.0.0"
 )


### PR DESCRIPTION
kinder has been used for kubeadm e2e tests for many releases, but its version remained 0.x. Update the version to v1.0.0 to identify its stability.