### PR TITLE
.github: pin action sources to commits

### DIFF
--- a/.github/workflows/support-command.yaml
+++ b/.github/workflows/support-command.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: check for the /support command
         id: command
-        uses: xt0rted/slash-command-action@v2
+        uses: xt0rted/slash-command-action@bf51f8f5f4ea3d58abc7eca58f77104182b23e88 # v2.0.0
         continue-on-error: true
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -20,11 +20,11 @@ jobs:
           permission-level: admin
       - name: comment with support text
         if: steps.command.outputs.command-name
-        uses: ben-z/actions-comment-on-issue@1.0.3
+        uses: ben-z/actions-comment-on-issue@402eb412a8f396be0d4ac52a823ec7121206cc26 # 1.0.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: |
-            Hello, @${{ github.event.issue.user.login }} :robot: :wave:
+            Hello, @${{ github.event.issue.user.login }} :wave: :robot:
 
             You seem to have troubles using Kubernetes and kubeadm.
             Note that our issue trackers **should not** be used for providing support to users.
@@ -34,9 +34,9 @@ jobs:
             - https://github.com/kubernetes/kubeadm#support
       - name: add support label
         if: steps.command.outputs.command-name
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: kind/support
       - name: close issue
         if: steps.command.outputs.command-name
-        uses: peter-evans/close-issue@v1
+        uses: peter-evans/close-issue@a700eac5bf2a1c7a8cb6da0c13f93ed96fd53dbe # v1.0.3


### PR DESCRIPTION
This is to take action on:
https://groups.google.com/a/kubernetes.io/g/dev/c/gvwLzCBx-hA/m/phP47p52AgAJ

> Immediate Action Required:
Project maintainers are requested to update their GitHub Actions workflows to comply with this policy by April 15, 2026. 
After this date, the Kubernetes project will enforce the "Require actions to be pinned to a full-length commit SHA" policy at the enterprise level, and any github action workflows using mutable references will fail to run.