### PR TITLE
kinder: bump to kindest/base:v20250521-31a79fd4

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/discovery-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/discovery-tasks.yaml
@@ -7,7 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-discovery
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/dryrun-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/dryrun-tasks.yaml
@@ -10,7 +10,7 @@ vars:
   upgradeVersion: "{{ resolve `ci/latest` }}"
   controlPlaneNodes: 1
   workerNodes: 1
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-dryrun
   kubeadmIgnorePreflightErrors: Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables

--- a/kinder/ci/tools/update-workflows/templates/workflows/encryption-algorithm-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/encryption-algorithm-tasks.yaml
@@ -10,7 +10,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 1
   workerNodes: 1
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-encryption-algorithm
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-ca-tasks.yaml
@@ -6,7 +6,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-external-ca
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/external-etcd-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-etcd-tasks.yaml
@@ -4,7 +4,7 @@ summary: |
   cluster with an external etcd cluster.
 vars:
   kubernetesVersion: v1.14.1
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-external-etcd
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/instance-config-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/instance-config-tasks.yaml
@@ -10,7 +10,7 @@ vars:
   upgradeVersion: latest
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-instance-config
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/patches-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/patches-tasks.yaml
@@ -6,7 +6,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-patches
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/presubmit-upgrade-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/presubmit-upgrade-tasks.yaml
@@ -7,7 +7,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-pull
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/regular-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/regular-tasks.yaml
@@ -9,7 +9,7 @@ vars:
   kubernetesVersion: v1.13.5
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-regular
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y-tasks.yaml
@@ -11,7 +11,7 @@ vars:
   kubernetesVersion: v1.12.8
   controlPlaneNodes: 1
   workerNodes: 2
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-xony
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/super-admin-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/super-admin-tasks.yaml
@@ -10,7 +10,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-super-admin
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/upgrade-no-addon-config-maps-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/upgrade-no-addon-config-maps-tasks.yaml
@@ -7,7 +7,7 @@ vars:
   initVersion: v1.13.5
   controlPlaneNodes: 1
   workerNodes: 1
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-upgrade
   kubeadmVerbosity: 6

--- a/kinder/ci/tools/update-workflows/templates/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/upgrade-tasks.yaml
@@ -9,7 +9,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 1
   workerNodes: 2
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-upgrade
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/discovery-tasks.yaml
+++ b/kinder/ci/workflows/discovery-tasks.yaml
@@ -8,7 +8,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-discovery
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/dryrun-tasks.yaml
+++ b/kinder/ci/workflows/dryrun-tasks.yaml
@@ -11,7 +11,7 @@ vars:
   upgradeVersion: "{{ resolve `ci/latest` }}"
   controlPlaneNodes: 1
   workerNodes: 1
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-dryrun
   kubeadmIgnorePreflightErrors: Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables

--- a/kinder/ci/workflows/encryption-algorithm-tasks.yaml
+++ b/kinder/ci/workflows/encryption-algorithm-tasks.yaml
@@ -11,7 +11,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 1
   workerNodes: 1
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-encryption-algorithm
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/workflows/external-ca-tasks.yaml
@@ -7,7 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-external-ca
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/external-etcd-tasks.yaml
+++ b/kinder/ci/workflows/external-etcd-tasks.yaml
@@ -5,7 +5,7 @@ summary: |
   cluster with an external etcd cluster.
 vars:
   kubernetesVersion: v1.14.1
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-external-etcd
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/instance-config-tasks.yaml
+++ b/kinder/ci/workflows/instance-config-tasks.yaml
@@ -11,7 +11,7 @@ vars:
   upgradeVersion: latest
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-instance-config
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/patches-tasks.yaml
+++ b/kinder/ci/workflows/patches-tasks.yaml
@@ -7,7 +7,7 @@ vars:
   # vars defines default values for variable used by tasks in this workflow;
   # those values might be overridden when importing this files.
   kubernetesVersion: v1.16.0
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-patches
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/presubmit-upgrade-tasks.yaml
+++ b/kinder/ci/workflows/presubmit-upgrade-tasks.yaml
@@ -8,7 +8,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-pull
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/regular-tasks.yaml
+++ b/kinder/ci/workflows/regular-tasks.yaml
@@ -10,7 +10,7 @@ vars:
   kubernetesVersion: v1.13.5
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-regular
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -12,7 +12,7 @@ vars:
   kubernetesVersion: v1.12.8
   controlPlaneNodes: 1
   workerNodes: 2
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-xony
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/super-admin-tasks.yaml
+++ b/kinder/ci/workflows/super-admin-tasks.yaml
@@ -11,7 +11,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 3
   workerNodes: 2
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-super-admin
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/upgrade-no-addon-config-maps-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-no-addon-config-maps-tasks.yaml
@@ -8,7 +8,7 @@ vars:
   initVersion: v1.13.5
   controlPlaneNodes: 1
   workerNodes: 1
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-upgrade
   kubeadmVerbosity: 6

--- a/kinder/ci/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-tasks.yaml
@@ -10,7 +10,7 @@ vars:
   upgradeVersion: v1.13.5
   controlPlaneNodes: 1
   workerNodes: 2
-  baseImage: kindest/base:v20221102-76f15095 # has containerd
+  baseImage: kindest/base:v20250521-31a79fd4 # has containerd
   image: kindest/node:test
   clusterName: kinder-upgrade
   kubeadmVerbosity: 6


### PR DESCRIPTION
Newer versions have containerd 2.x, and we can try using this newer version so that we can test features like HostUsers=true.

/hold