### PR TITLE
ginkgo: remove colors from the logs and set 16 nodes instead of an auto-detected number

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-ca-tasks.yaml
@@ -143,7 +143,7 @@ tasks:
       - test
       - e2e
       - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
-      - --parallel
+      - --ginkgo-flags=--nodes=16 --no-color
       - --name={{ .vars.clusterName }}
       - --loglevel=debug
     timeout: 35m

--- a/kinder/ci/tools/update-workflows/templates/workflows/external-etcd-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/external-etcd-tasks.yaml
@@ -87,7 +87,7 @@ tasks:
     - test
     - e2e
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
-    - --parallel
+    - --ginkgo-flags=--nodes=16 --no-color
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
   timeout: 35m

--- a/kinder/ci/tools/update-workflows/templates/workflows/regular-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/regular-tasks.yaml
@@ -97,7 +97,7 @@ tasks:
     - test
     - e2e
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
-    - --parallel
+    - --ginkgo-flags=--nodes=16 --no-color
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
   timeout: 35m

--- a/kinder/ci/tools/update-workflows/templates/workflows/rootless-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/rootless-tasks.yaml
@@ -250,7 +250,7 @@ tasks:
   - test
   - e2e
   - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
-  - --parallel
+  - --ginkgo-flags=--nodes=16 --no-color
   - --name={{ .vars.clusterName }}
   - --loglevel=debug
   timeout: 35m

--- a/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/skew-x-on-y-tasks.yaml
@@ -109,9 +109,8 @@ tasks:
     - test
     - e2e
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
-    - --parallel
     - --name={{ .vars.clusterName }}
-    - --ginkgo-flags={{ if .vars.ginkgoSkip }}--skip={{ .vars.ginkgoSkip }}{{ end }}
+    - --ginkgo-flags=--nodes=16 --no-color {{ if .vars.ginkgoSkip }}--skip={{ .vars.ginkgoSkip }}{{ end }}
     - --loglevel=debug
   timeout: 35m
 - name: get-logs

--- a/kinder/ci/tools/update-workflows/templates/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/upgrade-tasks.yaml
@@ -123,7 +123,7 @@ tasks:
     - test
     - e2e
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
-    - --parallel
+    - --ginkgo-flags=--nodes=16 --no-color
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
   timeout: 35m

--- a/kinder/ci/workflows/external-ca-tasks.yaml
+++ b/kinder/ci/workflows/external-ca-tasks.yaml
@@ -144,7 +144,7 @@ tasks:
       - test
       - e2e
       - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
-      - --parallel
+      - --ginkgo-flags=--nodes=16 --no-color
       - --name={{ .vars.clusterName }}
       - --loglevel=debug
     timeout: 35m

--- a/kinder/ci/workflows/external-etcd-tasks.yaml
+++ b/kinder/ci/workflows/external-etcd-tasks.yaml
@@ -88,7 +88,7 @@ tasks:
     - test
     - e2e
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
-    - --parallel
+    - --ginkgo-flags=--nodes=16 --no-color
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
   timeout: 35m

--- a/kinder/ci/workflows/regular-tasks.yaml
+++ b/kinder/ci/workflows/regular-tasks.yaml
@@ -98,7 +98,7 @@ tasks:
     - test
     - e2e
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
-    - --parallel
+    - --ginkgo-flags=--nodes=16 --no-color
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
   timeout: 35m

--- a/kinder/ci/workflows/rootless-tasks.yaml
+++ b/kinder/ci/workflows/rootless-tasks.yaml
@@ -251,7 +251,7 @@ tasks:
   - test
   - e2e
   - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
-  - --parallel
+  - --ginkgo-flags=--nodes=16 --no-color
   - --name={{ .vars.clusterName }}
   - --loglevel=debug
   timeout: 35m

--- a/kinder/ci/workflows/skew-x-on-y-tasks.yaml
+++ b/kinder/ci/workflows/skew-x-on-y-tasks.yaml
@@ -110,9 +110,8 @@ tasks:
     - test
     - e2e
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
-    - --parallel
     - --name={{ .vars.clusterName }}
-    - --ginkgo-flags={{ if .vars.ginkgoSkip }}--skip={{ .vars.ginkgoSkip }}{{ end }}
+    - --ginkgo-flags=--nodes=16 --no-color {{ if .vars.ginkgoSkip }}--skip={{ .vars.ginkgoSkip }}{{ end }}
     - --loglevel=debug
   timeout: 35m
 - name: get-logs

--- a/kinder/ci/workflows/upgrade-tasks.yaml
+++ b/kinder/ci/workflows/upgrade-tasks.yaml
@@ -124,7 +124,7 @@ tasks:
     - test
     - e2e
     - --test-flags=--report-dir={{ .env.ARTIFACTS }} --report-prefix=e2e
-    - --parallel
+    - --ginkgo-flags=--nodes=16 --no-color
     - --name={{ .vars.clusterName }}
     - --loglevel=debug
   timeout: 35m


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/135040
Fix https://github.com/kubernetes/kubernetes/issues/135039

[only 9minutes before, using 15 processes](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kubeadm-kinder-external-etcd-latest/1984595031012413440/artifacts/task-06-e2e-log.txt)

```
Will run [1m388[0m of [1m7209[0m specs
Running in parallel across [1m15[0m processes
```


[timeout for 35minutes on 2 processes](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kubeadm-kinder-external-etcd-latest/1985079728855322624/artifacts/task-06-e2e-log.txt)

```
Will run [1m388[0m of [1m7209[0m specs
Running in parallel across [1m2[0m processes
```



And now it uses 2 processes according to the CPU limit. This is caused by a change in ginkgo ~2.25. 
- https://github.com/onsi/ginkgo/pull/1545/
- https://github.com/kubernetes/kubernetes/pull/134881 (bump ginkgo version)

Some discussions on slack: https://kubernetes.slack.com/archives/C13J86Z63/p1762153236014159?thread_ts=1762067023.038729&cid=C13J86Z63

