### PR TITLE
[doc] Fix typo in ha-considerations.md

### DIFF
--- a/docs/ha-considerations.md
+++ b/docs/ha-considerations.md
@@ -253,7 +253,7 @@ With the services up, now the Kubernetes cluster can be bootstrapped using `kube
 
 ## kube-vip
 
-As an alternative to the more "traditional" approach of `keepalived` and `haproxy`, [kube-vip](https://kube-vip.io/) implements both management of a virtual IP and load balancing in one service. It can be implemented in bother layer2 (with ARP, and `leaderElection`) or layer3 utilising BGP peering. Similar to option 2 above, `kube-vip` will be run as a static pod on the control plane nodes.
+As an alternative to the more "traditional" approach of `keepalived` and `haproxy`, [kube-vip](https://kube-vip.io/) implements both management of a virtual IP and load balancing in one service. It can be implemented either as layer2 (with ARP, and `leaderElection`) or layer3 utilising BGP peering. Similar to option 2 above, `kube-vip` will be run as a static pod on the control plane nodes.
 
 Like with `keepalived`, the hosts negotiating a virtual IP need to be in the same IP subnet. Similarly, like with `haproxy`, stream-based load-balancing allows TLS termination to be handled by the API Server instances behind it.
 


### PR DESCRIPTION
https://github.com/kubernetes/kubeadm/blob/main/docs/ha-considerations.md#kube-vip , states word `bother` i assume it was meant to be word `both` instead.