### PR TITLE
kinder: fix grep in super-admin workflow

### DIFF
--- a/kinder/ci/tools/update-workflows/templates/workflows/super-admin-tasks.yaml
+++ b/kinder/ci/tools/update-workflows/templates/workflows/super-admin-tasks.yaml
@@ -74,7 +74,7 @@ tasks:
       ${CMD} grep 'client-certificate-data' /etc/kubernetes/super-admin.conf | awk '{print $2}' | base64 -d | openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout | grep "subject=O = system:masters, CN = kubernetes-super-admin" || exit 1
 
       # Check certificate subject for apiserver-kubelet-client.crt
-      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = system:kubelet-api-admin, CN = kube-apiserver-kubelet-client" || exit 1
+      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=CN = kube-apiserver-kubelet-client" || exit 1
 
       # Make sure that the check-expiration and renew commands do not return errors
       ${CMD} kubeadm certs renew admin.conf || exit 1
@@ -126,7 +126,7 @@ tasks:
       ${CMD} grep 'client-certificate-data' /etc/kubernetes/super-admin.conf | awk '{print $2}' | base64 -d | openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout | grep "subject=O = system:masters, CN = kubernetes-super-admin" || exit 1
 
       # Check certificate subject for apiserver-kubelet-client.crt
-      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = system:kubelet-api-admin, CN = kube-apiserver-kubelet-client" || exit 1
+      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=CN = kube-apiserver-kubelet-client" || exit 1
 
       # Delete super-admin.conf, simulating the user moving the file to a safe location
       ${CMD} rm -f "/etc/kubernetes/super-admin.conf" || exit 1
@@ -166,7 +166,7 @@ tasks:
       ${CMD} grep 'client-certificate-data' /etc/kubernetes/admin.conf | awk '{print $2}' | base64 -d | openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout | grep "subject=O = kubeadm:cluster-admins, CN = kubernetes-admin" || exit 1
 
       # Check certificate subject for apiserver-kubelet-client.crt
-      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = system:kubelet-api-admin, CN = kube-apiserver-kubelet-client" || exit 1
+      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=CN = kube-apiserver-kubelet-client" || exit 1
 
       # Check if 'kubeadm init' created the RBAC permissions for the admin.conf user
       ${CMD} kubectl -n kube-system --kubeconfig /etc/kubernetes/admin.conf get cm kubeadm-config || exit 1
@@ -204,7 +204,7 @@ tasks:
       ${CMD} grep 'client-certificate-data' /etc/kubernetes/admin.conf | awk '{print $2}' | base64 -d | openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout | grep "subject=O = kubeadm:cluster-admins, CN = kubernetes-admin" || exit 1
 
       # Check certificate subject for apiserver-kubelet-client.crt
-      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = system:kubelet-api-admin, CN = kube-apiserver-kubelet-client" || exit 1
+      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=CN = kube-apiserver-kubelet-client" || exit 1
 
       # Check if the admin.conf user still has RBAC permissions
       ${CMD} kubectl -n kube-system --kubeconfig /etc/kubernetes/admin.conf get cm kubeadm-config || exit 1
@@ -232,7 +232,7 @@ tasks:
       ${CMD} grep 'client-certificate-data' /etc/kubernetes/admin.conf | awk '{print $2}' | base64 -d | openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout | grep "subject=O = kubeadm:cluster-admins, CN = kubernetes-admin" || exit 1
 
       # Check certificate subject for apiserver-kubelet-client.crt
-      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = system:kubelet-api-admin, CN = kube-apiserver-kubelet-client" || exit 1
+      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=CN = kube-apiserver-kubelet-client" || exit 1
 
       # Check if the admin.conf user still has the RBAC permissions
       ${CMD} kubectl -n kube-system --kubeconfig /etc/kubernetes/admin.conf get cm kubeadm-config || exit 1

--- a/kinder/ci/workflows/super-admin-tasks.yaml
+++ b/kinder/ci/workflows/super-admin-tasks.yaml
@@ -75,7 +75,7 @@ tasks:
       ${CMD} grep 'client-certificate-data' /etc/kubernetes/super-admin.conf | awk '{print $2}' | base64 -d | openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout | grep "subject=O = system:masters, CN = kubernetes-super-admin" || exit 1
 
       # Check certificate subject for apiserver-kubelet-client.crt
-      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = system:kubelet-api-admin, CN = kube-apiserver-kubelet-client" || exit 1
+      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=CN = kube-apiserver-kubelet-client" || exit 1
 
       # Make sure that the check-expiration and renew commands do not return errors
       ${CMD} kubeadm certs renew admin.conf || exit 1
@@ -127,7 +127,7 @@ tasks:
       ${CMD} grep 'client-certificate-data' /etc/kubernetes/super-admin.conf | awk '{print $2}' | base64 -d | openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout | grep "subject=O = system:masters, CN = kubernetes-super-admin" || exit 1
 
       # Check certificate subject for apiserver-kubelet-client.crt
-      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = system:kubelet-api-admin, CN = kube-apiserver-kubelet-client" || exit 1
+      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=CN = kube-apiserver-kubelet-client" || exit 1
 
       # Delete super-admin.conf, simulating the user moving the file to a safe location
       ${CMD} rm -f "/etc/kubernetes/super-admin.conf" || exit 1
@@ -167,7 +167,7 @@ tasks:
       ${CMD} grep 'client-certificate-data' /etc/kubernetes/admin.conf | awk '{print $2}' | base64 -d | openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout | grep "subject=O = kubeadm:cluster-admins, CN = kubernetes-admin" || exit 1
 
       # Check certificate subject for apiserver-kubelet-client.crt
-      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = system:kubelet-api-admin, CN = kube-apiserver-kubelet-client" || exit 1
+      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=CN = kube-apiserver-kubelet-client" || exit 1
 
       # Check if 'kubeadm init' created the RBAC permissions for the admin.conf user
       ${CMD} kubectl -n kube-system --kubeconfig /etc/kubernetes/admin.conf get cm kubeadm-config || exit 1
@@ -205,7 +205,7 @@ tasks:
       ${CMD} grep 'client-certificate-data' /etc/kubernetes/admin.conf | awk '{print $2}' | base64 -d | openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout | grep "subject=O = kubeadm:cluster-admins, CN = kubernetes-admin" || exit 1
 
       # Check certificate subject for apiserver-kubelet-client.crt
-      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = system:kubelet-api-admin, CN = kube-apiserver-kubelet-client" || exit 1
+      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=CN = kube-apiserver-kubelet-client" || exit 1
 
       # Check if the admin.conf user still has RBAC permissions
       ${CMD} kubectl -n kube-system --kubeconfig /etc/kubernetes/admin.conf get cm kubeadm-config || exit 1
@@ -233,7 +233,7 @@ tasks:
       ${CMD} grep 'client-certificate-data' /etc/kubernetes/admin.conf | awk '{print $2}' | base64 -d | openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout | grep "subject=O = kubeadm:cluster-admins, CN = kubernetes-admin" || exit 1
 
       # Check certificate subject for apiserver-kubelet-client.crt
-      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=O = system:kubelet-api-admin, CN = kube-apiserver-kubelet-client" || exit 1
+      ${CMD} openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt | grep "subject=CN = kube-apiserver-kubelet-client" || exit 1
 
       # Check if the admin.conf user still has the RBAC permissions
       ${CMD} kubectl -n kube-system --kubeconfig /etc/kubernetes/admin.conf get cm kubeadm-config || exit 1


### PR DESCRIPTION
After the recent changes the apiserver-kubelet-client.crt cert intentionally has only CN = kube-apiserver-kubelet-client with no O = field. Authorization is handled by the ClusterRoleBinding created during the bootstrap-token phase instead of group membership via the cert's Organization.

Fix the 'grep' for that in all super-admin workflows.

without this there will be errors:
```
+ grep 'subject=O = system:kubelet-api-admin, CN = kube-apiserver-kubelet-client'
+ docker exec kinder-super-admin-control-plane-1 openssl x509 -subject -nameopt sep_comma_plus_space,space_eq,sname -noout -in /etc/kubernetes/pki/apiserver-kubelet-client.crt
+ exit 1
 exit status 1
```
https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-super-admin-latest