### PR TITLE
[docs] Fix typo docs (managing-e2e-tests, release-cycle, testing-pre-releases)

### DIFF
--- a/docs/managing-e2e-tests.md
+++ b/docs/managing-e2e-tests.md
@@ -8,7 +8,7 @@ Kubernetes uses applications such as the web-based [testgrid](https://testgrid.k
 
 ### Prow job configuration
 
-The following folder contains all the SIG Cluster Lifecycle (the SIG that maintains kubeadm) originated test jobs:
+The following folder contains all the SIG Cluster Lifecycle (the SIG that maintains kubeadm) originating test jobs:
 [sig-cluster-lifecycle](https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-cluster-lifecycle)
 
 Please note that this document will only cover details on the `kubeadm*.yaml` files and only on some parameters

--- a/docs/release-cycle.md
+++ b/docs/release-cycle.md
@@ -49,7 +49,7 @@ That said, nothing here is set in stone. See this as inspiration :)
 - Start writing docs and e2e tests for the new features.
 - The kubeadm upgrade document needs a manual update each cycle:
 https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/
-- Go through the kubeadm related documents in the `kuberentes/website` and this repository and plan what has to be updated.
+- Go through the kubeadm related documents in the `kubernetes/website` and this repository and plan what has to be updated.
 - Watch for new features in core Kubernetes that may affect kubeadm. Discuss what action has to be taken
 by the kubeadm maintainers.
 - Make sure that existing e2e test jobs are green at all times:

--- a/docs/testing-pre-releases.md
+++ b/docs/testing-pre-releases.md
@@ -23,10 +23,10 @@ execute tests.
     - [Overview](#overview)
     - [Kubeadm version skew policy](#kubeadm-version-skew-policy)
     - [Availability of pre-compiled release artifacts](#availability-of-pre-compiled-release-artifacts)
-        - [Getting .deb or .rpm packages form repository](#getting-deb-or-rpm-packages-form-repository)
+        - [Getting .deb or .rpm packages from repository](#getting-deb-or-rpm-packages-from-repository)
         - [Getting kubeadm binaries from a GCS bucket](#getting-kubeadm-binaries-from-a-gcs-bucket)
         - [Getting docker images from a GCR registry](#getting-docker-images-from-a-gcr-registry)
-        - [Getting kubeadm binaries or docker images form github release page](#getting-kubeadm-binaries-or-docker-images-form-github-release-page)
+        - [Getting kubeadm binaries or docker images from github release page](#getting-kubeadm-binaries-or-docker-images-from-github-release-page)
     - [Create a local version](#create-a-local-version)
         - [Build .deb and .rpm packages](#build-deb-and-rpm-packages)
         - [Build kubeadm binary](#build-kubeadm-binary)
@@ -69,7 +69,7 @@ components; however you can select version numbers "near to" the desired version
 
 To access GCS buckets from the command-line, install the [gsutil](https://cloud.google.com/storage/docs/gsutil_install) tool.
 
-### Getting .deb or .rpm packages form repository
+### Getting .deb or .rpm packages from repository
 
 Pre-compiled GA version of .deb or .rpm packages are deployed into official Kubernetes repositories. See [installing kubeadm](https://kubernetes.io/docs/setup/independent/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl)
 for instruction about how add the necessary repository and repository key.


### PR DESCRIPTION
Fix typo : originated -> originating
- 'docs/managing-e2e-tests.md`
ㅤ

Fix typo : kuberentes -> kubernetes
- `docs/release-cycle.md`
ㅤ

Fix typo : form -> from
- `docs/testing-pre-releases.md`