### PR TITLE
kinder: fix bug in generator config.yaml for kubelet skew

### DIFF
--- a/kinder/ci/tools/update-workflows/config.yaml
+++ b/kinder/ci/tools/update-workflows/config.yaml
@@ -85,7 +85,7 @@ jobGroups:
     skipVersions: [ 0, +1 ]
   - kubernetesVersion: latest
     kubeletVersion: -2
-    skipVersions: [ 0, +1, +2 ]
+    skipVersions: [ -1, 0, +1 ]
   - kubernetesVersion: 0
     kubeletVersion: -1
     skipVersions: [ 0 ]

--- a/kinder/ci/workflows/skew-kubelet-1.32-on-latest.yaml
+++ b/kinder/ci/workflows/skew-kubelet-1.32-on-latest.yaml
@@ -9,7 +9,7 @@ vars:
   kubeletVersion: "{{ resolve `ci/latest-1.32` }}"
   kubernetesVersion: "{{ resolve `ci/latest` }}"
   ignorePreflightErrors: "KubeletVersion"
-  ginkgoSkip: "\\[MinimumKubeletVersion:(1.34|1.35|1.36)\\]"
+  ginkgoSkip: "\\[MinimumKubeletVersion:(1.33|1.34|1.35)\\]"
   controlPlaneNodes: 3
 tasks:
 - import: skew-x-on-y-tasks.yaml


### PR DESCRIPTION
The skip versions must be:
  skipVersions: [ -1, 0, +1 ]

The +2 skips a version that's in the future, so that's not correct.