### PR TITLE
Let kinder supports arm64

### DIFF
--- a/kinder/pkg/cri/nodes/containerd/alterhelper_test.go
+++ b/kinder/pkg/cri/nodes/containerd/alterhelper_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerd
+
+import (
+	"testing"
+)
+
+func TestParseImageArchSuffix(t *testing.T) {
+	cases := []struct {
+		input string
+		base  string
+		arch  string
+		tag   string
+	}{
+		{"registry.k8s.io/kube-apiserver-arm64:v1.34", "registry.k8s.io/kube-apiserver", "arm64", "v1.34"},
+		{"registry.k8s.io/kube-apiserver-amd64:v1.34", "registry.k8s.io/kube-apiserver", "amd64", "v1.34"},
+		{"registry.k8s.io/kube-apiserver:v1.34", "registry.k8s.io/kube-apiserver", "", "v1.34"},
+		{"registry.k8s.io/kube-apiserver:dev", "registry.k8s.io/kube-apiserver", "", "dev"},
+	}
+	for _, c := range cases {
+		base, arch, tag := parseImageArchSuffix(c.input)
+		if base != c.base || arch != c.arch || tag != c.tag {
+			t.Errorf("parseImageArchSuffix(%q) = (%q, %q, %q), want (%q, %q, %q)", c.input, base, arch, tag, c.base, c.arch, c.tag)
+		}
+	}
+}

--- a/kinder/pkg/extract/extract.go
+++ b/kinder/pkg/extract/extract.go
@@ -32,6 +32,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -313,7 +314,7 @@ func extractFromHTTP(src string, files []string, dst string, m fileNameMutator, 
 
 	// in case the source is a Kubernetes build, add bin/OS/ARCH to the src uri
 	if strings.HasPrefix(src, releaseBuildURepository) || strings.HasPrefix(src, ciBuildRepository) {
-		src = fmt.Sprintf("%s/bin/linux/amd64", src)
+		src = fmt.Sprintf("%s/bin/linux/%s", src, runtime.GOARCH)
 	}
 
 	// Download the files.


### PR DESCRIPTION
kinder doesn't support arm64, which has been quite troublesome for me during testing because my laptop use the arm64 architecture. Making it compatible with arm64 now.